### PR TITLE
Adds an overload to SendAsync which will accept an object (as long as…

### DIFF
--- a/Src/Library/Endpoint/Auxiliary/EndpointDefinition.cs
+++ b/Src/Library/Endpoint/Auxiliary/EndpointDefinition.cs
@@ -40,9 +40,6 @@ public sealed class EndpointDefinition
     public string? OverriddenRoutePrefix { get; private set; }
     public List<string>? PreBuiltUserPolicies { get; private set; }
     public bool ThrowIfValidationFails { get; private set; } = true;
-    
-    public IResponseInterceptor? ResponseInterceptor { get; set; }
-
 
     //only accessible to internal code
     internal object[]? EpAttributes;
@@ -57,6 +54,7 @@ public sealed class EndpointDefinition
     internal ServiceBoundEpProp[]? ServiceBoundEpProps;
     internal JsonSerializerContext? SerializerContext;
     internal ResponseCacheAttribute? ResponseCacheSettings { get; private set; }
+    internal IResponseInterceptor? ResponseIntrcptr { get; private set; }
     internal Action<RouteHandlerBuilder>? UserConfigAction { get; private set; }
 
     private object? mapper;
@@ -264,8 +262,7 @@ public sealed class EndpointDefinition
                 pos++;
             }
         }
-    }    
-    
+    }
 
     /// <summary>
     /// adds global pre-processors to an endpoint definition which are to be executed in addition to the ones configured at the endpoint level.
@@ -308,6 +305,13 @@ public sealed class EndpointDefinition
             VaryByQueryKeys = varyByQueryKeys
         };
     }
+
+    /// <summary>
+    /// configure a response interceptor to be called before any SendAsync() methods are called.
+    /// if the interceptor sends a response to the client, the SendAsync() will be ignored.
+    /// </summary>
+    /// <param name="responseInterceptor">the response interceptor to be configured for the endpoint</param>
+    public void ResponseInterceptor(IResponseInterceptor responseInterceptor) => ResponseIntrcptr = responseInterceptor;
 
     /// <summary>
     /// allows access if the claims principal has ANY of the given roles

--- a/Src/Library/Endpoint/Auxiliary/EndpointDefinition.cs
+++ b/Src/Library/Endpoint/Auxiliary/EndpointDefinition.cs
@@ -40,6 +40,9 @@ public sealed class EndpointDefinition
     public string? OverriddenRoutePrefix { get; private set; }
     public List<string>? PreBuiltUserPolicies { get; private set; }
     public bool ThrowIfValidationFails { get; private set; } = true;
+    
+    public IResponseInterceptor? ResponseInterceptor { get; set; }
+
 
     //only accessible to internal code
     internal object[]? EpAttributes;
@@ -261,7 +264,8 @@ public sealed class EndpointDefinition
                 pos++;
             }
         }
-    }
+    }    
+    
 
     /// <summary>
     /// adds global pre-processors to an endpoint definition which are to be executed in addition to the ones configured at the endpoint level.

--- a/Src/Library/Endpoint/Endpoint.Send.cs
+++ b/Src/Library/Endpoint/Endpoint.Send.cs
@@ -27,9 +27,8 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
     protected async Task SendInterceptedAsync(object response, int statusCode = 200, CancellationToken cancellation = default)
     {
         if (Definition.ResponseIntrcptr is null)
-            throw new InvalidOperationException(
-                "Response interceptor has not been configured");
-        
+            throw new InvalidOperationException("Response interceptor has not been configured!");
+
         await RunResponseInterceptor(Definition.ResponseIntrcptr, response, statusCode, HttpContext, ValidationFailures, cancellation);
 
         if (!HttpContext.ResponseStarted())

--- a/Src/Library/Endpoint/Endpoint.Send.cs
+++ b/Src/Library/Endpoint/Endpoint.Send.cs
@@ -17,21 +17,18 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
     }
 
     /// <summary>
