### PR TITLE
#471 Nested classes are not discovered by source generator

### DIFF
--- a/Src/Generator/EndpointsDiscoveryGenerator.cs
+++ b/Src/Generator/EndpointsDiscoveryGenerator.cs
@@ -9,7 +9,7 @@ namespace FastEndpoints.Generator;
 [Generator(LanguageNames.CSharp)]
 public class EndpointsDiscoveryGenerator : IIncrementalGenerator
 {
-     public void Initialize(IncrementalGeneratorInitializationContext context)
+    public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var typeDeclarationSyntaxProvider = context.SyntaxProvider.CreateSyntaxProvider(
                 (sn, _) => sn is TypeDeclarationSyntax,

--- a/Src/Library/Main/EndpointData.cs
+++ b/Src/Library/Main/EndpointData.cs
@@ -33,8 +33,7 @@ internal sealed class EndpointData
 
         Stopwatch.Start();
 
-        //also update FastEndpoints.Generator.EndpointsDiscoveryGenerator class if updating these
-        IEnumerable<string> excludes = new[]
+        IEnumerable<string> exclusions = new[]
         {
             "Microsoft",
             "System",
@@ -65,8 +64,9 @@ internal sealed class EndpointData
 
             if (options.Assemblies?.Any() is true)
             {
+                //remove user supplied assemblies from exclusion list
                 assemblies = options.Assemblies;
-                excludes = excludes.Except(options.Assemblies.Select(a => a.FullName?.Split('.')[0]!));
+                exclusions = exclusions.Except(options.Assemblies.Select(a => a.FullName?.Split('.')[0]!));
             }
 
             if (!options.DisableAutoDiscovery)
@@ -78,7 +78,7 @@ internal sealed class EndpointData
             discoveredTypes = assemblies
                 .Where(a =>
                       !a.IsDynamic &&
-                      !excludes.Any(n => a.FullName!.StartsWith(n)))
+                      !exclusions.Any(n => a.FullName!.StartsWith(n)))
                 .SelectMany(a => a.GetTypes())
                 .Where(t =>
                       !t.IsDefined(Types.DontRegisterAttribute) &&

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -19,7 +19,7 @@ bld.AddHandlerServer();
 bld.Services
    .AddCors()
    .AddResponseCaching()
-   .AddFastEndpoints()//(o => o.SourceGeneratorDiscoveredTypes = DiscoveredTypes.All);
+   .AddFastEndpoints()//(o => o.SourceGeneratorDiscoveredTypes = DiscoveredTypes.All)
    .AddJWTBearerAuth(bld.Configuration["TokenKey"]!)
    .AddAuthorization(o => o.AddPolicy("AdminOnly", b => b.RequireRole(Role.Admin)))
    .AddScoped<IEmailService, EmailService>()


### PR DESCRIPTION
In current implementation of the Source Generator nested classes are not discovered properly. This may be an issue in case of some of Vertical Slices approaches where feature is a class that consists of multiple subclasses. 

```CS
public static partial class GetAssignedTasks
{
    public record Result()
    {
        public string ResultBlahBlah => "BlahBlahBlah";
    }

    public record Query()
        : TeamRequest<Result>
    {
    }

    public class Validator : AbstractValidator<Query>
    {
        public Validator()
        {
            RuleFor(p => p.GameId).NotEmpty();
            RuleFor(p => p.TeamId).NotEmpty();
            RuleFor(p => p.TeamName).NotEmpty();
        }
    }
    public partial class Endpoint : BaseTeamEndpoint<Query, Result, Result>
    {
        public override void Configure()
        {
            Get("assignedTasks");
        }
    }
}
```

Its not an issue with Endpoint and its inheritance as when class is moved outside the top level class it is discovered properly.

The PR also simplifies the approach with discovering namespaces - IMO current approach is the way around. 