### PR TITLE
Changed method reference for documentation

### DIFF
--- a/Src/Library/Main/MainExtensions.cs
+++ b/Src/Library/Main/MainExtensions.cs
@@ -44,7 +44,7 @@ public static class MainExtensions
 
     /// <summary>
     /// finalizes auto discovery of endpoints and prepares FastEndpoints to start processing requests
-    /// <para>HINT: this is the combination of <see cref="UseFastEndpoints(IApplicationBuilder, Action{Config}?)"/> and <see cref="MapFastEndpoints(IEndpointRouteBuilder, Action{Config}?)"/>.
+    /// <para>HINT: this is the combination of <see cref="UseFastEndpointsMiddleware(IApplicationBuilder)"/> and <see cref="MapFastEndpoints(IEndpointRouteBuilder, Action{Config}?)"/>.
     /// you can use those two methods separately if you have some special requirement such as using "Startup.cs", etc.
     /// </para>
     /// </summary>


### PR DESCRIPTION
The documentation pointer in UseFastEndpoints() was self-referencing.  Should have been UseFastEndpointsMiddleware()