### PR TITLE
Accept an optional `CancellationToken` parameter on async map-related methods

### DIFF
--- a/Src/Library/Endpoint/Endpoint.cs
+++ b/Src/Library/Endpoint/Endpoint.cs
@@ -345,7 +345,8 @@ public abstract class EndpointWithMapping<TRequest, TResponse, TEntity> : Endpoi
     /// override this method and place the logic for mapping the request dto to the desired domain entity
     /// </summary>
     /// <param name="r">the request dto to map from</param>
-    public virtual Task<TEntity> MapToEntityAsync(TRequest r) => throw new NotImplementedException($"Please override the {nameof(MapToEntityAsync)} method!");
+    /// <param name="ct">a cancellation token</param>
+    public virtual Task<TEntity> MapToEntityAsync(TRequest r, CancellationToken ct = default) => throw new NotImplementedException($"Please override the {nameof(MapToEntityAsync)} method!");
 
     /// <summary>
     /// override this method and place the logic for mapping a domain entity to a response dto
@@ -356,5 +357,6 @@ public abstract class EndpointWithMapping<TRequest, TResponse, TEntity> : Endpoi
     /// override this method and place the logic for mapping a domain entity to a response dto
     /// </summary>
     /// <param name="e">the domain entity to map from</param>
-    public virtual Task<TResponse> MapFromEntityAsync(TEntity e) => throw new NotImplementedException($"Please override the {nameof(MapFromEntityAsync)} method!");
+    /// <param name="ct">a cancellation token</param>
+    public virtual Task<TResponse> MapFromEntityAsync(TEntity e, CancellationToken ct = default) => throw new NotImplementedException($"Please override the {nameof(MapFromEntityAsync)} method!");
 }

--- a/Src/Library/Endpoint/Mapper/Mapper.cs
+++ b/Src/Library/Endpoint/Mapper/Mapper.cs
@@ -20,6 +20,7 @@ public abstract class Mapper<TRequest, TResponse, TEntity> : IMapper, IServiceRe
     /// override this method and place the logic for mapping the request dto to the desired domain entity
     /// </summary>
     /// <param name="r">the request dto to map from</param>
+    /// <param name="ct">a cancellation token</param>
     public virtual Task<TEntity> ToEntityAsync(TRequest r, CancellationToken ct = default) => throw new NotImplementedException($"Please override the {nameof(ToEntityAsync)} method!");
 
     /// <summary>
@@ -31,6 +32,7 @@ public abstract class Mapper<TRequest, TResponse, TEntity> : IMapper, IServiceRe
     /// override this method and place the logic for mapping a domain entity to a response dto
     /// </summary>
     /// <param name="e">the domain entity to map from</param>
+    /// <param name="ct">a cancellation token</param>
     public virtual Task<TResponse> FromEntityAsync(TEntity e, CancellationToken ct = default) => throw new NotImplementedException($"Please override the {nameof(FromEntityAsync)} method!");
 
     /// <summary>
@@ -69,6 +71,7 @@ public abstract class RequestMapper<TRequest, TEntity> : IRequestMapper, IServic
     /// override this method and place the logic for mapping the request dto to the desired domain entity
     /// </summary>
     /// <param name="r">the request dto to map from</param>
+    /// <param name="ct">a cancellation token</param>
     public virtual Task<TEntity> ToEntityAsync(TRequest r, CancellationToken ct = default) => throw new NotImplementedException($"Please override the {nameof(ToEntityAsync)} method!");
 
     ///<inheritdoc/>
@@ -100,6 +103,7 @@ public abstract class ResponseMapper<TResponse, TEntity> : IResponseMapper, ISer
     /// override this method and place the logic for mapping a domain entity to a response dto
     /// </summary>
     /// <param name="e">the domain entity to map from</param>
+    /// <param name="ct">a cancellation token</param>
     public virtual Task<TResponse> FromEntityAsync(TEntity e, CancellationToken ct = default) => throw new NotImplementedException($"Please override the {nameof(FromEntityAsync)} method!");
 
     ///<inheritdoc/>

--- a/Src/Library/Endpoint/Mapper/Mapper.cs
+++ b/Src/Library/Endpoint/Mapper/Mapper.cs
@@ -20,7 +20,7 @@ public abstract class Mapper<TRequest, TResponse, TEntity> : IMapper, IServiceRe
     /// override this method and place the logic for mapping the request dto to the desired domain entity
     /// </summary>
     /// <param name="r">the request dto to map from</param>
-    public virtual Task<TEntity> ToEntityAsync(TRequest r) => throw new NotImplementedException($"Please override the {nameof(ToEntityAsync)} method!");
+    public virtual Task<TEntity> ToEntityAsync(TRequest r, CancellationToken ct = default) => throw new NotImplementedException($"Please override the {nameof(ToEntityAsync)} method!");
 
     /// <summary>
     /// override this method and place the logic for mapping a domain entity to a response dto
@@ -31,7 +31,7 @@ public abstract class Mapper<TRequest, TResponse, TEntity> : IMapper, IServiceRe
     /// override this method and place the logic for mapping a domain entity to a response dto
     /// </summary>
     /// <param name="e">the domain entity to map from</param>
-    public virtual Task<TResponse> FromEntityAsync(TEntity e) => throw new NotImplementedException($"Please override the {nameof(FromEntityAsync)} method!");
+    public virtual Task<TResponse> FromEntityAsync(TEntity e, CancellationToken ct = default) => throw new NotImplementedException($"Please override the {nameof(FromEntityAsync)} method!");
 
     /// <summary>
     /// override this method and place the logic for mapping the updated request dto to the desired domain entity
@@ -69,7 +69,7 @@ public abstract class RequestMapper<TRequest, TEntity> : IRequestMapper, IServic
     /// override this method and place the logic for mapping the request dto to the desired domain entity
     /// </summary>
     /// <param name="r">the request dto to map from</param>
-    public virtual Task<TEntity> ToEntityAsync(TRequest r) => throw new NotImplementedException($"Please override the {nameof(ToEntityAsync)} method!");
+    public virtual Task<TEntity> ToEntityAsync(TRequest r, CancellationToken ct = default) => throw new NotImplementedException($"Please override the {nameof(ToEntityAsync)} method!");
 
     ///<inheritdoc/>
     public TService? TryResolve<TService>() where TService : class => Config.ServiceResolver.TryResolve<TService>();
@@ -100,7 +100,7 @@ public abstract class ResponseMapper<TResponse, TEntity> : IResponseMapper, ISer
     /// override this method and place the logic for mapping a domain entity to a response dto
     /// </summary>
     /// <param name="e">the domain entity to map from</param>
-    public virtual Task<TResponse> FromEntityAsync(TEntity e) => throw new NotImplementedException($"Please override the {nameof(FromEntityAsync)} method!");
+    public virtual Task<TResponse> FromEntityAsync(TEntity e, CancellationToken ct = default) => throw new NotImplementedException($"Please override the {nameof(FromEntityAsync)} method!");
 
     ///<inheritdoc/>
     public TService? TryResolve<TService>() where TService : class => Config.ServiceResolver.TryResolve<TService>();


### PR DESCRIPTION
Current async versions of `Mapper.FromEntity`, `Mapper.ToEntity`, `Endpoint.MapFromEntity` and `Endpoint.MapToEntity` don't accept a CancellationToken that could be desirable in certain contexts.

As the parameter is optional, it will not cause any breaking changes.