### PR TITLE
Add GlobalPre/PostProcessors and integration/unit test amendment

### DIFF
--- a/Src/Library/Endpoint/Processor/GlobalPostProcessor.cs
+++ b/Src/Library/Endpoint/Processor/GlobalPostProcessor.cs
@@ -4,6 +4,22 @@
 /// inherit this class to create a global post-processor with access to the common processor state of the endpoint
 /// </summary>
 /// <typeparam name="TState">type of the common processor state</typeparam>
-public abstract class GlobalPostProcessor<TState> : PostProcessor<object, TState, object>, IGlobalPostProcessor where TState : class, new()
+public abstract class GlobalPostProcessor<TState> : IGlobalPostProcessor where TState : class, new()
 {
+    /// <summary>
+    /// not intended for direct external use.
+    /// </summary>
+    [HideFromDocs]
+    public Task PostProcessAsync(IPostProcessorContext context, CancellationToken ct)
+        => PostProcessAsync(context, context.HttpContext.ProcessorState<TState>(), ct);
+
+    // ReSharper disable once MemberCanBeProtected.Global
+    /// <summary>
+    /// implement this method to define the post-processing logic using the provided context and state.
+    /// </summary>
+    /// <param name="context">the context object encapsulating all necessary information for post-processing.</param>
+    /// <param name="state">the common processor state object, derived from the HttpContext or newly instantiated.</param>
+    /// <param name="ct">cancellation token.</param>
+    /// <returns>a Task representing the asynchronous operation.</returns>
+    public abstract Task PostProcessAsync(IPostProcessorContext context, TState state, CancellationToken ct);
 }

--- a/Src/Library/Endpoint/Processor/GlobalPostProcessor.cs
+++ b/Src/Library/Endpoint/Processor/GlobalPostProcessor.cs
@@ -1,0 +1,9 @@
+﻿namespace FastEndpoints;
+
+/// <summary>
+/// inherit this class to create a global post-processor with access to the common processor state of the endpoint
+/// </summary>
+/// <typeparam name="TState">type of the common processor state</typeparam>
+public abstract class GlobalPostProcessor<TState> : PostProcessor<object, TState, object>, IGlobalPostProcessor where TState : class, new()
+{
+}

--- a/Src/Library/Endpoint/Processor/GlobalPreProcessor.cs
+++ b/Src/Library/Endpoint/Processor/GlobalPreProcessor.cs
@@ -4,6 +4,21 @@ namespace FastEndpoints;
 /// inherit this class to create a global pre-processor with access to the common processor state of the endpoint
 /// </summary>
 /// <typeparam name="TState">type of the common processor state</typeparam>
-public abstract class GlobalPreProcessor<TState> : PreProcessor<object, TState>, IGlobalPreProcessor where TState : class, new()
+public abstract class GlobalPreProcessor<TState> : IGlobalPreProcessor where TState : class, new()
 {
+    /// <summary>
+    /// not intended for direct external use.
+    /// </summary>
+    [HideFromDocs]
+    public Task PreProcessAsync(IPreProcessorContext context, CancellationToken ct)
+        => PreProcessAsync(context, context.HttpContext.ProcessorState<TState>(), ct);
+
+    // ReSharper disable once MemberCanBeProtected.Global
+    /// <summary>
+    /// this method is called with the given arguments when the pre-processor executes.
+    /// </summary>
+    /// <param name="context">the context object encapsulating all necessary information for pre-processing.</param>
+    /// <param name="state">the common processor state object</param>
+    /// <param name="ct">cancellation token</param>
+    public abstract Task PreProcessAsync(IPreProcessorContext context, TState state, CancellationToken ct);
 }

--- a/Src/Library/Endpoint/Processor/GlobalPreProcessor.cs
+++ b/Src/Library/Endpoint/Processor/GlobalPreProcessor.cs
@@ -1,0 +1,9 @@
+namespace FastEndpoints;
+
+/// <summary>
+/// inherit this class to create a global pre-processor with access to the common processor state of the endpoint
+/// </summary>
+/// <typeparam name="TState">type of the common processor state</typeparam>
+public abstract class GlobalPreProcessor<TState> : PreProcessor<object, TState>, IGlobalPreProcessor where TState : class, new()
+{
+}

