### PR TITLE
Added DelayDuration property for scheduled job checks with default delay of 60 seconds.

### DIFF
--- a/Src/Library/Messaging/Jobs/JobQueue.cs
+++ b/Src/Library/Messaging/Jobs/JobQueue.cs
@@ -1,4 +1,4 @@
-﻿using FastEndpoints.Messaging.Jobs;
+using FastEndpoints.Messaging.Jobs;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
@@ -15,6 +15,7 @@ abstract class JobQueueBase
 
     protected abstract Task StoreJobAsync(ICommand command, DateTime? executeAfter, DateTime? expireOn, CancellationToken ct);
 
+    internal abstract void SetDelayDuration(TimeSpan delayDuration);
     internal abstract void SetExecutionLimits(int concurrencyLimit, TimeSpan executionTimeLimit);
 
     internal static Task AddToQueueAsync(ICommand command, DateTime? executeAfter, DateTime? expireOn, CancellationToken ct)
@@ -46,6 +47,7 @@ sealed class JobQueue<TCommand, TStorageRecord, TStorageProvider> : JobQueueBase
     readonly SemaphoreSlim _sem = new(0);
     readonly ILogger _log;
     TimeSpan _executionTimeLimit = Timeout.InfiniteTimeSpan;
+    TimeSpan _delayDuration = TimeSpan.FromSeconds(60);
     bool _isInUse;
 
     public JobQueue(TStorageProvider storageProvider,
@@ -67,7 +69,10 @@ sealed class JobQueue<TCommand, TStorageRecord, TStorageProvider> : JobQueueBase
         _executionTimeLimit = executionTimeLimit;
         _ = CommandExecutorTask();
     }
-
+    internal override void SetDelayDuration(TimeSpan delayDuration)
+    {
+        _delayDuration = delayDuration;
+    }
     protected override async Task StoreJobAsync(ICommand command, DateTime? executeAfter, DateTime? expireOn, CancellationToken ct)
     {
         _isInUse = true;
@@ -116,17 +121,18 @@ sealed class JobQueue<TCommand, TStorageRecord, TStorageProvider> : JobQueueBase
 
             if (!records.Any())
             {
-                // if _isInUse is false, a job has never been queued and there's no need for another iteration of the while loop -
-                // until the semaphore is released when the first job is queued.
-                // if _isInUse if true, we need to block until the next job is queued or until 1 min has elapsed.
-                // we need to re-check the storage every minute to see if the user has re-scheduled old jobs while there's no new jobs being queued.
-                // without the 1 minute check, rescheduled jobs will only execute when there's a new job being queued.
-                // which could lead to the rescheduled job being already expired by the time it's executed.
+                // If _isInUse is false, it signifies that no job has been queued yet.
+                // Therefore, there is no necessity for further iterations within the loop until the semaphore is released upon queuing the first job.
+
+                // If _isInUse is true, it indicates that we must await the queuing of the next job or the passage of delay duration (default: 1 minute), whichever comes first.
+                // We must periodically reevaluate the storage status every minute to ascertain if the user has rescheduled any previous jobs while no new jobs are being queued.
+                // Failure to conduct this periodic check could result in rescheduled jobs only executing upon the arrival of new jobs, potentially leading to expired job executions.
+
                 await (
                           _isInUse
 
                               // ReSharper disable once MethodSupportsCancellation
-                              ? Task.WhenAny(_sem.WaitAsync(_appCancellation), Task.Delay(60000))
+                              ? Task.WhenAny(_sem.WaitAsync(_appCancellation), Task.Delay(_delayDuration))
                               : Task.WhenAny(_sem.WaitAsync(_appCancellation)));
             }
             else
@@ -156,11 +162,11 @@ sealed class JobQueue<TCommand, TStorageRecord, TStorageProvider> : JobQueueBase
                     {
                         _log.StorageOnExecutionFailureError(QueueID, _tCommandName, xx.Message);
 
-                    #pragma warning disable CA2016
+#pragma warning disable CA2016
 
                         //ReSharper disable once MethodSupportsCancellation
                         await Task.Delay(5000);
-                    #pragma warning restore CA2016
+#pragma warning restore CA2016
                     }
                 }
 
