### PR TITLE
Remove the read-only properties from the request body in Swagger

### DIFF
--- a/Src/Swagger/OperationProcessor.cs
+++ b/Src/Swagger/OperationProcessor.cs
@@ -188,6 +188,15 @@ internal class OperationProcessor : IOperationProcessor
         var reqParams = new List<OpenApiParameter>();
         var propsToRemoveFromExample = new List<string>();
 
+        if (reqDtoProps != null)
+        {
+            //Remove the readonly properties from the request body
+            foreach (var p in reqDtoProps.Where(p => !p.CanWrite))
+            {
+                RemovePropFromRequestBodyContent(p.Name, op.RequestBody?.Content, propsToRemoveFromExample);
+            }
+        }
+
         //add a path param for each route param such as /{xxx}/{yyy}/{zzz}
         reqParams = regex
             .Matches(apiDescription?.RelativePath!)


### PR DESCRIPTION
I've noticed that the swagger example will generate the schema even for the read-only properties which the client will be be able "of course should not be able" to fill out in the request.
So I've just added those read-only properties to the schema.Properties.