### PR TITLE
Expose the CommandHandlers Cache to be injectable

### DIFF
--- a/Src/Library/Messaging/Commands/CommandExtensions.cs
+++ b/Src/Library/Messaging/Commands/CommandExtensions.cs
@@ -3,7 +3,7 @@
 public static class CommandExtensions
 {
     //key: tCommand //val: handler definition
-    internal static readonly Dictionary<Type, CommandHandlerDefinition> handlerCache = new();
+    internal static readonly Dictionary<Type, CommandHandlerDefinition> handlerCache =  Config.ServiceResolver.TryResolve<IHandlersCacheContainer>()?.HandlersCache ?? new();
 
     /// <summary>
     /// executes the command that does not return a result

--- a/Src/Library/Messaging/Commands/CommandHandlerDefinition.cs
+++ b/Src/Library/Messaging/Commands/CommandHandlerDefinition.cs
@@ -1,11 +1,11 @@
 ﻿namespace FastEndpoints;
 
-internal sealed class CommandHandlerDefinition
+public sealed class CommandHandlerDefinition
 {
     internal Type HandlerType { get; init; }
     internal object? HandlerExecutor { get; set; }
 
-    internal CommandHandlerDefinition(Type handlerType)
+    public CommandHandlerDefinition(Type handlerType)
     {
         HandlerType = handlerType;
     }

--- a/Src/Library/Messaging/Commands/IHandlersCacheContainer.cs
+++ b/Src/Library/Messaging/Commands/IHandlersCacheContainer.cs
@@ -1,0 +1,6 @@
+﻿namespace FastEndpoints;
+
+public interface IHandlersCacheContainer
+{
+    Dictionary<Type, CommandHandlerDefinition> HandlersCache { get; }
+}

--- a/Tests/UnitTests/FastEndpoints.UnitTests/CommandBusTests.cs
+++ b/Tests/UnitTests/FastEndpoints.UnitTests/CommandBusTests.cs
@@ -32,10 +32,12 @@ public class CommandBusTests
         services.TryAddSingleton(fakeHandler.GetType(), _ => fakeHandler);
         services.TryAddSingleton<IServiceResolver>(sp => new ProxyServiceResolver(sp));
         var serviceProvider = services.BuildServiceProvider();
+        
+        var oldServiceResolver = FastEndpoints.Config.ServiceResolver; 
         FastEndpoints.Config.ServiceResolver = serviceProvider.GetRequiredService<IServiceResolver>();
-
         var result = await command.ExecuteAsync();
-     
+        FastEndpoints.Config.ServiceResolver = oldServiceResolver;
+        
         Assert.Equal("Fake Result", result);
     }
 

--- a/Tests/UnitTests/FastEndpoints.UnitTests/ProxyServiceResolver.cs
+++ b/Tests/UnitTests/FastEndpoints.UnitTests/ProxyServiceResolver.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace FastEndpoints.UnitTests;
+
+public class ProxyServiceResolver : IServiceResolver
+{
+    private readonly IServiceProvider sp;
+
+    public ProxyServiceResolver(IServiceProvider serviceProvider)
+    {
+        this.sp = serviceProvider;
+    }
+
+    public IServiceScope CreateScope() => sp.CreateScope();
+
+    public TService? TryResolve<TService>() where TService : class => sp.GetService<TService>() ?? null;
+
+    public object? TryResolve(Type typeOfService) => sp.GetService(typeOfService) ?? null;
+
+    public TService Resolve<TService>() where TService : class => sp.GetRequiredService<TService>();
+
+    public object Resolve(Type typeOfService) => sp.GetRequiredService(typeOfService);
+
+    public object CreateInstance(Type type, IServiceProvider? serviceProvider = null) => sp.GetRequiredService(type);
+
+    public object CreateSingleton(Type type) => ActivatorUtilities.CreateInstance(sp, type);
+}


### PR DESCRIPTION
Added the ability to inject the Command Handlers cache without the need to run the Endpoints.
To unit test the logic that uses commands inside without the need to call the actual command handler.

[Related discussion](https://discord.com/channels/933662816458645504/1096019129250627674)