-    /// Sends an object serialized as JSON to the client, if a response interceptor has been defined,
-    /// then that will be executed before the normal HTTP Response is sent.
+    /// sends an object serialized as json to the client. if a response interceptor has been defined,
+    /// then that will be executed before the normal response is sent.
     /// </summary>
-    /// <param name="response"></param>
-    /// <param name="statusCode"></param>
-    /// <param name="cancellation"></param>
+    /// <param name="response">the object to serialize to json</param>
+    /// <param name="statusCode">optional custom http status code</param>
+    /// <param name="cancellation">optional cancellation token. if not specified, the <c>HttpContext.RequestAborted</c> token is used</param>
     protected async Task SendAsync(object response, int statusCode = 200, CancellationToken cancellation = default)
     {
-        await RunResponseInterceptor(Definition.ResponseInterceptor, response, HttpContext, ValidationFailures,
-            cancellation);
+        await RunResponseInterceptor(Definition.ResponseIntrcptr, response, HttpContext, ValidationFailures, cancellation);
 
-        if(HttpContext.Response.HasStarted is false)
-        {
+        if (!HttpContext.ResponseStarted())
             await HttpContext.Response.SendAsync(response, statusCode, Definition.SerializerContext, cancellation);
-        }
     }
 
     /// <summary>

--- a/Src/Library/Endpoint/Endpoint.Send.cs
+++ b/Src/Library/Endpoint/Endpoint.Send.cs
@@ -23,7 +23,7 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
     /// <param name="response">the object to serialize to json</param>
     /// <param name="statusCode">optional custom http status code</param>
     /// <param name="cancellation">optional cancellation token. if not specified, the <c>HttpContext.RequestAborted</c> token is used</param>
-    protected async Task SendAsync(object response, int statusCode = 200, CancellationToken cancellation = default)
+    protected async Task SendInterceptedAsync(object response, int statusCode = 200, CancellationToken cancellation = default)
     {
         await RunResponseInterceptor(Definition.ResponseIntrcptr, response, HttpContext, ValidationFailures, cancellation);
 

--- a/Src/Library/Endpoint/Endpoint.Send.cs
+++ b/Src/Library/Endpoint/Endpoint.Send.cs
@@ -17,6 +17,24 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
     }
 
     /// <summary>
+    /// Sends an object serialized as JSON to the client, if a response interceptor has been defined,
+    /// then that will be executed before the normal HTTP Response is sent.
+    /// </summary>
+    /// <param name="response"></param>
+    /// <param name="statusCode"></param>
+    /// <param name="cancellation"></param>
+    protected async Task SendAsync(object response, int statusCode = 200, CancellationToken cancellation = default)
+    {
+        await RunResponseInterceptor(Definition.ResponseInterceptor, response, HttpContext, ValidationFailures,
+            cancellation);
+
+        if(HttpContext.Response.HasStarted is false)
+        {
+            await HttpContext.Response.SendAsync(response, statusCode, Definition.SerializerContext, cancellation);
+        }
+    }
+
+    /// <summary>
     /// send a 201 created response with a location header containing where the resource can be retrieved from.
     /// <para>HINT: if pointing to an endpoint with multiple verbs, make sure to specify the 'verb' argument and if pointing to a multi route endpoint, specify the 'routeNumber' argument.</para>
     /// <para>WARNING: this overload will not add a location header if you've set a custom endpoint name using .WithName() method. use the other overload that accepts a string endpoint name instead.</para>

--- a/Src/Library/Endpoint/Endpoint.Setup.cs
+++ b/Src/Library/Endpoint/Endpoint.Setup.cs
@@ -255,16 +255,7 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
             if (!Definition.PostProcessorList.Contains(p, TypeEqualityComparer.Instance))
                 Definition.PostProcessorList.Add(p);
         }
