### PR TITLE
New security options, new overloads for AddJWTBearerAuth and sensible defaults

### DIFF
--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
 
-        <Version>5.19.0.9-beta</Version>
+        <Version>5.19.0.10-beta</Version>
 
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>

--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
 
-        <Version>5.19.0.8-beta</Version>
+        <Version>5.19.0.9-beta</Version>
 
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>

--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
 
-        <Version>5.19.0.7-beta</Version>
+        <Version>5.19.0.8-beta</Version>
 
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>

--- a/Src/Library/Config/SecurityOptions.cs
+++ b/Src/Library/Config/SecurityOptions.cs
@@ -6,6 +6,15 @@
 public sealed class SecurityOptions
 {
     /// <summary>
+    /// specify a custom claim type used to identity the name of a user principal. defaults to `name`.
+    /// <para>
+    /// WARNING: do not change the default unless you fully comprehend what you're doing!!!
+    /// </para>
+    /// </summary>
+    public string NameClaimType { internal get; set; }
+        = "name";
+    
+    /// <summary>
     /// specify a custom claim type used to identify permissions of a user principal. defaults to `permission`.
     /// <para>
     /// WARNING: do not change the default unless you fully comprehend what you're doing!!!
@@ -13,4 +22,13 @@ public sealed class SecurityOptions
     /// </summary>
     public string PermissionsClaimType { internal get; set; }
         = "permissions"; //should never change from "permissions" or third party auth providers such as Auth0 won't work.
+    
+    /// <summary>
+    /// specify a custom claim type used to identify roles of a user principal. defaults to `role`.
+    /// <para>
+    /// WARNING: do not change the default unless you fully comprehend what you're doing!!!
+    /// </para>
+    /// </summary>
+    public string RoleClaimType { internal get; set; }
+        = "role";
 }

--- a/Src/Library/DTOs/ProblemDetails.cs
+++ b/Src/Library/DTOs/ProblemDetails.cs
@@ -54,21 +54,29 @@ public sealed class ProblemDetails : IResult
 #pragma warning restore CA1822
 
     [DefaultValue(400)]
-    public int Status { get; private set; }
+    public int Status { get; set; }
 
     [DefaultValue("/api/route")]
-    public string Instance { get; private set; }
+    public string Instance { get; set; } = null!;
 
     [DefaultValue("0HMPNHL0JHL76:00000001")]
-    public string TraceId { get; private set; }
+    public string TraceId { get; set; } = null!;
 
-    public IEnumerable<Error> Errors { get; private set; }
+    public IEnumerable<Error> Errors { get; set; } = null!;
 
-    public ProblemDetails(List<ValidationFailure> failures, int? statusCode = null) { Initialize(failures, null!, null!, statusCode ?? Config.ErrOpts.StatusCode); }
+    public ProblemDetails() { }
 
-    public ProblemDetails(List<ValidationFailure> failures, string instance, string traceId, int statusCode) { Initialize(failures, instance, traceId, statusCode); }
+    public ProblemDetails(IReadOnlyList<ValidationFailure> failures, int? statusCode = null)
+    {
+        Initialize(failures, null!, null!, statusCode ?? Config.ErrOpts.StatusCode);
+    }
 
