### PR TITLE
Added so we can set the signing algoritm for the refresh token service

### DIFF
--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -136,3 +136,32 @@ s.RequestExamples.Add(new(new MyRequest { ... })); // wrapped in a RequestExampl
 Previously the `PreSetupAsync()` virtual method was run per each test-class instantiation. That behavior does not make much sense as the WAF instance is created and cached just once per test run. The new behavior is more in line with other virtual methods such as `ConfigureApp()` & `ConfigureServices()` that they are only ever run once for the sake of creation of the WAF. This change will only affect you if you've been creating some state such as a `TestContainer` instance in `PreSetupAsync` and later on disposing that container in `TearDownAsync()`. From now on you should not be disposing the container yourself if your derived `AppFixture` class is being used by more than one test-class. See [this gist](https://gist.github.com/dj-nitehawk/04a78cea10f2239eb81c958c52ec84e0) to get a better understanding.
 
 </details>
+
+<details><summary>Consolidate Jwt key signing algorithm properties into one</summary>
+
+`JwtCreationOptions` class had two different properties to specify `SymmetricKeyAlgorithm` as well as `AsymmetricKeyAlgorithm`, which has now been consolidated into a single property called `SigningAlgorithm`.
+
+Before:
+
+```csharp
+var token = JwtBearer.CreateToken(
+    o =>
+    {
+        o.SymmetricKeyAlgorithm = SecurityAlgorithms.HmacSha256Signature;
+        //or
+        o.AsymmetricKeyAlgorithm = SecurityAlgorithms.RsaSha256;
+    });
+```
+
+After:
+
+```csharp
+var token = JwtBearer.CreateToken(
+    o =>
+    {
+        o.SigningStyle = TokenSigningStyle.Symmetric;
+        o.SigningAlgorithm = SecurityAlgorithms.HmacSha256Signature;
+    });
+```
+
+</details>

--- a/Src/Security/JWTBearer.cs
+++ b/Src/Security/JWTBearer.cs
@@ -1,9 +1,10 @@
-using Microsoft.IdentityModel.Tokens;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.IdentityModel.Tokens;
 #if NET8_0_OR_GREATER
 using Microsoft.IdentityModel.JsonWebTokens;
+
 #else
 using System.IdentityModel.Tokens.Jwt;
 #endif
@@ -72,10 +73,10 @@ public static class JwtBearer
                 else
                     rsa.ImportRSAPrivateKey(Convert.FromBase64String(opts.SigningKey), out _);
 
-                return new(new RsaSecurityKey(rsa), opts.AsymmetricKeyAlgorithm);
+                return new(new RsaSecurityKey(rsa), opts.SigningAlgorithm);
             }
 
-            return new(new SymmetricSecurityKey(Encoding.ASCII.GetBytes(opts.SigningKey)), opts.SymmetricKeyAlgorithm);
+            return new(new SymmetricSecurityKey(Encoding.ASCII.GetBytes(opts.SigningKey)), opts.SigningAlgorithm);
         }
     }
 }

--- a/Src/Security/JwtCreationOptions.cs
+++ b/Src/Security/JwtCreationOptions.cs
@@ -19,26 +19,24 @@ public sealed class JwtCreationOptions
     public TokenSigningStyle SigningStyle { get; set; } = TokenSigningStyle.Symmetric;
 
     /// <summary>
+    /// security algo used to sign keys.
+    /// defaults to HmacSha256 for symmetric keys and RsaSha256 for asymmetric keys.
+    /// </summary>
+    public string SigningAlgorithm { get; set; }
+
+    /// <summary>
     /// specifies whether the key is pem encoded.
     /// </summary>
     public bool KeyIsPemEncoded { get; set; }