-    }  
-    
-    /// <summary>
-    /// configure a response interceptor to be called before the SendAsync response is sent to the browser.
-    /// This will override any globally configured interceptor.  If you return a response to the browser, then
-    /// the rest of the SendAsync method will be skipped;
-    /// </summary>
-    /// <param name="responseInterceptor">the response interceptor to be executed</param>
-    protected void ResponseInterceptor(IResponseInterceptor responseInterceptor) => Definition.ResponseInterceptor = responseInterceptor;
-
+    }
 
     /// <summary>
     /// configure a collection of pre-processors to be executed before the main handler function is called. processors are executed in the order they are defined here.
@@ -320,6 +311,14 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
     /// <param name="varyByHeader">the value for the Vary response header</param>
     /// <param name="varyByQueryKeys">the query keys to vary by</param>
     protected void ResponseCache(int durationSeconds, ResponseCacheLocation location = ResponseCacheLocation.Any, bool noStore = false, string? varyByHeader = null, string[]? varyByQueryKeys = null) => Definition.ResponseCache(durationSeconds, location, noStore, varyByHeader, varyByQueryKeys);
+
+    /// <summary>
+    /// configure a response interceptor to be called before the SendAsync response is sent to the browser.
+    /// this will override any globally configured interceptor. if you return a response to the browser, then
+    /// the rest of the SendAsync method will be skipped.
+    /// </summary>
+    /// <param name="responseInterceptor">the response interceptor to be executed</param>
+    protected void ResponseInterceptor(IResponseInterceptor responseInterceptor) => Definition.ResponseInterceptor(responseInterceptor);
 
     /// <summary>
     /// allows access if the claims principal has ANY of the given roles

--- a/Src/Library/Endpoint/Endpoint.Setup.cs
+++ b/Src/Library/Endpoint/Endpoint.Setup.cs
@@ -255,7 +255,16 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
             if (!Definition.PostProcessorList.Contains(p, TypeEqualityComparer.Instance))
                 Definition.PostProcessorList.Add(p);
         }
-    }
+    }  
+    
+    /// <summary>
+    /// configure a response interceptor to be called before the SendAsync response is sent to the browser.
+    /// This will override any globally configured interceptor.  If you return a response to the browser, then
+    /// the rest of the SendAsync method will be skipped;
+    /// </summary>
+    /// <param name="responseInterceptor">the response interceptor to be executed</param>
+    protected void ResponseInterceptor(IResponseInterceptor responseInterceptor) => Definition.ResponseInterceptor = responseInterceptor;
+
 
     /// <summary>
     /// configure a collection of pre-processors to be executed before the main handler function is called. processors are executed in the order they are defined here.

--- a/Src/Library/Endpoint/Endpoint.Static.cs
+++ b/Src/Library/Endpoint/Endpoint.Static.cs
@@ -66,17 +66,13 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
         }
     }
 
