### PR TITLE
Fix explicit adding an assembly with exclusion name

### DIFF
--- a/Src/Library/Main/EndpointData.cs
+++ b/Src/Library/Main/EndpointData.cs
@@ -55,10 +55,7 @@ internal sealed class EndpointData
             var assemblies = Enumerable.Empty<Assembly>();
 
             if (options.Assemblies?.Any() is true)
-            {
-                //remove user supplied assemblies from exclusion list
                 assemblies = options.Assemblies;
-            }
 
             if (!options.DisableAutoDiscovery)
                 assemblies = assemblies.Union(AppDomain.CurrentDomain.GetAssemblies());
@@ -67,10 +64,7 @@ internal sealed class EndpointData
                 assemblies = assemblies.Where(options.AssemblyFilter);
 
             discoveredTypes = assemblies
-                .Where(a =>
-                      !a.IsDynamic &&
-                      (options.Assemblies?.Contains(a) == true ||
-                          !exclusions.Any(n => a.FullName!.StartsWith(n))))
+                .Where(a => !a.IsDynamic && (options.Assemblies?.Contains(a) is true || !exclusions.Any(x => a.FullName!.StartsWith(x))))
                 .SelectMany(a => a.GetTypes())
                 .Where(t =>
                       !t.IsDefined(Types.DontRegisterAttribute) &&

--- a/Src/Library/Main/EndpointData.cs
+++ b/Src/Library/Main/EndpointData.cs
@@ -70,7 +70,7 @@ internal sealed class EndpointData
             discoveredTypes = assemblies
                 .Where(a =>
                       !a.IsDynamic &&
-                      !exclusions.Any(n => a.FullName!.StartsWith(n)))
+                      !exclusions.Any(n => a.FullName!.Split('.', 1)[0].Equals(n)))
                 .SelectMany(a => a.GetTypes())
                 .Where(t =>
                       !t.IsDefined(Types.DontRegisterAttribute) &&

--- a/Src/Library/Main/EndpointData.cs
+++ b/Src/Library/Main/EndpointData.cs
@@ -58,7 +58,6 @@ internal sealed class EndpointData
             {
                 //remove user supplied assemblies from exclusion list
                 assemblies = options.Assemblies;
-                exclusions = exclusions.Except(options.Assemblies.Select(a => a.FullName?.Split('.')[0]!));
             }
 
             if (!options.DisableAutoDiscovery)
@@ -70,7 +69,8 @@ internal sealed class EndpointData
             discoveredTypes = assemblies
                 .Where(a =>
                       !a.IsDynamic &&
-                      !exclusions.Any(n => a.FullName!.Split('.', 1)[0].Equals(n)))
+                      (options.Assemblies?.Contains(a) == true ||
+                          !exclusions.Any(n => a.FullName!.StartsWith(n))))
                 .SelectMany(a => a.GetTypes())
                 .Where(t =>
                       !t.IsDefined(Types.DontRegisterAttribute) &&

--- a/Src/Library/Main/EndpointDiscoveryOptions.cs
+++ b/Src/Library/Main/EndpointDiscoveryOptions.cs
@@ -46,6 +46,7 @@ public sealed class EndpointDiscoveryOptions
     /// the function you set here will be executed for each discovered type during startup.
     /// return 'false' from the function if you want to exclude a type from discovery.
     /// return 'true' to include.
+    /// alternatively you can annotate the type/class with the <see cref="DontRegisterAttribute"/> to skip auto registration for that type.
     /// </summary>
     public Func<Type, bool>? Filter { internal get; set; }
 }


### PR DESCRIPTION
* Have an assembly name "SystemFoo" or any other which name starts with a string from the exclusion list
* Add it explicitly `options.Assemblies = new[] { typeof(Program).Assembly }`

**Actual result**
No endpoints discovered

**Expected result**
Endpoints found