### PR TITLE
prevent caching the HandlerExecutor method

### DIFF
--- a/Src/Library/Main/EndpointData.cs
+++ b/Src/Library/Main/EndpointData.cs
@@ -171,7 +171,7 @@ internal sealed class EndpointData
                                              "Consider using Event Pub/Sub pattern instead!");
                     }
 
-                    CommandExtensions.handlerCache.Add(tCommand, new(t));
+                    CommandExtensions.handlerCache.Add(tCommand, t);
 
                     continue;
                 }

--- a/Src/Library/Messaging/Commands/CommandExtensions.cs
+++ b/Src/Library/Messaging/Commands/CommandExtensions.cs
@@ -34,16 +34,15 @@ public static class CommandExtensions
     /// <param name="command">the command to execute</param>
     /// <param name="ct">optional cancellation token</param>
     /// <exception cref="InvalidOperationException">thrown when a handler for the command cannot be instantiated</exception>
-    public static Task ExecuteAsync(this ICommand command, CancellationToken ct = default)
+    public static Task ExecuteAsync<TCommand>(this TCommand command, CancellationToken ct = default) where TCommand : ICommand
     {
         var tCommand = command.GetType();
-
         if (handlerCache.TryGetValue(tCommand, out var handlerType))
         {
             var handler = Config.ServiceResolver.CreateInstance(handlerType);
-            var executeMethod = handlerType.HandlerExecutor(tCommand, handler);
-            return executeMethod(command, ct);
+            return ((ICommandHandler<TCommand>)handler).ExecuteAsync(command, ct);
         }
+
         throw new InvalidOperationException($"Unable to create an instance of the handler for command [{tCommand.FullName}]");
     }
 


### PR DESCRIPTION
prevent caching the HandlerExecutor method to not use the cached resolved services.

related to [this issue](https://github.com/FastEndpoints/FastEndpoints/issues/324)

https://discord.com/channels/933662816458645504/1039086761302818856