### PR TITLE
Add Null-conditional operator to Client.Dispose in the DisposeAsync method

### DIFF
--- a/Src/Testing/AppFixture.cs
+++ b/Src/Testing/AppFixture.cs
@@ -183,7 +183,7 @@ public abstract class AppFixture<TProgram> : BaseFixture, IAsyncLifetime where T
     async Task IAsyncLifetime.DisposeAsync()
     {
         await TearDownAsync();
-        Client.Dispose();
+        Client?.Dispose();
     }
 }
 


### PR DESCRIPTION
I noticed while trying to write some tests that I got an error from the dispose async method. When I looked it was not null checking to prevent calling dispose on a null object.

This should address that issue.