### PR TITLE
adding missing AddAuthorization for benchmarks

### DIFF
--- a/Benchmark/FastEndpointsBench/Program.cs
+++ b/Benchmark/FastEndpointsBench/Program.cs
@@ -3,6 +3,7 @@ using FEBench;
 
 var builder = WebApplication.CreateBuilder();
 builder.Logging.ClearProviders();
+builder.Services.AddAuthorization();
 builder.Services.AddFastEndpoints();
 builder.Services.AddScoped<ScopedValidator>();
 


### PR DESCRIPTION
AddAuthorization is no longer called in AddFastEndpoints() and needs to be added to the services for benchmarks.