### PR TITLE
Support For Command Bus Pattern

### DIFF
--- a/Src/Library/Extensions/EndpointData.cs
+++ b/Src/Library/Extensions/EndpointData.cs
@@ -85,6 +85,7 @@ internal sealed class EndpointData
                      t.GetInterfaces().Intersect(new[] {
                          Types.IEndpoint,
                          Types.IEventHandler,
+                         Types.IRequestHandler,
                          Types.ISummary,
                          options.IncludeAbstractValidators ? Types.IValidator : Types.IEndpointValidator
                      }).Any() &&
@@ -158,6 +159,20 @@ internal sealed class EndpointData
                         handlers.Add(handler);
                     else
                         EventBase.handlerDict[tEvent] = new() { handler };
+                    continue;
+                }
+
+                if (tInterface == Types.IRequestHandler)
+                {
+                    var tRequest = t.GetGenericArgumentsOfType(Types.FastRequestHandlerOf2)?[0]!;
+                    var handler = (IRequestHandler)Activator.CreateInstance(t)!;
+
+                    if (RequestBase.handlersDictionary.TryGetValue(tRequest, out _))
+                        throw new Exception($"There is an already registered handler for the request '{tRequest.Name}'. " +
+                                            "Only one handler is allowed when you use Req/Res pattern. " +
+                                            "Consider using Events Pub/Sub pattern in-case you need more than one handler!.");
+                    RequestBase.handlersDictionary.Add(tRequest, handler);
+
                     continue;
                 }
             }

--- a/Src/Library/Extensions/RequestExtensions.cs
+++ b/Src/Library/Extensions/RequestExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Reflection.Metadata;
+
+namespace FastEndpoints.Extensions;
+
+public static class RequestExtensions
+{
+    public static Task<TResponse> SendAsync<TResponse>(this IRequest<TResponse> requestModel, CancellationToken cancellation = default)
+    {
+        var requestType = typeof(Request<,>);
+        Type[] typeArgs = { requestModel.GetType(), typeof(TResponse) };
+
+        var requestGenericType = requestType.MakeGenericType(typeArgs);
+        var request = Activator.CreateInstance(requestGenericType);
+        if (request == null)
+            throw new Exception($"Couldn't create an instance of the request '{requestGenericType.Name}'!.");
+
+        var sendMethod = request.GetType().GetMethod("SendAsync")!;
+        return (Task<TResponse>)sendMethod.Invoke(request, new object[] { requestModel, cancellation })!;
+    }
+}

--- a/Src/Library/Interfaces/IRequestHandler.cs
+++ b/Src/Library/Interfaces/IRequestHandler.cs
@@ -1,0 +1,21 @@
+﻿namespace FastEndpoints;
+
+internal interface IRequestHandler
+{
+}
+
+internal interface IRequestHandler<in TRequest, TResponse>:IRequestHandler
+    where TRequest : IRequest<TResponse>
+{
+    Task<TResponse> HandleAsync(TRequest request, CancellationToken ct);
+}
+
+internal interface IRequestHandler<in TRequest> : IRequestHandler<TRequest, int>
+    where TRequest : IRequest<int>
+{
+}
+public interface IRequest<out TResponse>
+{
+}
+
+public interface IRequest: IRequest<int> { }

--- a/Src/Library/Requests/Request.cs
+++ b/Src/Library/Requests/Request.cs
@@ -1,0 +1,44 @@
+﻿namespace FastEndpoints;
+
+/// <summary>
+/// base class for the request bus
+/// </summary>
+public abstract class RequestBase
+{
+    //key: TRequest 
+    //val: unique list of concrete request handler instances (subscribers)
+    internal static readonly Dictionary<Type, IRequestHandler> handlersDictionary = new();
+}
+
+/// <summary>
+/// request notification bus which uses an in-process pub/sub messaging system
+/// </summary>
+/// <typeparam name="TRequest">the type of notification request dto</typeparam>
+/// <typeparam name="TResponse">the type of the Response result dto</typeparam>
+public class Request<TRequest, TResponse> : RequestBase where TRequest : notnull, IRequest<TResponse>
+{
+    private readonly IRequestHandler<TRequest, TResponse>? _handler = null;
+
+    /// <summary>
+    /// instantiates an request facade for the given request dto type.
+    /// </summary>
+    public Request()
+    {
+        if (handlersDictionary.TryGetValue(typeof(TRequest), out var handler))
+            _handler = handler as IRequestHandler<TRequest, TResponse>;
+    }
+
+    /// <summary>
+    /// send the given model/dto to the registered handler of the request
+    /// </summary>
+    /// <param name="requestModel">the request model/dto to handle</param>
+    ///<param name="cancellation">an optional cancellation token</param>
+    /// <returns/>a Task of the response result that matches the request type.
+    public Task<TResponse> SendAsync(TRequest requestModel, CancellationToken cancellation = default)
+    {
+        if (_handler == null)
+            throw new Exception($"Couldn't find a registered handler for the request of type '{typeof(TRequest).Name}'");
+
+        return _handler.HandleAsync(requestModel, cancellation);
+    }
+}

