### PR TITLE
Processors registered as singletons & ordered

### DIFF
--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
 
-        <Version>5.19.0.7-beta</Version>
+        <Version>5.19.0.8-beta</Version>
 
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>

--- a/Src/Library/Endpoint/Auxiliary/HitCounter.cs
+++ b/Src/Library/Endpoint/Auxiliary/HitCounter.cs
@@ -19,11 +19,7 @@ sealed class HitCounter
     }
 
     internal bool LimitReached(string headerValue)
-    {
-        return _clients.GetOrAdd(
-            headerValue,
-            hVal => new(_durationSeconds, hVal, _limit, ref _clients)).LimitReached();
-    }
+        => _clients.GetOrAdd(headerValue, new Counter(_durationSeconds, headerValue, _limit, ref _clients)).LimitReached();
 
     sealed class Counter : IDisposable
     {

--- a/Src/Library/Endpoint/Factory/EndpointFactory.cs
+++ b/Src/Library/Endpoint/Factory/EndpointFactory.cs
@@ -20,9 +20,10 @@ public sealed class EndpointFactory : IEndpointFactory
 
         var epInstance = (BaseEndpoint)Conf.ServiceResolver.CreateInstance(definition.EndpointType, ctx.RequestServices);
 
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
         var isAppStartup = ctx.Connection.Id == null;
 
-        for (var i = 0; i < definition.ServiceBoundEpProps?.Length; i++)
+        for (var i = 0; i < definition.ServiceBoundEpProps.Length; i++)
         {
             var prop = definition.ServiceBoundEpProps[i];
             prop.PropSetter ??= definition.EndpointType.SetterForProp(prop.PropName);

--- a/Src/Library/ServiceResolver/IServiceResolver.cs
+++ b/Src/Library/ServiceResolver/IServiceResolver.cs
@@ -54,8 +54,8 @@ public interface IServiceResolverBase
 public interface IServiceResolver : IServiceResolverBase
 {
     /// <summary>
-    /// create an instance of a given type (which may not be registered in the DI container). this method will be called repeatedly per request. so a cached
-    /// delegate/compiled expression such as <see cref="ActivatorUtilities.CreateFactory(Type, Type[])" /> should be used for instance creation.
+    /// create an instance of a given type (which may not be registered in the DI container). this method will be called repeatedly. so a cached
+    /// delegate/compiled expression using something like <see cref="ActivatorUtilities.CreateFactory(Type, Type[])" /> should be used for instance creation.
     /// </summary>
     /// <param name="type">the type to create an instance of</param>
     /// <param name="serviceProvider">optional service provider</param>
@@ -63,7 +63,8 @@ public interface IServiceResolver : IServiceResolverBase
 
     /// <summary>
     /// create an instance of a given type (which may not be registered in the DI container) which will be used as a singleton. a utility such as
-    /// <see cref="ActivatorUtilities.CreateInstance(IServiceProvider, Type, object[])" /> may be used.
+    /// <see cref="ActivatorUtilities.CreateInstance(IServiceProvider, Type, object[])" /> may be used. repeated calls with the same input type should return the same singleton
+    /// instance by utilizing an internal concurrent/thread-safe cache.
     /// </summary>
     /// <param name="type">the type to create an instance of</param>
     object CreateSingleton(Type type);

--- a/Src/Library/ServiceResolver/ServiceResolver.cs
+++ b/Src/Library/ServiceResolver/ServiceResolver.cs
@@ -25,13 +25,13 @@ sealed class ServiceResolver : IServiceResolver
 
     public object CreateInstance(Type type, IServiceProvider? serviceProvider = null)
     {
-        var factory = _factoryCache.GetOrAdd(type, t => ActivatorUtilities.CreateFactory(t, Type.EmptyTypes));
+        var factory = _factoryCache.GetOrAdd(type, ActivatorUtilities.CreateFactory(type, Type.EmptyTypes));
 
         return factory(serviceProvider ?? _ctxAccessor?.HttpContext?.RequestServices ?? _rootServiceProvider, null);
     }
 
     public object CreateSingleton(Type type)
-        => _singletonCache.GetOrAdd(type, t => ActivatorUtilities.GetServiceOrCreateInstance(_rootServiceProvider, t));
+        => _singletonCache.GetOrAdd(type, ActivatorUtilities.GetServiceOrCreateInstance(_rootServiceProvider, type));
 
     public IServiceScope CreateScope()
         => _isUnitTestMode

--- a/Src/Library/ServiceResolver/ServiceResolver.cs
+++ b/Src/Library/ServiceResolver/ServiceResolver.cs
@@ -7,6 +7,7 @@ namespace FastEndpoints;
 sealed class ServiceResolver : IServiceResolver
 {
     readonly ConcurrentDictionary<Type, ObjectFactory> _factoryCache = new();
+    readonly ConcurrentDictionary<Type, object> _singletonCache = new();
     readonly IServiceProvider _rootServiceProvider;
     readonly IHttpContextAccessor _ctxAccessor;
 
@@ -30,7 +31,7 @@ sealed class ServiceResolver : IServiceResolver
     }
 
     public object CreateSingleton(Type type)
-        => ActivatorUtilities.CreateInstance(_rootServiceProvider, type);
+        => _singletonCache.GetOrAdd(type, t => ActivatorUtilities.GetServiceOrCreateInstance(_rootServiceProvider, t));
 
     public IServiceScope CreateScope()
         => _isUnitTestMode

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -16,6 +16,12 @@ todo: write description
 
 </details>
 
+<details><summary>Simpler way to register Pre/Post Processors with DI support</summary>
+
+ref: https://github.com/FastEndpoints/FastEndpoints/pull/528
+
+</details>
+
 <details><summary>Exception handling capability for Post-Processors</summary>
 
 todo: update doc page and link here

--- a/Tests/UnitTests/FastEndpoints/EndpointDataTests.cs
+++ b/Tests/UnitTests/FastEndpoints/EndpointDataTests.cs
@@ -1,4 +1,7 @@
 ﻿using FastEndpoints;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
 
 namespace EPData;
@@ -26,6 +29,108 @@ public class EndpointDataTests
         sut.Found[0].Routes.Should().HaveCount(1);
         sut?.Found[0]?.Routes?[0].Should().BeEquivalentTo(typename);
     }
+
+    EndpointDefinition WireupProcessorEndpoint()
+    {
+        var services = new ServiceCollection();
+        services.AddHttpContextAccessor();
+        services.TryAddSingleton<IServiceResolver, ServiceResolver>();
+        services.TryAddSingleton<IEndpointFactory, EndpointFactory>();
+        var sp = services.BuildServiceProvider();
+        Config.ServiceResolver = sp.GetRequiredService<IServiceResolver>();
+        var epFactory = sp.GetRequiredService<IEndpointFactory>();
+        using var scope = sp.CreateScope();
+        var httpCtx = new DefaultHttpContext { RequestServices = scope.ServiceProvider };
+        var epDef = new EndpointDefinition(typeof(PreProcessorRegistration), typeof(EmptyRequest), typeof(EmptyResponse));
+        var baseEp = epFactory.Create(epDef, httpCtx);
+        epDef.ImplementsConfigure = true; // Override as there's no EndpointData resolver
+        epDef.Initialize(baseEp, httpCtx);
+
+        return epDef;
+    }
+    
+    [Fact]
+    public void BaselineProcessorOrder()
+    {
+        var epDef = WireupProcessorEndpoint();
+
+        // Simulate global definition
+        epDef.PreProcessors(Order.Before, new ProcOne(), new ProcTwo());
+        epDef.PreProcessors(Order.After, new ProcThree(), new ProcFour());
+        epDef.PostProcessors(Order.Before, new PostProcOne(), new PostProcTwo());
+        epDef.PostProcessors(Order.After, new PostProcThree(), new PostProcFour());
+
+        epDef.PreProcessorList.Should().HaveCount(5);
+        epDef.PreProcessorList[0].Should().BeOfType<ProcOne>();
+        epDef.PreProcessorList[1].Should().BeOfType<ProcTwo>();
+        epDef.PreProcessorList[2].Should().BeOfType<ProcRequest>();
+        epDef.PreProcessorList[3].Should().BeOfType<ProcThree>();
+        epDef.PreProcessorList[4].Should().BeOfType<ProcFour>();
+
+        epDef.PostProcessorList.Should().HaveCount(5);
+        epDef.PostProcessorList[0].Should().BeOfType<PostProcOne>();
+        epDef.PostProcessorList[1].Should().BeOfType<PostProcTwo>();
+        epDef.PostProcessorList[2].Should().BeOfType<PostProcRequest>();
+        epDef.PostProcessorList[3].Should().BeOfType<PostProcThree>();
+        epDef.PostProcessorList[4].Should().BeOfType<PostProcFour>();
+    }
+
+    [Fact]
+    public void MultiCallProcessorOrder()
+    {
+        var epDef = WireupProcessorEndpoint();
+
+        // Simulate global definition
+        epDef.PreProcessors(Order.Before, new ProcOne());
+        epDef.PreProcessors(Order.Before, new ProcTwo());
+        epDef.PreProcessors(Order.After, new ProcThree());
+        epDef.PreProcessors(Order.After, new ProcFour());
+        epDef.PostProcessors(Order.Before, new PostProcOne());
+        epDef.PostProcessors(Order.Before, new PostProcTwo());
+        epDef.PostProcessors(Order.After, new PostProcThree());
+        epDef.PostProcessors(Order.After, new PostProcFour());
+
+        epDef.PreProcessorList.Should().HaveCount(5);
+        epDef.PreProcessorList[0].Should().BeOfType<ProcOne>();
+        epDef.PreProcessorList[1].Should().BeOfType<ProcTwo>();
+        epDef.PreProcessorList[2].Should().BeOfType<ProcRequest>();
+        epDef.PreProcessorList[3].Should().BeOfType<ProcThree>();
+        epDef.PreProcessorList[4].Should().BeOfType<ProcFour>();
+        epDef.PostProcessorList.Should().HaveCount(5);
+        epDef.PostProcessorList[0].Should().BeOfType<PostProcOne>();
+        epDef.PostProcessorList[1].Should().BeOfType<PostProcTwo>();
+        epDef.PostProcessorList[2].Should().BeOfType<PostProcRequest>();
+        epDef.PostProcessorList[3].Should().BeOfType<PostProcThree>();
+        epDef.PostProcessorList[4].Should().BeOfType<PostProcFour>();
+    }
+
+    [Fact]
+    public void ServiceResolvedProcessorOrder()
+    {
+        var epDef = WireupProcessorEndpoint();
+        // Simulate global definition
+        epDef.PreProcessor<ProcOne>(Order.Before);
+        epDef.PreProcessor<ProcTwo>(Order.Before);
+        epDef.PreProcessor<ProcThree>(Order.After);
+        epDef.PreProcessor<ProcFour>(Order.After);
+        epDef.PostProcessor<PostProcOne>(Order.Before);
+        epDef.PostProcessor<PostProcTwo>(Order.Before);
+        epDef.PostProcessor<PostProcThree>(Order.After);
+        epDef.PostProcessor<PostProcFour>(Order.After);
+
+        epDef.PreProcessorList.Should().HaveCount(5);
+        epDef.PreProcessorList[0].Should().BeOfType<ProcOne>();
+        epDef.PreProcessorList[1].Should().BeOfType<ProcTwo>();
+        epDef.PreProcessorList[2].Should().BeOfType<ProcRequest>();
+        epDef.PreProcessorList[3].Should().BeOfType<ProcThree>();
+        epDef.PreProcessorList[4].Should().BeOfType<ProcFour>();
+        epDef.PostProcessorList.Should().HaveCount(5);
+        epDef.PostProcessorList[0].Should().BeOfType<PostProcOne>();
+        epDef.PostProcessorList[1].Should().BeOfType<PostProcTwo>();
+        epDef.PostProcessorList[2].Should().BeOfType<PostProcRequest>();
+        epDef.PostProcessorList[3].Should().BeOfType<PostProcThree>();
+        epDef.PostProcessorList[4].Should().BeOfType<PostProcFour>();
+    }
 }
 
 public class Foo : EndpointWithoutRequest
@@ -38,4 +143,50 @@ public class Boo : EndpointWithoutRequest
 {
     public override void Configure() => Get(nameof(Boo));
     public override async Task HandleAsync(CancellationToken ct) => await SendOkAsync(ct);
+}
+
+public class PreProcessorRegistration : EndpointWithoutRequest
+{
+    public override void Configure()
+    {
+        Get(nameof(PreProcessorRegistration));
+        PreProcessors(new ProcRequest());
+        PostProcessors(new PostProcRequest());
+    }
+}
+
+public class ProcOne : IGlobalPreProcessor
+{
+    public async Task PreProcessAsync(IPreProcessorContext context, CancellationToken ct)
+        => throw new NotImplementedException();
+}
+
+public class PostProcOne : IGlobalPostProcessor
+{
+    public async Task PostProcessAsync(IPostProcessorContext context, CancellationToken ct)
+        => throw new NotImplementedException();
+}
+
+public class ProcTwo : ProcOne { }
+
+public class PostProcTwo : PostProcOne { }
+
+public class ProcThree : ProcOne { }
+
+public class PostProcThree : PostProcOne { }
+
+public class ProcFour : ProcOne { }
+
+public class PostProcFour : PostProcOne { }
+
+public class ProcRequest : IPreProcessor<EmptyRequest>
+{
+    public async Task PreProcessAsync(IPreProcessorContext<EmptyRequest> context, CancellationToken ct)
+        => throw new NotImplementedException();
+}
+
+public class PostProcRequest : IPostProcessor<EmptyRequest, object?>
+{
+    public Task PostProcessAsync(IPostProcessorContext<EmptyRequest, object?> context, CancellationToken ct)
+        => throw new NotImplementedException();
 }

--- a/Tests/UnitTests/FastEndpoints/EndpointDataTests.cs
+++ b/Tests/UnitTests/FastEndpoints/EndpointDataTests.cs
@@ -30,7 +30,7 @@ public class EndpointDataTests
         sut?.Found[0]?.Routes?[0].Should().BeEquivalentTo(typename);
     }
 
