### PR TITLE
Make Extensions more compatible

### DIFF
--- a/Src/Library/Extensions/ExceptionHandlerExtensions.cs
+++ b/Src/Library/Extensions/ExceptionHandlerExtensions.cs
@@ -23,7 +23,7 @@ public static class ExceptionHandlerExtensions
     /// </summary>
     /// <param name="logger">an optional logger instance</param>
     /// <param name="logStructuredException">set to true if you'd like to log the error in a structured manner</param>
-    public static void UseDefaultExceptionHandler(this IApplicationBuilder app, ILogger? logger = null, bool logStructuredException = false)
+    public static IApplicationBuilder UseDefaultExceptionHandler(this IApplicationBuilder app, ILogger? logger = null, bool logStructuredException = false)
     {
         app.UseExceptionHandler(errApp =>
         {
@@ -61,5 +61,7 @@ REASON: {error}
                 }
             });
         });
+
+        return app;
     }
 }

--- a/Src/Library/Extensions/MainExtensions.cs
+++ b/Src/Library/Extensions/MainExtensions.cs
@@ -47,17 +47,17 @@ public static class MainExtensions
 
     /// <summary>
     /// finalizes auto discovery of endpoints and prepares FastEndpoints to start processing requests
-    /// <para>HINT: this is the combination of <c>app.UseFastEndpointsMiddleware()</c> and <c>app.MapFastEndpoints()</c>.
+    /// <para>HINT: this is the combination of <see cref="UseFastEndpoints(IApplicationBuilder, Action{Config}?)"/> and <see cref="MapFastEndpoints(IEndpointRouteBuilder, Action{Config}?)"/>.
     /// you can use those two methods separately if you have some special requirement such as using "Startup.cs", etc.
     /// </para>
     /// </summary>
     /// <param name="configAction">an optional action to configure FastEndpoints</param>
-    /// <exception cref="InvalidOperationException"></exception>
-    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="InvalidCastException">thrown when the <c>app</c> cannot be cast to <see cref="IEndpointRouteBuilder"/></exception>
     public static IApplicationBuilder UseFastEndpoints(this IApplicationBuilder app, Action<Config>? configAction = null)
     {
         UseFastEndpointsMiddleware(app);
-        if (app is not IEndpointRouteBuilder routeBuilder) throw new InvalidCastException($"Cannot cast {nameof(app)} to IEndpointRouteBuilder");
+        if (app is not IEndpointRouteBuilder routeBuilder)
+            throw new InvalidCastException($"Cannot cast [{nameof(app)}] to IEndpointRouteBuilder");
         MapFastEndpoints(routeBuilder, configAction);
         return app;
     }

--- a/Src/Library/Extensions/MainExtensions.cs
+++ b/Src/Library/Extensions/MainExtensions.cs
@@ -54,10 +54,11 @@ public static class MainExtensions
     /// <param name="configAction">an optional action to configure FastEndpoints</param>
     /// <exception cref="InvalidOperationException"></exception>
     /// <exception cref="ArgumentException"></exception>
-    public static WebApplication UseFastEndpoints(this WebApplication app, Action<Config>? configAction = null)
+    public static IApplicationBuilder UseFastEndpoints(this IApplicationBuilder app, Action<Config>? configAction = null)
     {
         UseFastEndpointsMiddleware(app);
-        MapFastEndpoints(app, configAction);
+        if (app is not IEndpointRouteBuilder routeBuilder) throw new InvalidCastException($"Cannot cast {nameof(app)} to IEndpointRouteBuilder");
+        MapFastEndpoints(routeBuilder, configAction);
         return app;
     }
 


### PR DESCRIPTION
Allows us to turn:
```cs
app.PrepInfrastructure()
       .UseMiddleware<APIKeyAuthenticator>()
       .UseDefaultExceptionHandler();

app.UseAuthentication()
   .UseAuthorization();

app.UseFastEndpoints(c =>
    {
        c.Versioning.Prefix = "v";
        c.Serializer.ResponseSerializer = app.Services.GetService<JsonOptionMiddleware>()!.ResponseSerializer;
    })
   .UseSwaggerUi3(s =>
        {
            s.ConfigureDefaults();
            s.CustomJavaScriptPath = "/assets/js/apiKeyInjector.js";
        })
   .UseOpenApi();
```

Into

```cs
app.PrepInfrastructure()
   .UseMiddleware<APIKeyAuthenticator>()
   .UseDefaultExceptionHandler()
   .UseAuthentication()
   .UseAuthorization();
   .UseFastEndpoints(c =>
   {
       c.Versioning.Prefix = "v";
       c.Serializer.ResponseSerializer = app.Services.GetService<JsonOptionMiddleware>()!.ResponseSerializer;
   })
   .UseSwaggerUi3(s =>
   {
       s.ConfigureDefaults();
       s.CustomJavaScriptPath = "/assets/js/apiKeyInjector.js";
   })
   .UseOpenApi();
```