-    void Initialize(List<ValidationFailure> failures, string instance, string traceId, int statusCode)
+    public ProblemDetails(IReadOnlyList<ValidationFailure> failures, string instance, string traceId, int statusCode)
+    {
+        Initialize(failures, instance, traceId, statusCode);
+    }
+
+    void Initialize(IReadOnlyList<ValidationFailure> failures, string instance, string traceId, int statusCode)
     {
         Status = statusCode;
         Instance = instance;
@@ -128,25 +136,27 @@ public sealed class ProblemDetails : IResult
         /// the name of the error or property of the dto that caused the error
         /// </summary>
         [DefaultValue("Error or field name")]
-        public string Name { get; init; }
+        public string Name { get; set; } = null!;
 
         /// <summary>
         /// the reason for the error
         /// </summary>
         [DefaultValue("Error reason")]
-        public string Reason { get; init; }
+        public string Reason { get; set; } = null!;
 
         /// <summary>
         /// the code of the error
         /// </summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public string? Code { get; init; }
+        public string? Code { get; set; }
 
         /// <summary>
         /// the severity of the error
         /// </summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        public string? Severity { get; init; }
+        public string? Severity { get; set; }
+
+        public Error() { }
 
         public Error(ValidationFailure failure)
         {

--- a/Src/Library/Endpoint/Auxiliary/HitCounter.cs
+++ b/Src/Library/Endpoint/Auxiliary/HitCounter.cs
@@ -19,11 +19,7 @@ sealed class HitCounter
     }
 
     internal bool LimitReached(string headerValue)
-    {
-        return _clients.GetOrAdd(
-            headerValue,
-            hVal => new(_durationSeconds, hVal, _limit, ref _clients)).LimitReached();
-    }
+        => _clients.GetOrAdd(headerValue, new Counter(_durationSeconds, headerValue, _limit, ref _clients)).LimitReached();
 
     sealed class Counter : IDisposable
     {

--- a/Src/Library/Endpoint/Endpoint.Setup.cs
+++ b/Src/Library/Endpoint/Endpoint.Setup.cs
@@ -353,25 +353,31 @@ public abstract partial class Endpoint<TRequest, TResponse> where TRequest : not
     //because Order.After below ultimately causes an append via list.Add()
     static int _unused;
 
-    //todo: write tests
+    /// <summary>
+    /// configure a  post-processor to be executed after the main handler function is done. call this method multiple times to add multiple post-processors.
+    /// processors are executed in the order they are configured in the endpoint.
+    /// </summary>
+    /// <typeparam name="TPostProcessor">the post-processor to add</typeparam>
     protected void PostProcessor<TPostProcessor>() where TPostProcessor : class, IPostProcessor<TRequest, TResponse>
         => EndpointDefinition.AddProcessor<TPostProcessor>(Order.After, Definition.PostProcessorList, ref _unused);
 
     /// <summary>
-    /// configure a collection of post-processors to be executed after the main handler function is done. processors are executed in the order they are
-    /// defined here.
+    /// configure a collection of post-processors to be executed after the main handler function is done. processors are executed in the order they are  defined here.
     /// </summary>
     /// <param name="postProcessors">the post processors to be executed</param>
     protected void PostProcessors(params IPostProcessor<TRequest, TResponse>[] postProcessors)
         => EndpointDefinition.AddProcessors(Order.After, postProcessors, Definition.PostProcessorList, ref _unused);
 
-    //todo: write tests
+    /// <summary>
+    /// configure a  pre-processor to be executed before the main handler function is called. call this method multiple times to add multiple pre-processors.
+    /// processors are executed in the order they are configured in the endpoint.
+    /// </summary>
+    /// <typeparam name="TPreProcessor">the pre-processor to add</typeparam>
     protected void PreProcessor<TPreProcessor>() where TPreProcessor : class, IPreProcessor<TRequest>
         => EndpointDefinition.AddProcessor<TPreProcessor>(Order.After, Definition.PreProcessorList, ref _unused);
 
     /// <summary>
-    /// configure a collection of pre-processors to be executed before the main handler function is called. processors are executed in the order they are
-    /// defined here.
+    /// configure a collection of pre-processors to be executed before the main handler function is called. processors are executed in the order they are defined here.
     /// </summary>
     /// <param name="preProcessors">the pre processors to be executed</param>
     protected void PreProcessors(params IPreProcessor<TRequest>[] preProcessors)

--- a/Src/Library/Endpoint/Endpoint.Static.cs
+++ b/Src/Library/Endpoint/Endpoint.Static.cs
@@ -82,7 +82,7 @@ public abstract partial class Endpoint<TRequest, TResponse> where TRequest : not
                                        object resp,
                                        int statusCode,
                                        HttpContext ctx,
-                                       List<ValidationFailure> validationFailures,
+                                       IReadOnlyCollection<ValidationFailure> validationFailures,
                                        CancellationToken cancellation)
         => interceptor.InterceptResponseAsync(resp, statusCode, ctx, validationFailures, cancellation);
 
@@ -93,15 +93,4 @@ public abstract partial class Endpoint<TRequest, TResponse> where TRequest : not
         => responseDto is null
                ? ctx.Response.SendNoContentAsync(cancellation)
                : ctx.Response.SendAsync(responseDto, ctx.Response.StatusCode, jsonSerializerContext, cancellation);
-
-    static void AddProcessors(object[] processors, List<object> target)
-    {
-        for (var i = 0; i < processors.Length; i++)
-        {
-            var p = processors[i];
-
-            if (!target.Contains(p, TypeEqualityComparer.Instance))
-                target.Add(p);
-        }
-    }
 }

--- a/Src/Library/Endpoint/Factory/EndpointFactory.cs
+++ b/Src/Library/Endpoint/Factory/EndpointFactory.cs
@@ -20,9 +20,10 @@ public sealed class EndpointFactory : IEndpointFactory
 
         var epInstance = (BaseEndpoint)Conf.ServiceResolver.CreateInstance(definition.EndpointType, ctx.RequestServices);
 
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         var isAppStartup = ctx.Connection.Id == null;
 