-
-    /// <summary>
-    /// security algo used to sign symmetric keys
-    /// </summary>
-    public string SymmetricKeyAlgorithm { get; set; } = SecurityAlgorithms.HmacSha256Signature;
-
-    /// <summary>
-    /// security algo used to sign asymmetric keys
-    /// </summary>
-    public string AsymmetricKeyAlgorithm { get; set; } = SecurityAlgorithms.RsaSha256;
 
     /// <summary>
     /// specify the privileges of the user
     /// </summary>
     public UserPrivileges User { get; } = new();
 
-    /// <summary>the value for the 'audience' claim.</summary>
+    /// <summary>
+    /// the value for the 'audience' claim.
+    /// </summary>
     public string? Audience { get; set; }
 
     /// <summary>
@@ -55,4 +53,11 @@ public sealed class JwtCreationOptions
     /// the compression algorithm  compressing the token payload.
     /// </summary>
     public string? CompressionAlgorithm { get; set; }
+
+    public JwtCreationOptions()
+    {
+        SigningAlgorithm = SigningStyle == TokenSigningStyle.Symmetric
+                               ? SecurityAlgorithms.HmacSha256Signature
+                               : SecurityAlgorithms.RsaSha256;
+    }
 }

--- a/Src/Security/RefreshTokens/RefreshServiceOptions.cs
+++ b/Src/Security/RefreshTokens/RefreshServiceOptions.cs
@@ -1,5 +1,9 @@
-﻿namespace FastEndpoints.Security;
+﻿using Microsoft.IdentityModel.Tokens;
 
+namespace FastEndpoints.Security;
+
+//this class could inherit from JwtCreationOptions, but we want the lingo to be different for the public api.
+//so we need to keep this class in sync manually with JwtCreationOptions and do mapping between the two in RefreshTokenService.CreateToken() method.
 public class RefreshServiceOptions
 {
     /// <summary>
@@ -13,6 +17,19 @@ public class RefreshServiceOptions
     /// </summary>
     [DontInject]
     public TokenSigningStyle TokenSigningStyle { internal get; set; } = TokenSigningStyle.Symmetric;
+
+    /// <summary>
+    /// security algo used to sign tokens.
+    /// defaults to HmacSha256 for symmetric keys and RsaSha256 for asymmetric keys.
+    /// </summary>
+    [DontInject]
+    public string TokenSigningAlgorithm { internal get; set; }
+
+    /// <summary>
+    /// specifies whether the key is pem encoded.
+    /// </summary>
+    [DontInject]
+    public bool SigningKeyIsPemEncoded { get; set; }
 
     /// <summary>
     /// specifies how long the access token should be valid for. default is 5 minutes.
@@ -37,19 +54,22 @@ public class RefreshServiceOptions
     /// </summary>
     [DontInject]
     public string? Audience { internal get; set; }
+
     /// <summary>
-    /// specifies the symmetric key algorithm to be used if signing style is symmetric
+    /// the compression algorithm  compressing the token payload.
     /// </summary>
     [DontInject]
-    public string? SymmetricKeyAlgorithm { internal get; set; }
-    /// <summary>
-    /// specifies the symmetric key algorithm to be used if signing style is asymmetric
-    /// </summary>
-    [DontInject]
-    public string? AsymmetricKeyAlgorithm { internal get; set; }
+    public string? TokenCompressionAlgorithm { get; set; }
 
     internal string RefreshRoute = "/api/refresh-token";
     internal Action<EndpointDefinition>? EpSettings;
+
+    public RefreshServiceOptions()
+    {
+        TokenSigningAlgorithm = TokenSigningStyle == TokenSigningStyle.Symmetric
+                                    ? SecurityAlgorithms.HmacSha256Signature
+                                    : SecurityAlgorithms.RsaSha256;
+    }
 
     /// <summary>
     /// endpoint configuration action

--- a/Src/Security/RefreshTokens/RefreshServiceOptions.cs
+++ b/Src/Security/RefreshTokens/RefreshServiceOptions.cs
@@ -37,6 +37,16 @@ public class RefreshServiceOptions
     /// </summary>
     [DontInject]
     public string? Audience { internal get; set; }
+    /// <summary>
+    /// specifies the symmetric key algorithm to be used if signing style is symmetric
+    /// </summary>
+    [DontInject]
+    public string? SymmetricKeyAlgorithm { internal get; set; }
+    /// <summary>
+    /// specifies the symmetric key algorithm to be used if signing style is asymmetric
+    /// </summary>
+    [DontInject]
+    public string? AsymmetricKeyAlgorithm { internal get; set; }
 
     internal string RefreshRoute = "/api/refresh-token";
     internal Action<EndpointDefinition>? EpSettings;

--- a/Src/Security/RefreshTokens/RefreshTokenService.cs
+++ b/Src/Security/RefreshTokens/RefreshTokenService.cs
@@ -118,6 +118,10 @@ public abstract class RefreshTokenService<TRequest, TResponse> : Endpoint<TReque
                     o.User.Claims.AddRange(privs.Claims);
                     o.Issuer = _opts.Issuer;
                     o.Audience = _opts.Audience;
+                    if (_opts.SymmetricKeyAlgorithm != null)
+                        o.SymmetricKeyAlgorithm = _opts.SymmetricKeyAlgorithm;
+                    if (_opts.AsymmetricKeyAlgorithm != null)
+                        o.AsymmetricKeyAlgorithm = _opts.AsymmetricKeyAlgorithm;
                 }),
             AccessExpiry = accessExpiry,
             RefreshToken = Guid.NewGuid().ToString("N"),