--- a/Src/Library/Requests/RequestHandler.cs
+++ b/Src/Library/Requests/RequestHandler.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace FastEndpoints;
+
+/// <summary>
+/// inherit this base class to handle requests sent using Request/Response pattern
+/// <para>WARNING: request handlers are singletons. DO NOT maintain state in them. Use the <c>Resolve*()</c> methods to obtain dependencies.</para>
+/// </summary>
+/// <typeparam name="TRequest">the type of the request to handle</typeparam>
+/// <typeparam name="TResult">the type of the response result</typeparam>
+public abstract class FastRequestHandler<TRequest, TResult> : IRequestHandler<TRequest, TResult>, IServiceResolver where TRequest : IRequest<TResult>
+{
+    /// <summary>
+    /// this method will be called when an request of the specified type is published.
+    /// </summary>
+    /// <param name="requestModel">the request model/dto received</param>
+    /// <param name="ct">an optional cancellation token</param>
+    public abstract Task<TResult> HandleAsync(TRequest requestModel, CancellationToken ct);
+
+    /// <summary>
+    /// try to resolve an instance for the given type from the dependency injection container. will return null if unresolvable.
+    /// </summary>
+    /// <typeparam name="TService">the type of the service to resolve</typeparam>
+    public TService? TryResolve<TService>() where TService : class => IServiceResolver.RootServiceProvider.GetService<TService>();
+    /// <summary>
+    /// try to resolve an instance for the given type from the dependency injection container. will return null if unresolvable.
+    /// </summary>
+    /// <param name="typeOfService">the type of the service to resolve</param>
+    public object? TryResolve(Type typeOfService) => IServiceResolver.RootServiceProvider.GetService(typeOfService);
+    /// <summary>
+    /// resolve an instance for the given type from the dependency injection container. will throw if unresolvable.
+    /// </summary>
+    /// <typeparam name="TService">the type of the service to resolve</typeparam>
+    /// <exception cref="InvalidOperationException">Thrown if requested service cannot be resolved</exception>
+    public TService Resolve<TService>() where TService : class => IServiceResolver.RootServiceProvider.GetRequiredService<TService>();
+    /// <summary>
+    /// resolve an instance for the given type from the dependency injection container. will throw if unresolvable.
+    /// </summary>
+    /// <param name="typeOfService">the type of the service to resolve</param>
+    /// <exception cref="InvalidOperationException">Thrown if requested service cannot be resolved</exception>
+    public object Resolve(Type typeOfService) => IServiceResolver.RootServiceProvider.GetRequiredService(typeOfService);
+    /// <summary>
+    /// if you'd like to resolve scoped or transient services from the DI container, obtain a service scope from this method and dispose the scope when the work is complete.
+    ///<para>
+    /// <code>
+    /// using var scope = CreateScope();
+    /// var scopedService = scope.ServiceProvider.GetService(...);
+    /// </code>
+    /// </para>
+    /// </summary>
+    public IServiceScope CreateScope() => IServiceResolver.RootServiceProvider.CreateScope();
+
+    #region equality check
+
+    //equality will be checked when discovered concrete handlers are being added to RequestBase.handlerDict HashSet<T>
+    //we need this check to be done on the type of the handler instead of the default instance equality check
+    //to prrequest duplicate handlers being added to the hash set if/when multiple instances of the app are being run
+    //under the same app domain such as OrchardCore multi-tenancy. ex: https://github.com/FastEndpoints/Library/issues/208
+
+    public override bool Equals(object? obj) => obj?.GetType() == GetType();
+    public override int GetHashCode() => GetType().GetHashCode();
+    #endregion
+}

--- a/Src/Library/Types.cs
+++ b/Src/Library/Types.cs
@@ -19,6 +19,7 @@ internal static class Types
     internal static readonly Type EndpointWithMapperOf2 = typeof(EndpointWithMapper<,>);
     internal static readonly Type EndpointWithOutRequestOf2 = typeof(EndpointWithoutRequest<,>);
     internal static readonly Type FastEventHandlerOf1 = typeof(FastEventHandler<>);
+    internal static readonly Type FastRequestHandlerOf2 = typeof(FastRequestHandler<,>);
     internal static readonly Type Http = typeof(Http);
     internal static readonly Type HttpAttribute = typeof(HttpAttribute);
     internal static readonly Type IEndpoint = typeof(IEndpoint);
@@ -26,6 +27,7 @@ internal static class Types
     internal static readonly Type IEndpointValidator = typeof(IEndpointValidator);
     internal static readonly Type IEnumerable = typeof(IEnumerable);
     internal static readonly Type IEventHandler = typeof(IEventHandler);
+    internal static readonly Type IRequestHandler = typeof(IRequestHandler);
     internal static readonly Type IFormFile = typeof(IFormFile);
     internal static readonly Type IHasMapper = typeof(IHasMapper);
     internal static readonly Type IMapper = typeof(IMapper);


### PR DESCRIPTION
Related to this [discord thread](https://discord.com/channels/933662816458645504/1033637031911379014)
I've added support for the Request/Response pattern.
e.g.

simple class to represent the Request:
```
public class SomeRequest : IRequest<string>
{
    public string SomeDto { get; set; }
}
```
The handler that should handle the request:
```
public class SomeRequestHandler : SomeRequestHandler<SomeRequest, string>
{
    public override Task<string> HandleAsync(SomeRequest requestModel, CancellationToken ct)
    {
        return Task.FromResult("It's OK");
    }
}
```

simply you can create the request and send it to get the response:
`var result = new SomeRequest(){SomeDto = "normal DTO"}.SendAsync();`