-        for (var i = 0; i < definition.ServiceBoundEpProps?.Length; i++)
+        for (var i = 0; i < definition.ServiceBoundEpProps.Length; i++)
         {
             var prop = definition.ServiceBoundEpProps[i];
             prop.PropSetter ??= definition.EndpointType.SetterForProp(prop.PropName);

--- a/Src/Library/ServiceResolver/IServiceResolver.cs
+++ b/Src/Library/ServiceResolver/IServiceResolver.cs
@@ -54,8 +54,8 @@ public interface IServiceResolverBase
 public interface IServiceResolver : IServiceResolverBase
 {
     /// <summary>
-    /// create an instance of a given type (which may not be registered in the DI container). this method will be called repeatedly per request. so a cached
-    /// delegate/compiled expression such as <see cref="ActivatorUtilities.CreateFactory(Type, Type[])" /> should be used for instance creation.
+    /// create an instance of a given type (which may not be registered in the DI container). this method will be called repeatedly. so a cached
+    /// delegate/compiled expression using something like <see cref="ActivatorUtilities.CreateFactory(Type, Type[])" /> should be used for instance creation.
     /// </summary>
     /// <param name="type">the type to create an instance of</param>
     /// <param name="serviceProvider">optional service provider</param>
@@ -63,7 +63,8 @@ public interface IServiceResolver : IServiceResolverBase
 
     /// <summary>
     /// create an instance of a given type (which may not be registered in the DI container) which will be used as a singleton. a utility such as
-    /// <see cref="ActivatorUtilities.CreateInstance(IServiceProvider, Type, object[])" /> may be used.
+    /// <see cref="ActivatorUtilities.CreateInstance(IServiceProvider, Type, object[])" /> may be used. repeated calls with the same input type should return the same singleton
+    /// instance by utilizing an internal concurrent/thread-safe cache.
     /// </summary>
     /// <param name="type">the type to create an instance of</param>
     object CreateSingleton(Type type);

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -63,7 +63,7 @@ The `ProblemDetails` DTO properties had private setter properties preventing STJ
 
 </details>
 
-## Breaking Changes ⚠️
+## Minor Breaking Changes ⚠️
 
 <details><summary>Pre/Post Processor interface changes</summary>
 

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -16,6 +16,12 @@ todo: write description
 
 </details>
 
+<details><summary>Simpler way to register Pre/Post Processors with DI support</summary>
+
+ref: https://github.com/FastEndpoints/FastEndpoints/pull/528
+
+</details>
+
 <details><summary>Exception handling capability for Post-Processors</summary>
 
 todo: update doc page and link here

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -57,6 +57,12 @@ ref: https://discord.com/channels/933662816458645504/1168177198415482972
 
 </details>
 
+<details><summary>Test assertions couldn't be done on ProblemDetails DTO</summary>
+
+The `ProblemDetails` DTO properties had private setter properties preventing STJ from being able to deserialize the JSON which has now been corrected.
+
+</details>
+
 ## Breaking Changes ⚠️
 
 <details><summary>Pre/Post Processor interface changes</summary>

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -70,3 +70,23 @@ The `ProblemDetails` DTO properties had private setter properties preventing STJ
 todo: describe the change and how to migrate
 
 </details>
+
+<details><summary>AddJWTBearerAuth() default claim type mapping behavior change</summary>
+
+The `JwtSecurityTokenHandler.DefaultInboundClaimTypeMap` static dictionary is presently used by ASP.NET for mapping claim types for inbound claim type mapping. In most
+cases people use `JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear()` to not have long claim types such
+as `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier` as the claim type for the `sub` claim for example.
+
+The default behavior has now been changed to make the claim types not use the SOAP type identifies like above. If for some reason you'd like to revert to the old
+behavior, it can be achieved like so:
+
+```csharp
+.AddJWTBearerAuth("jwt_signing_key", o =>
+{
+    o.MapInboundClaims = true;
+});
+```
+
+See #526 for more info.
+
+</details>

--- a/Src/Security/AuthExtensions.cs
+++ b/Src/Security/AuthExtensions.cs
@@ -19,29 +19,6 @@ public static class AuthExtensions
     /// configure and enable jwt bearer authentication
     /// </summary>
     /// <param name="tokenSigningKey">the secret key to use for verifying the jwt tokens</param>
-    public static IServiceCollection AddJWTBearerAuth(this IServiceCollection services,
-                                                      string tokenSigningKey)
-    {
-        return services.AddJWTBearerAuth(tokenSigningKey, TokenSigningStyle.Symmetric, null);
-    }
-
-
-    /// <summary>
-    /// configure and enable jwt bearer authentication
-    /// </summary>
-    /// <param name="tokenSigningKey">the secret key to use for verifying the jwt tokens</param>
-    /// <param name="tokenSigningStyle">specify the token signing style</param>
-    public static IServiceCollection AddJWTBearerAuth(this IServiceCollection services,
-                                                      string tokenSigningKey,
-                                                      TokenSigningStyle tokenSigningStyle = TokenSigningStyle.Symmetric)
-    {
-        return services.AddJWTBearerAuth(tokenSigningKey, tokenSigningStyle, null);
-    }
-
-    /// <summary>
-    /// configure and enable jwt bearer authentication
-    /// </summary>
-    /// <param name="tokenSigningKey">the secret key to use for verifying the jwt tokens</param>
     /// <param name="tokenSigningStyle">specify the token signing style</param>
     /// <param name="tokenValidation">configuration action to specify additional token validation parameters</param>
     /// <param name="bearerEvents">configuration action to specify custom jwt bearer events</param>
@@ -65,11 +42,21 @@ public static class AuthExtensions
     /// configure and enable jwt bearer authentication
     /// </summary>
     /// <param name="tokenSigningKey">the secret key to use for verifying the jwt tokens</param>
+    /// <param name="jwtOptions">configuration action to specify options for the authentication scheme</param>
+    public static IServiceCollection AddJWTBearerAuth(this IServiceCollection services,
+                                                      string tokenSigningKey,
+                                                      Action<JwtBearerOptions> jwtOptions)
+        => AddJWTBearerAuth(services, tokenSigningKey, TokenSigningStyle.Asymmetric, jwtOptions);
+
+    /// <summary>
+    /// configure and enable jwt bearer authentication
+    /// </summary>
+    /// <param name="tokenSigningKey">the secret key to use for verifying the jwt tokens</param>
     /// <param name="tokenSigningStyle">specify the token signing style</param>
     /// <param name="jwtOptions">configuration action to specify options for the authentication scheme</param>
     public static IServiceCollection AddJWTBearerAuth(this IServiceCollection services,
                                                       string tokenSigningKey,
-                                                      TokenSigningStyle tokenSigningStyle = TokenSigningStyle.Symmetric,
+                                                      TokenSigningStyle tokenSigningStyle,
                                                       Action<JwtBearerOptions>? jwtOptions = null)
     {
         services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
@@ -79,9 +66,7 @@ public static class AuthExtensions
                         SecurityKey key;
 
                         if (tokenSigningStyle == TokenSigningStyle.Symmetric)
-                        {
                             key = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(tokenSigningKey));
-                        }
                         else
                         {
                             var rsa = RSA.Create();
@@ -105,7 +90,7 @@ public static class AuthExtensions
                         o.MapInboundClaims = false;
 
                         jwtOptions?.Invoke(o);
-                        
+
                         //correct any user mistake
                         o.TokenValidationParameters.ValidateAudience = o.TokenValidationParameters.ValidAudience is not null;
                         o.TokenValidationParameters.ValidateIssuer = o.TokenValidationParameters.ValidIssuer is not null;
@@ -117,21 +102,22 @@ public static class AuthExtensions
     /// <summary>
     /// configure and enable cookie based authentication
     /// </summary>
-    /// <param name="validFor">specify how long the created cookie is valid for with a <see cref="TimeSpan"/></param>
+    /// <param name="validFor">specify how long the created cookie is valid for with a <see cref="TimeSpan" /></param>
     /// <param name="options">optional action for configuring cookie authentication options</param>
     public static IServiceCollection AddCookieAuth(this IServiceCollection services,
                                                    TimeSpan validFor,
                                                    Action<CookieAuthenticationOptions>? options = null)
     {
         services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
-            .AddCookie(o =>
-            {
-                o.ExpireTimeSpan = validFor;
-                o.Cookie.MaxAge = validFor;
-                o.Cookie.HttpOnly = true;
-                o.Cookie.SameSite = SameSiteMode.Lax;
-                options?.Invoke(o);
-            });
+                .AddCookie(
+                    o =>
+                    {
+                        o.ExpireTimeSpan = validFor;
+                        o.Cookie.MaxAge = validFor;
+                        o.Cookie.HttpOnly = true;
+                        o.Cookie.SameSite = SameSiteMode.Lax;
+                        options?.Invoke(o);
+                    });
 
         return services;
     }
@@ -158,29 +144,21 @@ public static class AuthExtensions
         => principal.FindFirstValue(claimType);
 
     /// <summary>
-    /// adds multiple <see cref="Claim"/>s to the list.
+    /// adds multiple <see cref="Claim" />s to the list.
     /// </summary>
-    /// <param name="claims">the <see cref="Claim"/>s to append to the list.</param>
-    public static void Add(this List<Claim> list, params Claim[] claims)
-    {
-        list.AddRange(claims);
-    }
+    /// <param name="claims">the <see cref="Claim" />s to append to the list.</param>
+    public static void Add(this List<Claim> list, params Claim[] claims) { list.AddRange(claims); }
 
     /// <summary>
-    /// adds multiple <see cref="Claim"/>s to the list.
+    /// adds multiple <see cref="Claim" />s to the list.
     /// </summary>
     /// <param name="claims">the claim <c>Type</c> &amp; <c>Value</c> tuples to add to the list.</param>
     public static void Add(this List<Claim> list, params (string claimType, string claimValue)[] claims)
-    {
-        list.AddRange(claims.Select(c => new Claim(c.claimType, c.claimValue)));
-    }
+        => list.AddRange(claims.Select(c => new Claim(c.claimType, c.claimValue)));
 
     /// <summary>
     /// adds multiple strings to a list.
     /// </summary>
     /// <param name="values">the strings to append to the list.</param>
-    public static void Add(this List<string> list, params string[] values)
-    {
-        list.AddRange(values);
-    }
+    public static void Add(this List<string> list, params string[] values) { list.AddRange(values); }
 }

--- a/Src/Security/JWTBearer.cs
+++ b/Src/Security/JWTBearer.cs
@@ -3,6 +3,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.IdentityModel.JsonWebTokens;
 
 namespace FastEndpoints.Security;
 
@@ -117,7 +118,7 @@ public static class JWTBearer
             claimList.AddRange(permissions.Select(p => new Claim(Conf.SecOpts.PermissionsClaimType, p)));
 
         if (roles != null)
-            claimList.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+            claimList.AddRange(roles.Select(r => new Claim(Conf.SecOpts.RoleClaimType, r)));
 
         var descriptor = new SecurityTokenDescriptor
         {
@@ -129,9 +130,13 @@ public static class JWTBearer
             SigningCredentials = GetSigningCredentials(signingKey, signingStyle)
         };
 
+        #if NET8_0_OR_GREATER
+        var handler = new JsonWebTokenHandler();
+        return handler.CreateToken(descriptor);
+        #else
         var handler = new JwtSecurityTokenHandler();
-
         return handler.WriteToken(handler.CreateToken(descriptor));
+        #endif
     }
 
     static SigningCredentials GetSigningCredentials(string key, TokenSigningStyle style)

--- a/Src/Security/JWTBearer.cs
+++ b/Src/Security/JWTBearer.cs
@@ -1,9 +1,13 @@
 using Microsoft.IdentityModel.Tokens;
-using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
+#if NET8_0_OR_GREATER
 using Microsoft.IdentityModel.JsonWebTokens;
+
+#else
+using System.IdentityModel.Tokens.Jwt;
+#endif
 
 namespace FastEndpoints.Security;
 
@@ -130,13 +134,15 @@ public static class JWTBearer
             SigningCredentials = GetSigningCredentials(signingKey, signingStyle)
         };
 
