### PR TITLE
Allow configuration of TokenValidationParameters

### DIFF
--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -16,6 +16,7 @@
 - add `EndpointVersion()` method to `EndpointDefinition` for use with global config #209
 - filtering (endpoint inclusion) for swagger documents #252
 - specify response examples with `EndpointSummary` #205
+- `TokenValidationParameters` config action argument for `AddAuthenticationJWTBearer()` method #268
 
 ### FIXES
 - pre/post processor collection modification bug #224

--- a/Src/Security/AuthExtensions.cs
+++ b/Src/Security/AuthExtensions.cs
@@ -19,12 +19,14 @@ public static class AuthExtensions
     /// <param name="tokenSigningKey">the secret key to use for verifying the jwt tokens</param>
     /// <param name="issuer">validates issuer if set</param>
     /// <param name="audience">validates audience if set</param>
-    /// <param name="tokenSigningStyle">specify the toke signing style</param>
+    /// <param name="tokenSigningStyle">specify the token signing style</param>
+    /// <param name="tokenValidationConfiguration">Configuration Action to specify additional Token Validation parameters</param>
     public static IServiceCollection AddAuthenticationJWTBearer(this IServiceCollection services,
                                                                 string tokenSigningKey,
                                                                 string? issuer = null,
                                                                 string? audience = null,
-                                                                TokenSigningStyle tokenSigningStyle = TokenSigningStyle.Symmetric)
+                                                                TokenSigningStyle tokenSigningStyle = TokenSigningStyle.Symmetric, 
+                                                                Action<TokenValidationParameters>? tokenValidationConfiguration = null)
     {
         services.AddAuthentication(o =>
         {
@@ -53,10 +55,31 @@ public static class AuthExtensions
                 ValidIssuer = issuer,
                 IssuerSigningKey = key,
             };
+
+            if(tokenValidationConfiguration is not null)
+            {
+                tokenValidationConfiguration.Invoke(o.TokenValidationParameters);
+            }
         });
 
         return services;
     }
+
+    /// <summary>
+    /// configure and enable jwt bearer authentication
+    /// </summary>
+    /// <param name="tokenSigningKey">the secret key to use for verifying the jwt tokens</param>
+    /// <param name="tokenValidationConfiguration">configuration Action to specify additional Token Validation parameters</param>
+    public static IServiceCollection AddAuthenticationJWTBearer(this IServiceCollection services,
+                                                                string tokenSigningKey,
+                                                                Action<TokenValidationParameters> tokenValidationConfiguration)
+        => AddAuthenticationJWTBearer(services,
+                                      tokenSigningKey,
+                                      null,
+                                      null,
+                                      TokenSigningStyle.Symmetric,
+                                      tokenValidationConfiguration);
+
 
     /// <summary>
     /// returns true of the current user principal has a given permission code.

--- a/Src/Security/AuthExtensions.cs
+++ b/Src/Security/AuthExtensions.cs
@@ -20,12 +20,12 @@ public static class AuthExtensions
     /// <param name="issuer">validates issuer if set</param>
     /// <param name="audience">validates audience if set</param>
     /// <param name="tokenSigningStyle">specify the token signing style</param>
-    /// <param name="tokenValidationConfiguration">Configuration Action to specify additional Token Validation parameters</param>
+    /// <param name="tokenValidationConfiguration">configuration action to specify additional token validation parameters</param>
     public static IServiceCollection AddAuthenticationJWTBearer(this IServiceCollection services,
                                                                 string tokenSigningKey,
                                                                 string? issuer = null,
                                                                 string? audience = null,
-                                                                TokenSigningStyle tokenSigningStyle = TokenSigningStyle.Symmetric, 
+                                                                TokenSigningStyle tokenSigningStyle = TokenSigningStyle.Symmetric,
                                                                 Action<TokenValidationParameters>? tokenValidationConfiguration = null)
     {
         services.AddAuthentication(o =>
@@ -56,10 +56,7 @@ public static class AuthExtensions
                 IssuerSigningKey = key,
             };
 
-            if(tokenValidationConfiguration is not null)
-            {
-                tokenValidationConfiguration.Invoke(o.TokenValidationParameters);
-            }
+            tokenValidationConfiguration?.Invoke(o.TokenValidationParameters);
         });
 
         return services;
@@ -69,16 +66,19 @@ public static class AuthExtensions
     /// configure and enable jwt bearer authentication
     /// </summary>
     /// <param name="tokenSigningKey">the secret key to use for verifying the jwt tokens</param>
-    /// <param name="tokenValidationConfiguration">configuration Action to specify additional Token Validation parameters</param>
+    /// <param name="tokenValidationConfiguration">configuration action to specify additional token validation parameters</param>
     public static IServiceCollection AddAuthenticationJWTBearer(this IServiceCollection services,
                                                                 string tokenSigningKey,
                                                                 Action<TokenValidationParameters> tokenValidationConfiguration)
-        => AddAuthenticationJWTBearer(services,
-                                      tokenSigningKey,
-                                      null,
-                                      null,
-                                      TokenSigningStyle.Symmetric,
-                                      tokenValidationConfiguration);
+    {
+        return AddAuthenticationJWTBearer(
+            services,
+            tokenSigningKey,
+            null,
+            null,
+            TokenSigningStyle.Symmetric,
+            tokenValidationConfiguration);
+    }
 
 
     /// <summary>


### PR DESCRIPTION
I wanted to configure the ClockSkew, so I could accurately test JWT expiration. It occurred to me that the TokenValidationParameters have many options, it might be worth exposing an Action to allow that config?