--- a/Tests/IntegrationTests/FastEndpoints/WebTests/MiscTestCases.cs
+++ b/Tests/IntegrationTests/FastEndpoints/WebTests/MiscTestCases.cs
@@ -897,7 +897,7 @@ public class MiscTestCases : TestClass<Fixture>
                     string>(new() { Id = 10101 });
 
         x.Response.StatusCode.Should().Be(HttpStatusCode.OK);
-        x.Result.Should().Be("10101 jane doe");
+        x.Result.Should().Be("10101 jane doe True");
     }
 
     [Fact]

--- a/Tests/UnitTests/FastEndpoints/WebTests.cs
+++ b/Tests/UnitTests/FastEndpoints/WebTests.cs
@@ -194,7 +194,8 @@ public class WebTests
         await ep.HandleAsync(new() { Id = 0 }, default);
 
         //assert
-        ep.Response.Should().Be("101 blah");
+        // False represents the lack of global state addition from endpoint without global preprocessor
+        ep.Response.Should().Be("101 blah False");
         state.Duration.Should().BeGreaterThan(95);
     }
 

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -6,6 +6,7 @@ using TestCases.ClientStreamingTest;
 using TestCases.CommandBusTest;
 using TestCases.EventQueueTest;
 using TestCases.JobQueueTest;
+using TestCases.ProcessorStateTest;
 using TestCases.ServerStreamingTest;
 using TestCases.UnitTestConcurrencyTest;
 using Web;
@@ -115,6 +116,7 @@ app.UseRequestLocalization(
            c.Endpoints.Filter = ep => ep.EndpointTags?.Contains("exclude") is not true;
            c.Endpoints.Configurator = ep =>
            {
+               ep.PreProcessors(Order.Before, new GlobalStatePreProcessor());
                ep.PreProcessors(Order.Before, new AdminHeaderChecker());
                if (ep.EndpointTags?.Contains("orders") is true)
                    ep.Description(b => b.Produces<ErrorResponse>(400, "application/problem+json"));

--- a/Web/[Features]/TestCases/ProcessorStateTest/Endpoint.cs
+++ b/Web/[Features]/TestCases/ProcessorStateTest/Endpoint.cs
@@ -16,6 +16,6 @@ public class Endpoint : Endpoint<Request, string>
     {
         var state = ProcessorState<Thingy>();
         await Task.Delay(100);
-        await SendAsync(state.Id + " " + state.Name);
+        await SendAsync(state.Id + " " + state.Name + " " + state.GlobalStateApplied);
     }
 }

--- a/Web/[Features]/TestCases/ProcessorStateTest/GlobalStatePreProcessor.cs
+++ b/Web/[Features]/TestCases/ProcessorStateTest/GlobalStatePreProcessor.cs
@@ -4,9 +4,10 @@ namespace TestCases.ProcessorStateTest;
 
 public class GlobalStatePreProcessor : GlobalPreProcessor<Thingy>
 {
-    public override Task PreProcessAsync(object req, Thingy state, HttpContext ctx, List<ValidationFailure> failures, CancellationToken ct)
+    public override Task PreProcessAsync(IPreProcessorContext context, Thingy state, CancellationToken ct)
     {
         state.GlobalStateApplied = true;
+
         return Task.CompletedTask;
     }
 }

--- a/Web/[Features]/TestCases/ProcessorStateTest/GlobalStatePreProcessor.cs
+++ b/Web/[Features]/TestCases/ProcessorStateTest/GlobalStatePreProcessor.cs
@@ -1,0 +1,12 @@
+using FluentValidation.Results;
+
+namespace TestCases.ProcessorStateTest;
+
+public class GlobalStatePreProcessor : GlobalPreProcessor<Thingy>
+{
+    public override Task PreProcessAsync(object req, Thingy state, HttpContext ctx, List<ValidationFailure> failures, CancellationToken ct)
+    {
+        state.GlobalStateApplied = true;
+        return Task.CompletedTask;
+    }
+}

--- a/Web/[Features]/TestCases/ProcessorStateTest/Thingy.cs
+++ b/Web/[Features]/TestCases/ProcessorStateTest/Thingy.cs
@@ -9,6 +9,7 @@ public class Thingy
     public int Id { get; set; }
     public string? Name { get; set; }
     public long Duration => _stopWatch.ElapsedMilliseconds;
+    public bool GlobalStateApplied { get; set; }
 
     public Thingy()
     {


### PR DESCRIPTION
This adds a  `GlobalPreProcessor` and `GlobalPostProcessor` class to support state-driven global processors.

The existing unit/integration tests were hijacked as the change is relatively straightforward and related, though they could be separated if needed?