-    private static Task RunResponseInterceptor(IResponseInterceptor? interceptor,
-                                               object resp,
-                                               HttpContext ctx,
-                                               List<ValidationFailure> validationFailures,
-                                               CancellationToken cancellation)
-    {
-        if (interceptor is not null)
-            return interceptor.InterceptResponseAsync(resp, ctx, validationFailures, cancellation);
-
-        return Task.CompletedTask;
-    }
+    private static Task RunResponseInterceptor(IResponseInterceptor interceptor,
+        object resp,
+        int statusCode,
+        HttpContext ctx,
+        List<ValidationFailure> validationFailures,
+        CancellationToken cancellation) =>
+        interceptor.InterceptResponseAsync(resp, statusCode, ctx, validationFailures, cancellation);
 
     private static Task AutoSendResponse(HttpContext ctx,
                                          TResponse responseDto,

--- a/Src/Library/Endpoint/Endpoint.Static.cs
+++ b/Src/Library/Endpoint/Endpoint.Static.cs
@@ -67,12 +67,14 @@ public abstract partial class Endpoint<TRequest, TResponse> : BaseEndpoint where
     }
 
     private static Task RunResponseInterceptor(IResponseInterceptor interceptor,
-        object resp,
-        int statusCode,
-        HttpContext ctx,
-        List<ValidationFailure> validationFailures,
-        CancellationToken cancellation) =>
-        interceptor.InterceptResponseAsync(resp, statusCode, ctx, validationFailures, cancellation);
+                                               object resp,
+                                               int statusCode,
+                                               HttpContext ctx,
+                                               List<ValidationFailure> validationFailures,
+                                               CancellationToken cancellation)
+    {
+        return interceptor.InterceptResponseAsync(resp, statusCode, ctx, validationFailures, cancellation);
+    }
 
     private static Task AutoSendResponse(HttpContext ctx,
                                          TResponse responseDto,

--- a/Src/Library/Endpoint/Processor/IResponseInterceptor.cs
+++ b/Src/Library/Endpoint/Processor/IResponseInterceptor.cs
@@ -1,0 +1,13 @@
+﻿using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
+
+namespace FastEndpoints;
+
+/// <summary>
+/// interface for defining a response interceptor to be executed before the main endpoint handler executes
+/// </summary>
+/// <param name="TResponse">Intercept responses returning this object type</param>
+public interface IResponseInterceptor
+{
+    Task InterceptResponseAsync(object res, HttpContext ctx, IReadOnlyCollection<ValidationFailure> failures, CancellationToken ct);
+}

--- a/Src/Library/Endpoint/Processor/IResponseInterceptor.cs
+++ b/Src/Library/Endpoint/Processor/IResponseInterceptor.cs
@@ -9,13 +9,16 @@ namespace FastEndpoints;
 public interface IResponseInterceptor
 {
     /// <summary>
-    /// implement this method to intercep the http response.
+    /// implement this method to intercept the http response with the use of SendInterceptedAsync() method.
     /// </summary>
     /// <param name="response">the response object</param>
     /// <param name="statusCode"></param>
     /// <param name="ctx">the http context of the current request</param>
     /// <param name="failures">the collection of validation failures for the endpoint</param>
     /// <param name="ct">cancellation token</param>
-    Task InterceptResponseAsync(object response, int statusCode, HttpContext ctx,
-        IReadOnlyCollection<ValidationFailure> failures, CancellationToken ct);
+    Task InterceptResponseAsync(object response,
+                                int statusCode,
+                                HttpContext ctx,
+                                IReadOnlyCollection<ValidationFailure> failures,
+                                CancellationToken ct);
 }

--- a/Src/Library/Endpoint/Processor/IResponseInterceptor.cs
+++ b/Src/Library/Endpoint/Processor/IResponseInterceptor.cs
@@ -6,8 +6,14 @@ namespace FastEndpoints;
 /// <summary>
 /// interface for defining a response interceptor to be executed before the main endpoint handler executes
 /// </summary>
-/// <param name="TResponse">Intercept responses returning this object type</param>
 public interface IResponseInterceptor
 {
-    Task InterceptResponseAsync(object res, HttpContext ctx, IReadOnlyCollection<ValidationFailure> failures, CancellationToken ct);
+    /// <summary>
+    /// implement this method to intercep the http response.
+    /// </summary>
+    /// <param name="response">the response object</param>
+    /// <param name="ctx">the http context of the current request</param>
+    /// <param name="failures">the collection of validation failures for the endpoint</param>
+    /// <param name="ct">cancellation token</param>
+    Task InterceptResponseAsync(object response, HttpContext ctx, IReadOnlyCollection<ValidationFailure> failures, CancellationToken ct);
 }

--- a/Src/Library/Endpoint/Processor/IResponseInterceptor.cs
+++ b/Src/Library/Endpoint/Processor/IResponseInterceptor.cs
@@ -12,8 +12,10 @@ public interface IResponseInterceptor
     /// implement this method to intercep the http response.
     /// </summary>
     /// <param name="response">the response object</param>
+    /// <param name="statusCode"></param>
     /// <param name="ctx">the http context of the current request</param>
     /// <param name="failures">the collection of validation failures for the endpoint</param>
     /// <param name="ct">cancellation token</param>
-    Task InterceptResponseAsync(object response, HttpContext ctx, IReadOnlyCollection<ValidationFailure> failures, CancellationToken ct);
+    Task InterceptResponseAsync(object response, int statusCode, HttpContext ctx,
+        IReadOnlyCollection<ValidationFailure> failures, CancellationToken ct);
 }

