### PR TITLE
fix test failure when running on non-us locale

### DIFF
--- a/Tests/IntegrationTests/FastEndpoints/WebTests/CustomersTests.cs
+++ b/Tests/IntegrationTests/FastEndpoints/WebTests/CustomersTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+using System.Globalization;
+using System.Net;
 using Create = Customers.Create;
 using List = Customers.List;
 using Orders = Sales.Orders;
@@ -92,7 +93,7 @@ public class CustomersTests(AppFixture App) : TestBase<AppFixture>
         res.Header1.Should().Be(0);
         res.Header2.Should().Be(default);
         rsp.Headers.GetValues("x-header-one").Single().Should().Be("12345");
-        rsp.Headers.GetValues("Header2").Single().Should().Be(new DateOnly(2020, 11, 12).ToString());
+        rsp.Headers.GetValues("Header2").Single().Should().Be(new DateOnly(2020, 11, 12).ToString(CultureInfo.InvariantCulture));
     }
 
     [Fact]


### PR DESCRIPTION
my os has a non-us locale and this test fails with an error

`Expected rsp.Headers.GetValues("Header2").Single() to be "12.11.2020", but "11/12/2020" differs near "1/1" (index 1).`

Fixed by using invariant culture for comparison.