@@ -180,11 +186,11 @@ sealed class JobQueue<TCommand, TStorageRecord, TStorageProvider> : JobQueueBase
                 {
                     _log.StorageMarkAsCompleteError(QueueID, _tCommandName, x.Message);
 
-                #pragma warning disable CA2016
+#pragma warning disable CA2016
 
                     // ReSharper disable once MethodSupportsCancellation
                     await Task.Delay(5000);
-                #pragma warning restore CA2016
+#pragma warning restore CA2016
                 }
             }
         }

--- a/Src/Library/Messaging/Jobs/JobQueueExtensions.cs
+++ b/Src/Library/Messaging/Jobs/JobQueueExtensions.cs
@@ -54,8 +54,7 @@ public static class JobQueueExtensions
 
             var tJobQ = Types.JobQueueOf3.MakeGenericType(tCommand, _tStorageRecord, _tStorageProvider);
             var jobQ = app.ApplicationServices.GetRequiredService(tJobQ);
-            opts.SetDelayDuration((JobQueueBase)jobQ);
-            opts.SetExecutionLimits(tCommand, (JobQueueBase)jobQ);
+            opts.SetLimits(tCommand, (JobQueueBase)jobQ);
         }
 
         return app;

--- a/Src/Library/Messaging/Jobs/JobQueueExtensions.cs
+++ b/Src/Library/Messaging/Jobs/JobQueueExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace FastEndpoints;
@@ -54,6 +54,7 @@ public static class JobQueueExtensions
 
             var tJobQ = Types.JobQueueOf3.MakeGenericType(tCommand, _tStorageRecord, _tStorageProvider);
             var jobQ = app.ApplicationServices.GetRequiredService(tJobQ);
+            opts.SetDelayDuration((JobQueueBase)jobQ);
             opts.SetExecutionLimits(tCommand, (JobQueueBase)jobQ);
         }
 

--- a/Src/Library/Messaging/Jobs/JobQueueOptions.cs
+++ b/Src/Library/Messaging/Jobs/JobQueueOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace FastEndpoints;
+namespace FastEndpoints;
 
 /// <summary>
 /// options for job queues
@@ -14,6 +14,13 @@ public class JobQueueOptions
     /// you can specify per queue type overrides using <see cref="LimitsFor{TCommand}(int, TimeSpan)" />
     /// </summary>
     public int MaxConcurrency { get; set; } = Environment.ProcessorCount;
+
+    /// <summary>
+    /// Specifies the interval for periodic re-checks of the storage to detect any scheduled jobs.
+    /// These checks ensure that scheduled jobs are promptly executed, preventing potential expiration issues.
+    /// The default interval is set to 60 seconds.
+    /// </summary>
+    public TimeSpan DelayDuration { get; set; } = TimeSpan.FromSeconds(60);
 
     /// <summary>
     /// the per job type max execution time limit for handler executions unless otherwise overridden using <see cref="LimitsFor{TCommand}(int, TimeSpan)" />
@@ -36,7 +43,10 @@ public class JobQueueOptions
     {
         _limitOverrides[typeof(TCommand)] = new(maxConcurrency, timeLimit);
     }
