### PR TITLE
Skip processors calls for request dto failure

### DIFF
--- a/Src/Library/Endpoint/Endpoint.Static.cs
+++ b/Src/Library/Endpoint/Endpoint.Static.cs
@@ -8,6 +8,12 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
 {
     private static async Task RunPostProcessors(HashSet<object> postProcessors, TRequest req, TResponse resp, HttpContext ctx, List<ValidationFailure> validationFailures, CancellationToken cancellation)
     {
+
+        if (validationFailures.Any())
+        {
+            return;
+        }
+
         foreach (var p in postProcessors)
         {
             switch (p)
@@ -24,6 +30,10 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
 
     private static async Task RunPreprocessors(HashSet<object> preProcessors, TRequest req, HttpContext ctx, List<ValidationFailure> validationFailures, CancellationToken cancellation)
     {
+        if (validationFailures.Any())
+        {
+            return;
+        }
         foreach (var p in preProcessors)
         {
             switch (p)


### PR DESCRIPTION
@dj-nitehawk  
While calling the pre processors I observed it do get the validation failure error, there is no options to separate the errors of pre processor from request dto validation failure... 

These error should be separate from general errors
Also, suppose we use any request dto parameter in preprocessor which is faulty still it will be used in preprocessor and exception error would be thrown 

So, I created this PR .. 
Either we should completely skip the processors in case of validation failure with request object or we should have flag or option for user to throw them separate or add all the errors and throw them together