### PR TITLE
fix test failing on some locales

### DIFF
--- a/Tests/IntegrationTests/FastEndpoints/WebTests/CustomersTests.cs
+++ b/Tests/IntegrationTests/FastEndpoints/WebTests/CustomersTests.cs
@@ -93,7 +93,7 @@ public class CustomersTests(AppFixture App) : TestBase<AppFixture>
         res.Header1.Should().Be(0);
         res.Header2.Should().Be(default);
         rsp.Headers.GetValues("x-header-one").Single().Should().Be("12345");
-        DateOnly.Parse(rsp.Headers.GetValues("Header2").Single()).Should().Be(new(2020, 11, 12));
+        DateOnly.Parse(rsp.Headers.GetValues("Header2").Single(), CultureInfo.InvariantCulture).Should().Be(new(2020, 11, 12));
     }
 
     [Fact]


### PR DESCRIPTION
after a recent test change it started failing for me again due to locale issues. 