### PR TITLE
Add support for byte arrays in query params

### DIFF
--- a/Src/Library/Extensions/ReflectionExtensions.cs
+++ b/Src/Library/Extensions/ReflectionExtensions.cs
@@ -156,14 +156,9 @@ internal static class ReflectionExtensions
 
             static object? DeserializeByteArray(object? input)
             {
-                if (input is not StringValues vals || vals.Count != 1)
-                    return null;
-
-                if (vals.Count == 1)
-                {
-                    return Convert.FromBase64String(vals[0]);
-                }
-                return null;
+                return input is not StringValues vals || vals.Count != 1
+                    ? null
+                    : Convert.FromBase64String(vals[0]);
             }
 
             static object? DeserializeJsonArrayString(object? input, Type tProp)

--- a/Src/Library/Types.cs
+++ b/Src/Library/Types.cs
@@ -11,6 +11,7 @@ internal static class Types
     //it's only there to make code more readable and save a few keystrokes.
 
     internal static readonly Type Bool = typeof(bool);
+    internal static readonly Type Byte = typeof(byte);
     internal static readonly Type DontInjectAttribute = typeof(DontInjectAttribute);
     internal static readonly Type EmptyRequest = typeof(EmptyRequest);
     internal static readonly Type EmptyResponse = typeof(EmptyResponse);

--- a/Tests/IntegrationTests/FastEndpoints.IntegrationTests/WebTests/MiscTestCases.cs
+++ b/Tests/IntegrationTests/FastEndpoints.IntegrationTests/WebTests/MiscTestCases.cs
@@ -401,6 +401,22 @@ public class MiscTestCases : EndToEndTestBase
     }
 
     [Fact]
+    public async Task ByteArrayQueryParamBindingTestUse()
+    {
+        var (rsp, res) = await GuestClient
+            .GETAsync<TestCases.ByteArrayQueryParamBindingTest.Request, TestCases.ByteArrayQueryParamBindingTest.Response>(
+                "api/test-cases/byte-array-query-param-binding-test?timestamp=AAAAAAAAw1U%3D",
+
+                new()
+                {
+                });
+
+        rsp?.StatusCode.Should().Be(HttpStatusCode.OK);
+        System.Text.Json.JsonSerializer.Serialize(res!.Timestamp)
+            .Should()
+            .BeEquivalentTo("\"AAAAAAAAw1U=\"");
+    }
+    [Fact]
     public async Task BindingArraysOfObjectsFromQueryUse()
     {
         var (rsp, res) = await GuestClient

--- a/Tests/IntegrationTests/FastEndpoints.IntegrationTests/WebTests/MiscTestCases.cs
+++ b/Tests/IntegrationTests/FastEndpoints.IntegrationTests/WebTests/MiscTestCases.cs
@@ -214,7 +214,8 @@ public class MiscTestCases : EndToEndTestBase
             "doubles=[123.45,543.21]&" +
             "dates=[\"2022-01-01\",\"2022-02-02\"]&" +
             "guids=[\"b01ec302-0adc-4a2b-973d-bbfe639ed9a5\",\"e08664a4-efd8-4062-a1e1-6169c6eac2ab\"]&" +
-            "ints=[1,2,3]",
+            "ints=[1,2,3]&" +
+            "steven={\"age\":12,\"name\":\"steven\"}",
             new());
 
         rsp?.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -226,6 +227,12 @@ public class MiscTestCases : EndToEndTestBase
         res?.Guids[0].Should().Be(Guid.Parse("b01ec302-0adc-4a2b-973d-bbfe639ed9a5"));
         res?.Ints.Count().Should().Be(3);
         res?.Ints.First().Should().Be(1);
+        res?.Steven.Should().BeEquivalentTo(
+            new TestCases.JsonArrayBindingForIEnumerableProps.Request.Person
+            {
+                Age = 12,
+                Name = "steven"
+            });
     }
 
     [Fact]
@@ -416,6 +423,7 @@ public class MiscTestCases : EndToEndTestBase
             .Should()
             .BeEquivalentTo("\"AAAAAAAAw1U=\"");
     }
+
     [Fact]
     public async Task BindingArraysOfObjectsFromQueryUse()
     {
@@ -576,6 +584,7 @@ public class MiscTestCases : EndToEndTestBase
     }
 
     [Fact]
+
     public async Task BindingObjectFromQueryUseSwaggerUiStyle()
     {
         var (rsp, res) = await GuestClient
@@ -626,6 +635,7 @@ public class MiscTestCases : EndToEndTestBase
             }
             );
     }
+
     [Fact]
     public async Task TestEventHandling()
     {

--- a/Web/[Features]/TestCases/ByteArrayQueryParamBindingTest/Endpoint.cs
+++ b/Web/[Features]/TestCases/ByteArrayQueryParamBindingTest/Endpoint.cs
@@ -1,0 +1,28 @@
+﻿namespace TestCases.ByteArrayQueryParamBindingTest;
+
+public class Endpoint : Endpoint<Request, Response>
+{
+    public override void Configure()
+    {
+        Verbs(Http.GET);
+        Routes("/test-cases/byte-array-query-param-binding-test");
+        AllowAnonymous();
+        DontThrowIfValidationFails();
+        Options(x => x
+            .WithName("ByteArrayQueryParamBindingTest"));
+        Summary(s =>
+        {
+            s.Description = "descr";
+            s.Summary = "summary";
+        });
+    }
+
+    public override Task HandleAsync(Request r, CancellationToken t)
+    {
+
+        return SendAsync(new Response
+        {
+            Timestamp = r.Timestamp
+        });
+    }
+}

--- a/Web/[Features]/TestCases/ByteArrayQueryParamBindingTest/Models.cs
+++ b/Web/[Features]/TestCases/ByteArrayQueryParamBindingTest/Models.cs
@@ -1,0 +1,13 @@
+namespace TestCases.ByteArrayQueryParamBindingTest;
+
+
+public class Request
+{
+    [QueryParam]
+    public byte[] Timestamp { get; init; }
+}
+
+public class Response
+{
+    public byte[] Timestamp { get; init; }
+}

--- a/Web/[Features]/TestCases/JsonArrayBindingForIEnumerableProps/Endpoint.cs
+++ b/Web/[Features]/TestCases/JsonArrayBindingForIEnumerableProps/Endpoint.cs
@@ -14,6 +14,7 @@ public class Endpoint : Endpoint<Request, Response>
         Response.Dates = r.Dates;
         Response.Guids = r.Guids;
         Response.Ints = r.Ints;
+        Response.Steven = r.Steven;
         return Task.CompletedTask;
     }
 }

--- a/Web/[Features]/TestCases/JsonArrayBindingForIEnumerableProps/Models.cs
+++ b/Web/[Features]/TestCases/JsonArrayBindingForIEnumerableProps/Models.cs
@@ -6,6 +6,13 @@ public class Request
     public IEnumerable<int> Ints { get; set; }
     public List<Guid> Guids { get; set; }
     public ICollection<DateTime> Dates { get; set; }
+    public Person Steven { get; set; }
+
+    public class Person
+    {
+        public int Age { get; set; }
+        public string Name { get; set; }
+    }
 }
 
 public class Response : Request


### PR DESCRIPTION
Hi! There is a problem with byte array desirialization in query params, but it should work now.
Is used for sql row version for example.