--- a/Src/Library/Extensions/HttpContextExtensions.cs
+++ b/Src/Library/Extensions/HttpContextExtensions.cs
@@ -45,5 +45,5 @@ public static class HttpContextExtensions
     /// check if the current response has already started or not.
     /// </summary>
     public static bool ResponseStarted(this HttpContext ctx)
-        => ctx.Response.HasStarted || ctx.Items.ContainsKey(0); //item must match above
+        => ctx.Response.HasStarted || ctx.Items.ContainsKey(0); //item must match above - MarkResponseStart()
 }

--- a/Tests/UnitTests/FastEndpoints.UnitTests/EndpointTests.cs
+++ b/Tests/UnitTests/FastEndpoints.UnitTests/EndpointTests.cs
@@ -76,7 +76,7 @@ public class EndpointTests
 
             await Assert.ThrowsAsync<ResponseInterceptor.InterceptedResponseException>(() =>
             {
-                return SendAsync(new {
+                return SendInterceptedAsync(new {
                     Id = 0,
                     Age = 1,
                     Name = "Test"

--- a/Tests/UnitTests/FastEndpoints.UnitTests/EndpointTests.cs
+++ b/Tests/UnitTests/FastEndpoints.UnitTests/EndpointTests.cs
@@ -67,12 +67,6 @@ public class EndpointTests
 
     public class SendShouldCallResponseInterceptor : Endpoint<Request, Response>
     {
-
-        public SendShouldCallResponseInterceptor()
-        {
-            ResponseInterceptor(new ResponseInterceptor());
-        }
-
         [Fact]
         public async Task execute_test()
         {

--- a/Tests/UnitTests/FastEndpoints.UnitTests/EndpointTests.cs
+++ b/Tests/UnitTests/FastEndpoints.UnitTests/EndpointTests.cs
@@ -85,6 +85,24 @@ public class EndpointTests
 
         }
     }
+    
+    public class SendInterceptedShouldThrowInvalidOperationExceptionIfCalledWithNoInterceptor : Endpoint<Request, Response>
+    {
+        [Fact]
+        public async Task execute_test()
+        {
+            HttpContext = new DefaultHttpContext();
+            Definition = new EndpointDefinition();
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => 
+                SendInterceptedAsync(new {
+                Id = 0,
+                Age = 1,
+                Name = "Test"
+            }, StatusCodes.Status200OK, default));
+
+        }
+    }
 
     public class SendShouldNotCallResponseInterceptorIfExpectedTypedResponseObjectIsSupplied : Endpoint<Request, Response>
     {
@@ -126,7 +144,7 @@ public class EndpointTests
 
     public class ResponseInterceptor : IResponseInterceptor
     {
-        public Task InterceptResponseAsync(object res, HttpContext ctx, IReadOnlyCollection<ValidationFailure> failures, CancellationToken ct)
+        public Task InterceptResponseAsync(object res, int statusCode, HttpContext ctx, IReadOnlyCollection<ValidationFailure> failures, CancellationToken ct)
             => throw new InterceptedResponseException();
 
         public class InterceptedResponseException : Exception


### PR DESCRIPTION
… it is not of the typed TResponse type).

It will check to see if an IResponseInterceptor has been provided to the Definition of the endpoint, and if it has, run that code.

Then it checks to see if a response has started, if it has, it will simply return, or if not, it will run the SendAsync extension of HttpContext as normal.

Please note: I cannot seem to find the docs to add this information, if you need that too, let me know.