-        #if NET8_0_OR_GREATER
+    #if NET8_0_OR_GREATER
         var handler = new JsonWebTokenHandler();
+
         return handler.CreateToken(descriptor);
-        #else
+    #else
         var handler = new JwtSecurityTokenHandler();
+
         return handler.WriteToken(handler.CreateToken(descriptor));
-        #endif
+    #endif
     }
 
     static SigningCredentials GetSigningCredentials(string key, TokenSigningStyle style)
@@ -146,14 +152,10 @@ public static class JWTBearer
             var rsa = RSA.Create(); // don't dispose this
             rsa.ImportRSAPrivateKey(Convert.FromBase64String(key), out _);
 
-            return new(
-                new RsaSecurityKey(rsa),
-                SecurityAlgorithms.RsaSha256);
+            return new(new RsaSecurityKey(rsa), SecurityAlgorithms.RsaSha256);
         }
 
-        return new(
-            new SymmetricSecurityKey(Encoding.ASCII.GetBytes(key)),
-            SecurityAlgorithms.HmacSha256Signature);
+        return new(new SymmetricSecurityKey(Encoding.ASCII.GetBytes(key)), SecurityAlgorithms.HmacSha256Signature);
     }
 
     /// <summary>

--- a/Tests/UnitTests/FastEndpoints/EndpointDataTests.cs
+++ b/Tests/UnitTests/FastEndpoints/EndpointDataTests.cs
@@ -1,4 +1,7 @@
 ﻿using FastEndpoints;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
 
 namespace EPData;