-    EndpointDefinition WireupProcessorEndpoint()
+    static EndpointDefinition WireUpProcessorEndpoint()
     {
         var services = new ServiceCollection();
         services.AddHttpContextAccessor();
@@ -48,11 +48,11 @@ public class EndpointDataTests
 
         return epDef;
     }
-    
+
     [Fact]
     public void BaselineProcessorOrder()
     {
-        var epDef = WireupProcessorEndpoint();
+        var epDef = WireUpProcessorEndpoint();
 
         // Simulate global definition
         epDef.PreProcessors(Order.Before, new ProcOne(), new ProcTwo());
@@ -78,7 +78,7 @@ public class EndpointDataTests
     [Fact]
     public void MultiCallProcessorOrder()
     {
-        var epDef = WireupProcessorEndpoint();
+        var epDef = WireUpProcessorEndpoint();
 
         // Simulate global definition
         epDef.PreProcessors(Order.Before, new ProcOne());
@@ -107,7 +107,8 @@ public class EndpointDataTests
     [Fact]
     public void ServiceResolvedProcessorOrder()
     {
-        var epDef = WireupProcessorEndpoint();
+        var epDef = WireUpProcessorEndpoint();
+
         // Simulate global definition
         epDef.PreProcessor<ProcOne>(Order.Before);
         epDef.PreProcessor<ProcTwo>(Order.Before);
@@ -135,14 +136,20 @@ public class EndpointDataTests
 
 public class Foo : EndpointWithoutRequest
 {
-    public override void Configure() => Get(nameof(Foo));
-    public override async Task HandleAsync(CancellationToken ct) => await SendOkAsync(ct);
+    public override void Configure()
+        => Get(nameof(Foo));
+
+    public override async Task HandleAsync(CancellationToken ct)
+        => await SendOkAsync(ct);
 }
 
 public class Boo : EndpointWithoutRequest
 {
-    public override void Configure() => Get(nameof(Boo));
-    public override async Task HandleAsync(CancellationToken ct) => await SendOkAsync(ct);
+    public override void Configure()
+        => Get(nameof(Boo));
+
+    public override async Task HandleAsync(CancellationToken ct)
+        => await SendOkAsync(ct);
 }
 
 public class PreProcessorRegistration : EndpointWithoutRequest

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -116,7 +116,7 @@ app.UseRequestLocalization(
            c.Endpoints.Filter = ep => ep.EndpointTags?.Contains("exclude") is not true;
            c.Endpoints.Configurator = ep =>
            {
-               ep.PreProcessors(Order.Before, new GlobalStatePreProcessor());
+               ep.PreProcessor<GlobalStatePreProcessor>(Order.Before);
                ep.PreProcessors(Order.Before, new AdminHeaderChecker());
                if (ep.EndpointTags?.Contains("orders") is true)
                    ep.Description(b => b.Produces<ErrorResponse>(400, "application/problem+json"));

--- a/Web/[Features]/TestCases/ProcessorStateTest/GlobalStatePreProcessor.cs
+++ b/Web/[Features]/TestCases/ProcessorStateTest/GlobalStatePreProcessor.cs
@@ -4,6 +4,11 @@ namespace TestCases.ProcessorStateTest;
 
 public class GlobalStatePreProcessor : GlobalPreProcessor<Thingy>
 {
+    public GlobalStatePreProcessor(ILogger<GlobalStatePreProcessor> logger)
+    {
+        logger.LogInformation("PP Injection works, and you should only see me once");
+    }
+    
     public override Task PreProcessAsync(IPreProcessorContext context, Thingy state, CancellationToken ct)
     {
         state.GlobalStateApplied = true;


### PR DESCRIPTION
This:
- Changes the `IServiceResolved.AddSingleton` to actually register the object as a singleton
- Adds `.AddPre/PostProcessor<TProcessor>()`
- Adds guaranteed ordering (based on calls made) to the global pre/post processor registration
- Adds tests for the registration of, and ordering of processors
- Adds a logger to the `GlobalStatePreProcessor` test processor to test service injection and guarantee of single creation on startup