### PR TITLE
Pass handled exceptions to logger

### DIFF
--- a/Src/Library/Extensions/ExceptionHandlerExtensions.cs
+++ b/Src/Library/Extensions/ExceptionHandlerExtensions.cs
@@ -49,13 +49,13 @@ public static class ExceptionHandlerExtensions
                             else
                             {
                                 logger.LogError(
+                                    exHandlerFeature.Error,
                                     $"""
                                      =================================
                                      {route}
                                      TYPE: {exceptionType}
                                      REASON: {reason}
                                      ---------------------------------
-                                     {exHandlerFeature.Error.StackTrace}
                                      """);
                             }
 

--- a/Src/Library/Extensions/ExceptionHandlerExtensions.cs
+++ b/Src/Library/Extensions/ExceptionHandlerExtensions.cs
@@ -45,17 +45,18 @@ public static class ExceptionHandlerExtensions
                             var reason = exHandlerFeature.Error.Message;
 
                             if (logStructuredException)
-                                logger.LogError("{@route}{@exceptionType}{@reason}{@exception}", route, exceptionType, reason, exHandlerFeature.Error);
+                                logger.LogError(exHandlerFeature.Error, "[{@exceptionType}] at [{@route}] due to [{@reason}]", exceptionType, route, reason);
                             else
                             {
+                                //this branch is only meant for unstructured textual logging
                                 logger.LogError(
-                                    exHandlerFeature.Error,
                                     $"""
                                      =================================
                                      {route}
                                      TYPE: {exceptionType}
                                      REASON: {reason}
                                      ---------------------------------
+                                     {exHandlerFeature.Error.StackTrace}
                                      """);
                             }
 


### PR DESCRIPTION
Exceptions handled in `ExceptionHandlerExtensions` are not currently passed to `ILogger.LogError()`. This is required for logger providers to correctly extract structured data.

#105 tried to fix this in the wrong way IMO. The PR mentions [Serilog.Exceptions](https://github.com/RehanSaeed/Serilog.Exceptions?tab=readme-ov-file#what-does-it-do) which shows passing an exception to the logger in its first example.

The default console logger prints the exception after the message, which is very similar to the current output:

```diff
 =================================
 HTTP: GET /api/things
 TYPE: MyException
 REASON: My exception message.
 ---------------------------------
+MyException: My exception message.
    at ...
    at ...
```