@@ -26,16 +29,171 @@ public class EndpointDataTests
         sut.Found[0].Routes.Should().HaveCount(1);
         sut?.Found[0]?.Routes?[0].Should().BeEquivalentTo(typename);
     }
+
+    static EndpointDefinition WireUpProcessorEndpoint()
+    {
+        var services = new ServiceCollection();
+        services.AddHttpContextAccessor();
+        services.TryAddSingleton<IServiceResolver, ServiceResolver>();
+        services.TryAddSingleton<IEndpointFactory, EndpointFactory>();
+        var sp = services.BuildServiceProvider();
+        Config.ServiceResolver = sp.GetRequiredService<IServiceResolver>();
+        var epFactory = sp.GetRequiredService<IEndpointFactory>();
+        using var scope = sp.CreateScope();
+        var httpCtx = new DefaultHttpContext { RequestServices = scope.ServiceProvider };
+        var epDef = new EndpointDefinition(typeof(PreProcessorRegistration), typeof(EmptyRequest), typeof(EmptyResponse));
+        var baseEp = epFactory.Create(epDef, httpCtx);
+        epDef.ImplementsConfigure = true; // Override as there's no EndpointData resolver
+        epDef.Initialize(baseEp, httpCtx);
+
+        return epDef;
+    }
+
+    [Fact]
+    public void BaselineProcessorOrder()
+    {
+        var epDef = WireUpProcessorEndpoint();
+
+        // Simulate global definition
+        epDef.PreProcessors(Order.Before, new ProcOne(), new ProcTwo());
+        epDef.PreProcessors(Order.After, new ProcThree(), new ProcFour());
+        epDef.PostProcessors(Order.Before, new PostProcOne(), new PostProcTwo());
+        epDef.PostProcessors(Order.After, new PostProcThree(), new PostProcFour());
+
+        epDef.PreProcessorList.Should().HaveCount(5);
+        epDef.PreProcessorList[0].Should().BeOfType<ProcOne>();
+        epDef.PreProcessorList[1].Should().BeOfType<ProcTwo>();
+        epDef.PreProcessorList[2].Should().BeOfType<ProcRequest>();
+        epDef.PreProcessorList[3].Should().BeOfType<ProcThree>();
+        epDef.PreProcessorList[4].Should().BeOfType<ProcFour>();
+
+        epDef.PostProcessorList.Should().HaveCount(5);
+        epDef.PostProcessorList[0].Should().BeOfType<PostProcOne>();
+        epDef.PostProcessorList[1].Should().BeOfType<PostProcTwo>();
+        epDef.PostProcessorList[2].Should().BeOfType<PostProcRequest>();
+        epDef.PostProcessorList[3].Should().BeOfType<PostProcThree>();
+        epDef.PostProcessorList[4].Should().BeOfType<PostProcFour>();
+    }
+
+    [Fact]
+    public void MultiCallProcessorOrder()
+    {
+        var epDef = WireUpProcessorEndpoint();
+
+        // Simulate global definition
+        epDef.PreProcessors(Order.Before, new ProcOne());
+        epDef.PreProcessors(Order.Before, new ProcTwo());
+        epDef.PreProcessors(Order.After, new ProcThree());
+        epDef.PreProcessors(Order.After, new ProcFour());
+        epDef.PostProcessors(Order.Before, new PostProcOne());
+        epDef.PostProcessors(Order.Before, new PostProcTwo());
+        epDef.PostProcessors(Order.After, new PostProcThree());
+        epDef.PostProcessors(Order.After, new PostProcFour());
+
+        epDef.PreProcessorList.Should().HaveCount(5);
+        epDef.PreProcessorList[0].Should().BeOfType<ProcOne>();
+        epDef.PreProcessorList[1].Should().BeOfType<ProcTwo>();
+        epDef.PreProcessorList[2].Should().BeOfType<ProcRequest>();
+        epDef.PreProcessorList[3].Should().BeOfType<ProcThree>();
+        epDef.PreProcessorList[4].Should().BeOfType<ProcFour>();
+        epDef.PostProcessorList.Should().HaveCount(5);
+        epDef.PostProcessorList[0].Should().BeOfType<PostProcOne>();
+        epDef.PostProcessorList[1].Should().BeOfType<PostProcTwo>();
+        epDef.PostProcessorList[2].Should().BeOfType<PostProcRequest>();
+        epDef.PostProcessorList[3].Should().BeOfType<PostProcThree>();
+        epDef.PostProcessorList[4].Should().BeOfType<PostProcFour>();
+    }
+
+    [Fact]
+    public void ServiceResolvedProcessorOrder()
+    {
+        var epDef = WireUpProcessorEndpoint();
+
+        // Simulate global definition
+        epDef.PreProcessor<ProcOne>(Order.Before);
+        epDef.PreProcessor<ProcTwo>(Order.Before);
+        epDef.PreProcessor<ProcThree>(Order.After);
+        epDef.PreProcessor<ProcFour>(Order.After);
+        epDef.PostProcessor<PostProcOne>(Order.Before);
+        epDef.PostProcessor<PostProcTwo>(Order.Before);
+        epDef.PostProcessor<PostProcThree>(Order.After);
+        epDef.PostProcessor<PostProcFour>(Order.After);
+
+        epDef.PreProcessorList.Should().HaveCount(5);
+        epDef.PreProcessorList[0].Should().BeOfType<ProcOne>();
+        epDef.PreProcessorList[1].Should().BeOfType<ProcTwo>();
+        epDef.PreProcessorList[2].Should().BeOfType<ProcRequest>();
+        epDef.PreProcessorList[3].Should().BeOfType<ProcThree>();
+        epDef.PreProcessorList[4].Should().BeOfType<ProcFour>();
+        epDef.PostProcessorList.Should().HaveCount(5);
+        epDef.PostProcessorList[0].Should().BeOfType<PostProcOne>();
+        epDef.PostProcessorList[1].Should().BeOfType<PostProcTwo>();
+        epDef.PostProcessorList[2].Should().BeOfType<PostProcRequest>();
+        epDef.PostProcessorList[3].Should().BeOfType<PostProcThree>();
+        epDef.PostProcessorList[4].Should().BeOfType<PostProcFour>();
+    }
 }
 
 public class Foo : EndpointWithoutRequest
 {
-    public override void Configure() => Get(nameof(Foo));
-    public override async Task HandleAsync(CancellationToken ct) => await SendOkAsync(ct);
+    public override void Configure()
+        => Get(nameof(Foo));
+
+    public override async Task HandleAsync(CancellationToken ct)
+        => await SendOkAsync(ct);
 }
 
 public class Boo : EndpointWithoutRequest
 {
-    public override void Configure() => Get(nameof(Boo));
-    public override async Task HandleAsync(CancellationToken ct) => await SendOkAsync(ct);
+    public override void Configure()
+        => Get(nameof(Boo));
+
+    public override async Task HandleAsync(CancellationToken ct)
+        => await SendOkAsync(ct);
+}
+
+public class PreProcessorRegistration : EndpointWithoutRequest
+{
+    public override void Configure()
+    {
+        Get(nameof(PreProcessorRegistration));
+        PreProcessors(new ProcRequest());
+        PostProcessors(new PostProcRequest());
+    }
+}
+
+public class ProcOne : IGlobalPreProcessor
+{
+    public async Task PreProcessAsync(IPreProcessorContext context, CancellationToken ct)
+        => throw new NotImplementedException();
+}
+
+public class PostProcOne : IGlobalPostProcessor
+{
+    public async Task PostProcessAsync(IPostProcessorContext context, CancellationToken ct)
+        => throw new NotImplementedException();
+}
+
+public class ProcTwo : ProcOne { }
+
+public class PostProcTwo : PostProcOne { }
+
+public class ProcThree : ProcOne { }
+
+public class PostProcThree : PostProcOne { }
+
+public class ProcFour : ProcOne { }
+
+public class PostProcFour : PostProcOne { }
+
+public class ProcRequest : IPreProcessor<EmptyRequest>
+{
+    public async Task PreProcessAsync(IPreProcessorContext<EmptyRequest> context, CancellationToken ct)
+        => throw new NotImplementedException();
+}
+
+public class PostProcRequest : IPostProcessor<EmptyRequest, object?>
+{
+    public Task PostProcessAsync(IPostProcessorContext<EmptyRequest, object?> context, CancellationToken ct)
+        => throw new NotImplementedException();
 }