-
+    internal void SetDelayDuration(JobQueueBase jobQueue)
+    {
+        jobQueue.SetDelayDuration(DelayDuration);
+    }
     internal void SetExecutionLimits(Type tCommand, JobQueueBase jobQueue)
     {
         if (_limitOverrides.TryGetValue(tCommand, out var limits))

--- a/Src/Library/Messaging/Jobs/JobQueueOptions.cs
+++ b/Src/Library/Messaging/Jobs/JobQueueOptions.cs
@@ -16,11 +16,11 @@ public class JobQueueOptions
     public int MaxConcurrency { get; set; } = Environment.ProcessorCount;
 
     /// <summary>
-    /// Specifies the interval for periodic re-checks of the storage to detect any scheduled jobs.
-    /// These checks ensure that scheduled jobs are promptly executed, preventing potential expiration issues.
-    /// The default interval is set to 60 seconds.
+    /// specifies the interval for periodic re-checks of the storage to detect any scheduled jobs. these checks ensure that re-scheduled jobs are promptly executed.
+    /// the default interval is set to 60 seconds. a shorter delay will make re-scheduled jobs run faster but will increase the overall load on the storage system,
+    /// due to too frequent queries being issued. only reduce this delay if you need re-scheduled jobs re-execute faster.
     /// </summary>
-    public TimeSpan DelayDuration { get; set; } = TimeSpan.FromSeconds(60);
+    public TimeSpan StorageProbeDelay { get; set; } = TimeSpan.FromSeconds(60);
 
     /// <summary>
     /// the per job type max execution time limit for handler executions unless otherwise overridden using <see cref="LimitsFor{TCommand}(int, TimeSpan)" />
@@ -43,15 +43,12 @@ public class JobQueueOptions
     {
         _limitOverrides[typeof(TCommand)] = new(maxConcurrency, timeLimit);
     }
-    internal void SetDelayDuration(JobQueueBase jobQueue)
-    {
-        jobQueue.SetDelayDuration(DelayDuration);
-    }
-    internal void SetExecutionLimits(Type tCommand, JobQueueBase jobQueue)
+
+    internal void SetLimits(Type tCommand, JobQueueBase jobQueue)
     {
         if (_limitOverrides.TryGetValue(tCommand, out var limits))
-            jobQueue.SetExecutionLimits(limits.concurrency, limits.timeLimit);
+            jobQueue.SetLimits(limits.concurrency, limits.timeLimit, StorageProbeDelay);
         else
-            jobQueue.SetExecutionLimits(MaxConcurrency, ExecutionTimeLimit);
+            jobQueue.SetLimits(MaxConcurrency, ExecutionTimeLimit, StorageProbeDelay);
     }
 }

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -52,6 +52,20 @@ AdminDashboard
 
 </details>
 
+<details><summary>Ability to customize job queue storage provider re-check frequency</summary>
+
+You can now customize the job queue storage provider re-check time delay in case you need re-scheduled jobs to execute quicker.
+
+```csharp
+app.UseJobQueues( 
+    o => 
+    { 
+        o.StorageProbeDelay = TimeSpan.FromSeconds(5); 
+    });
+```
+
+</details>
+
 ## Fixes 🪲
 
 <details><summary>Swagger UI displaying random text for email fields</summary>

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -166,6 +166,7 @@ app.UseJobQueues(
     {
         o.MaxConcurrency = 4;
         o.LimitsFor<JobTestCommand>(1, TimeSpan.FromSeconds(1));
+        o.DelayDuration = TimeSpan.FromSeconds(3);
     });
 
 var isTestHost = app.Services.CreateScope().ServiceProvider.GetService<IEmailService>() is not EmailService;

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -166,7 +166,7 @@ app.UseJobQueues(
     {
         o.MaxConcurrency = 4;
         o.LimitsFor<JobTestCommand>(1, TimeSpan.FromSeconds(1));
-        o.DelayDuration = TimeSpan.FromSeconds(3);
+        o.StorageProbeDelay = TimeSpan.FromSeconds(5);
     });
 
 var isTestHost = app.Services.CreateScope().ServiceProvider.GetService<IEmailService>() is not EmailService;


### PR DESCRIPTION
Implemented DelayDuration property for scheduled job checks

- Added DelayDuration property with a default delay of 60 seconds to regulate the loop for checking scheduled items.
- Included summary documentation to clarify the purpose and usage of DelayDuration.