### PR TITLE
Custom TryParse method should take precedence over JsonSerializer for Enumerable types

### DIFF
--- a/Src/Library/Extensions/ReflectionExtensions.cs
+++ b/Src/Library/Extensions/ReflectionExtensions.cs
@@ -84,12 +84,14 @@ internal static class ReflectionExtensions
         if (type == Types.Uri)
             return input => (true, new Uri((string)input!));
 
-        if (type.GetInterfaces().Contains(Types.IEnumerable))
-            return input => (true, input is null ? null : JsonSerializer.Deserialize((string)input, type, Config.SerializerOpts))!;
-
         var tryParseMethod = type.GetMethod("TryParse", BindingFlags.Public | BindingFlags.Static, new[] { Types.String, type.MakeByRefType() });
         if (tryParseMethod == null || tryParseMethod.ReturnType != Types.Bool)
+        {
+            if (type.GetInterfaces().Contains(Types.IEnumerable))
+                return input => (true, input is null ? null : JsonSerializer.Deserialize((string)input, type, Config.SerializerOpts))!;
+
             return null;
+        }
 
         // The 'object' parameter passed into our delegate
         var inputParameter = Expression.Parameter(Types.Object, "input");

--- a/Tests/IntegrationTests/FastEndpoints.IntegrationTests/WebTests/MiscTestCases.cs
+++ b/Tests/IntegrationTests/FastEndpoints.IntegrationTests/WebTests/MiscTestCases.cs
@@ -148,7 +148,7 @@ public class MiscTestCases : EndToEndTestBase
     {
         var (rsp, res) = await GuestClient
             .POSTAsync<TestCases.RouteBindingTest.Request, TestCases.RouteBindingTest.Response>(
-                "api/test-cases/route-binding-test/something/true/99/483752874564876/2232.12/123.45?Url=https://test.com&Custom=12",
+                "api/test-cases/route-binding-test/something/true/99/483752874564876/2232.12/123.45?Url=https://test.com&Custom=12&CustomList=1;2",
                 new()
                 {
                     Bool = false,
@@ -158,7 +158,8 @@ public class MiscTestCases : EndToEndTestBase
                     Int = 1,
                     Long = 1,
                     String = "nothing",
-                    Custom = new() { Value = 11111 }
+                    Custom = new() { Value = 11111 },
+                    CustomList = new() { 0 }
                 });
 
         rsp?.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -171,6 +172,7 @@ public class MiscTestCases : EndToEndTestBase
         res?.Decimal.Should().Be(123.45m);
         res?.Url.Should().Be("https://test.com/");
         res?.Custom.Value.Should().Be(12);
+        res?.CustomList.Should().ContainInOrder(1,2);
     }
 
     [Fact]

--- a/Web/[Features]/TestCases/RouteBindingTest/Endpoint.cs
+++ b/Web/[Features]/TestCases/RouteBindingTest/Endpoint.cs
@@ -38,7 +38,8 @@ public class Endpoint : Endpoint<Request, Response>
             String = r.String,
             Blank = r.Blank,
             Url = r.Url?.ToString(),
-            Custom = r.Custom
+            Custom = r.Custom,
+            CustomList = r.CustomList,
         });
     }
 }

--- a/Web/[Features]/TestCases/RouteBindingTest/Models.cs
+++ b/Web/[Features]/TestCases/RouteBindingTest/Models.cs
@@ -19,6 +19,32 @@ public class Custom //: IParseable<Custom>
     }
 }
 
+public class CustomList : List<int>
+{
+    public static bool TryParse(string? input, out CustomList? output)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            output = null;
+            return false;
+        }
+        output = new CustomList();
+        foreach (var item in input.Split(';'))
+        {
+            if (int.TryParse(item, out var id))
+            {
+                output.Add(id);
+            }
+            else
+            {
+                output = null;
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
 public class Request
 {
     /// <summary>
@@ -31,6 +57,7 @@ public class Request
     public double Double { get; set; }
     public Uri? Url { get; set; }
     public Custom Custom { get; set; }
+    public CustomList CustomList { get; set; }
 
     [BindFrom("decimal")]
     public decimal DecimalNumber { get; set; }
@@ -67,4 +94,5 @@ public class Response
     public string FromBody { get; set; }
     public string? Url { get; set; }
     public Custom Custom { get; set; }
+    public CustomList CustomList { get; set; }
 }


### PR DESCRIPTION
See also this thread on discord: https://discord.com/channels/933662816458645504/991649707602489367

I think this is a possible fix for that.

Also added a test case for it to the existing RouteValueBinding test, which failed at first (although with a very undescriptive error message - general 500).