--- a/Tests/UnitTests/FastEndpoints/WebTests.cs
+++ b/Tests/UnitTests/FastEndpoints/WebTests.cs
@@ -1,5 +1,7 @@
+using System.Text.Json;
 using FakeItEasy;
 using FastEndpoints;
+using FluentValidation.Results;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
@@ -321,5 +323,25 @@ public class WebTests
         ep.ValidationFailures[1].PropertyName.Should().Be("NumbersList[0][1]");
         ep.ValidationFailures[2].PropertyName.Should().Be("NumbersList[1][0]");
         ep.ValidationFailures[3].PropertyName.Should().Be("NumbersList[1][1]");
+    }
+
+    [Fact]
+    public async Task problem_details_serialization_test()
+    {
+        var problemDetails = new ProblemDetails(
+            new List<ValidationFailure>
+            {
+                new("p1", "v1"),
+                new("p2", "v2")
+            },
+            "instance",
+            "trace",
+            400);
+
+        var json = JsonSerializer.Serialize(problemDetails);
+
+        var res = JsonSerializer.Deserialize<ProblemDetails>(json)!;
+
+        res.Should().BeEquivalentTo(problemDetails);
     }
 }

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -116,7 +116,7 @@ app.UseRequestLocalization(
            c.Endpoints.Filter = ep => ep.EndpointTags?.Contains("exclude") is not true;
            c.Endpoints.Configurator = ep =>
            {
-               ep.PreProcessors(Order.Before, new GlobalStatePreProcessor());
+               ep.PreProcessor<GlobalStatePreProcessor>(Order.Before);
                ep.PreProcessors(Order.Before, new AdminHeaderChecker());
                if (ep.EndpointTags?.Contains("orders") is true)
                    ep.Description(b => b.Produces<ErrorResponse>(400, "application/problem+json"));

--- a/Web/[Features]/Inventory/Manage/Create/Endpoint.cs
+++ b/Web/[Features]/Inventory/Manage/Create/Endpoint.cs
@@ -17,7 +17,7 @@ public class Endpoint : Endpoint<Request>
         ClaimsAll(
             Claim.AdminID,
             "test-claim");
-        Policy(b => b.RequireClaim(ClaimTypes.Role, Role.Admin));
+        Policy(b => b.RequireRole(Role.Admin));
         Description(
             x => x.Accepts<Request>("application/json")
                   .Produces(201)

--- a/Web/[Features]/Sales/Orders/Retrieve/Endpoint.cs
+++ b/Web/[Features]/Sales/Orders/Retrieve/Endpoint.cs
@@ -7,13 +7,11 @@ public class Endpoint : Endpoint<Request, Response>
     public override void Configure()
     {
         Get("/sales/orders/retrieve/{@id}", r => new { r.OrderID });
-        PreProcessors(new SecurityProcessor<Request>());
+        PreProcessor<SecurityProcessor<Request>>();
         AllowAnonymous();
         Tags("orders");
     }
 
     public override Task HandleAsync(Request r, CancellationToken c)
-    {
-        return SendAsync(Response);
-    }
+        => SendAsync(Response);
 }

--- a/Web/[Features]/TestCases/PostProcessorTest/Endpoint.cs
+++ b/Web/[Features]/TestCases/PostProcessorTest/Endpoint.cs
@@ -33,7 +33,7 @@ public class Endpoint : Endpoint<Request, ExceptionDetailsResponse>
     {
         Get("testcases/post-processor-handles-exception");
         AllowAnonymous();
-        PostProcessors(new Processor());
+        PostProcessor<Processor>();
     }
 
     public override Task HandleAsync(Request r, CancellationToken c)

--- a/Web/[Features]/TestCases/ProcessorStateTest/GlobalStatePreProcessor.cs
+++ b/Web/[Features]/TestCases/ProcessorStateTest/GlobalStatePreProcessor.cs
@@ -4,6 +4,11 @@ namespace TestCases.ProcessorStateTest;
 
 public class GlobalStatePreProcessor : GlobalPreProcessor<Thingy>
 {
+    public GlobalStatePreProcessor(ILogger<GlobalStatePreProcessor> logger)
+    {
+        logger.LogInformation("PP Injection works, and you should only see me once");
+    }
+    
     public override Task PreProcessAsync(IPreProcessorContext context, Thingy state, CancellationToken ct)
     {
         state.GlobalStateApplied = true;


### PR DESCRIPTION
Fixes #526 

This:
- Adds new overloads for the configuration of JWTBearerAuth, including the option to configure the whole `JWTBearerOptions`
- Sets sensible defaults for the JWTBearerAuth, specifically:
- - No longer maps inbound claims
- - Overrides the Role claim to `role` (`Conf.SecOpts.RoleClaimType`)
- - Overrides the Name claim to `name` (`Conf.SecOpts.NameClaimType`)
- Adds new security options (`Conf.SecOpts`) for the Role and Name claim so that it can be customised back to the crazy SOAP ones by doing `Conf.SecOpts.RoleClaimType = ClaimTypes.Role` for example
- `JWTBearer.CreateToken` is using the `Conf.SecOpts.RoleClaimType`

All of the above allows for smaller tokens to be generated and consumed, without unexpected behaviour, whilst still being fully customisable.

Note that, due to the change in the claim role type this is a "breaking change", though the impact should be minimal and will only affect older tokens.