--- a/Src/Security/RefreshTokens/RefreshTokenService.cs
+++ b/Src/Security/RefreshTokens/RefreshTokenService.cs
@@ -71,7 +71,7 @@ public abstract class RefreshTokenService<TRequest, TResponse> : Endpoint<TReque
     /// this only applies to renewal/refresh requests received to the refresh endpoint and not the initial jwt creation.
     /// </summary>
     /// <param name="request">the request dto received from the client</param>
-    /// <param name="privileges">the user priviledges to be embeded in the jwt such as roles/claims/permissions</param>
+    /// <param name="privileges">the user privileges to be embedded in the jwt such as roles/claims/permissions</param>
     public abstract Task SetRenewalPrivilegesAsync(TRequest request, UserPrivileges privileges);
 
     /// <summary>
@@ -112,16 +112,15 @@ public abstract class RefreshTokenService<TRequest, TResponse> : Endpoint<TReque
                 {
                     o.SigningKey = _opts.TokenSigningKey;
                     o.SigningStyle = _opts.TokenSigningStyle;
+                    o.SigningAlgorithm = _opts.TokenSigningAlgorithm;
+                    o.KeyIsPemEncoded = _opts.SigningKeyIsPemEncoded;
                     o.ExpireAt = accessExpiry;
                     o.User.Permissions.AddRange(privs.Permissions);
                     o.User.Roles.AddRange(privs.Roles);
                     o.User.Claims.AddRange(privs.Claims);
                     o.Issuer = _opts.Issuer;
                     o.Audience = _opts.Audience;
-                    if (_opts.SymmetricKeyAlgorithm != null)
-                        o.SymmetricKeyAlgorithm = _opts.SymmetricKeyAlgorithm;
-                    if (_opts.AsymmetricKeyAlgorithm != null)
-                        o.AsymmetricKeyAlgorithm = _opts.AsymmetricKeyAlgorithm;
+                    o.CompressionAlgorithm = _opts.TokenCompressionAlgorithm;
                 }),
             AccessExpiry = accessExpiry,
             RefreshToken = Guid.NewGuid().ToString("N"),


### PR DESCRIPTION
Had some issues since the release where the default algorithm for the JwtCreationOptions became HmacSha256Signature since a lot of non .NET validators doesn't support this. Added the option so that we can set that in the TokenService constructor. If there's already a way to achieve this, please let me know 😃.