### PR TITLE
Public configuration getters

### DIFF
--- a/Src/Library/Config/EndpointOptions.cs
+++ b/Src/Library/Config/EndpointOptions.cs
@@ -13,7 +13,7 @@ public class EndpointOptions
     /// <summary>
     /// prefix for all routes (example 'api').
     /// </summary>
-    public string? RoutePrefix { internal get; set; }
+    public string? RoutePrefix { get; set; }
 
     /// <summary>
     /// a function to filter out endpoints from auto registration.

--- a/Src/Library/Config/VersioningOptions.cs
+++ b/Src/Library/Config/VersioningOptions.cs
@@ -8,7 +8,7 @@ public class VersioningOptions
     /// <summary>
     /// the prefix used in front of the version (for example 'v' produces 'v{version}').
     /// </summary>
-    public string? Prefix { internal get; set; }
+    public string? Prefix { get; set; }
 
     /// <summary>
     /// this value will be used on endpoints that does not specify a version

--- a/Src/Library/Endpoint/Summary/EndpointSummary.cs
+++ b/Src/Library/Endpoint/Summary/EndpointSummary.cs
@@ -128,7 +128,7 @@ public abstract class Summary<TEndpoint> : EndpointSummary, ISummary where TEndp
 ///<typeparam name="TRequest">the type of the request dto</typeparam>
 public abstract class Summary<TEndpoint, TRequest> : EndpointSummary<TRequest>, ISummary where TEndpoint : IEndpoint where TRequest : new() { }
 
-internal class ProducesResponseTypeMetadata : IProducesResponseTypeMetadata
+public class ProducesResponseTypeMetadata : IProducesResponseTypeMetadata
 {
     public Type? Type { get; set; }
 


### PR DESCRIPTION
Make configuration getters and EndpointSummary public to allow custom OperationProcessors based on the original source code.