### PR TITLE
Fix params parsing when path is using Google rest api guidelines

### DIFF
--- a/Src/Swagger/DocumentProcessor.cs
+++ b/Src/Swagger/DocumentProcessor.cs
@@ -1,5 +1,4 @@
-﻿using System.Net.Http.Headers;
-using NSwag.Generation.Processors;
+﻿using NSwag.Generation.Processors;
 using NSwag.Generation.Processors.Contexts;
 
 namespace FastEndpoints.Swagger;

--- a/Src/Swagger/EnableTesting.cs
+++ b/Src/Swagger/EnableTesting.cs
@@ -1,4 +1,0 @@
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Unit.Swagger")]
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/Src/Swagger/EnableTesting.cs
+++ b/Src/Swagger/EnableTesting.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Unit.Swagger")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/Src/Swagger/OperationProcessor.cs
+++ b/Src/Swagger/OperationProcessor.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -671,8 +671,10 @@ sealed class OperationProcessor(DocumentOptions docOpts) : IOperationProcessor
         return prm;
     }
 
-    readonly struct ParamCreationContext
+    internal readonly struct ParamCreationContext
     {
+        static readonly Regex _regex = new("\\{[a-zA-Z0-9]+:[a-zA-Z0-9]+\\}", RegexOptions.Compiled);
+
         public OperationProcessorContext OpCtx { get; }
         public DocumentOptions DocOpts { get; }
         public JsonSerializer Serializer { get; }
@@ -692,10 +694,11 @@ sealed class OperationProcessor(DocumentOptions docOpts) : IOperationProcessor
             Descriptions = descriptions;
             _paramMap = new(
                 operationPath.Split('/')
-                             .Where(s => s.Contains('{') && s.Contains(':') && s.Contains('}'))
+                             .Where(s => _regex.IsMatch(s))
                              .Select(
                                  s =>
                                  {
+                                     Console.WriteLine(s);
                                      var withoutBraces = s[(s.IndexOf('{') + 1)..s.IndexOfAny(['(', '}'])];
                                      var parts = withoutBraces.Split(':');
                                      var name = parts[0].Trim();

--- a/Tests/IntegrationTests/FastEndpoints.Swagger/initial-release.json
+++ b/Tests/IntegrationTests/FastEndpoints.Swagger/initial-release.json
@@ -2704,6 +2704,44 @@
         ]
       }
     },
+    "/api/test-cases/idempotency/{id}": {
+      "get": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesIdempotencyEndpoint",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestCasesIdempotencyResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/test-cases/json-array-binding-for-ienumerable-props": {
       "get": {
         "tags": [
@@ -5233,6 +5271,19 @@
       "TestCasesHydratedTestUrlGeneratorTestRequest": {
         "type": "object",
         "additionalProperties": false
+      },
+      "TestCasesIdempotencyResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": "string"
+          },
+          "Ticks": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
       },
       "TestCasesJsonArrayBindingForIEnumerablePropsResponse": {
         "allOf": [

--- a/Tests/IntegrationTests/FastEndpoints.Swagger/release-1.json
+++ b/Tests/IntegrationTests/FastEndpoints.Swagger/release-1.json
@@ -2775,6 +2775,44 @@
         ]
       }
     },
+    "/api/test-cases/idempotency/{id}": {
+      "get": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesIdempotencyEndpoint",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestCasesIdempotencyResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/test-cases/json-array-binding-for-ienumerable-props": {
       "get": {
         "tags": [
@@ -5346,6 +5384,19 @@
       "TestCasesHydratedTestUrlGeneratorTestRequest": {
         "type": "object",
         "additionalProperties": false
+      },
+      "TestCasesIdempotencyResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": "string"
+          },
+          "Ticks": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
       },
       "TestCasesJsonArrayBindingForIEnumerablePropsResponse": {
         "allOf": [

--- a/Tests/IntegrationTests/FastEndpoints.Swagger/release-2.json
+++ b/Tests/IntegrationTests/FastEndpoints.Swagger/release-2.json
@@ -2920,6 +2920,44 @@
         ]
       }
     },
+    "/api/test-cases/idempotency/{id}": {
+      "get": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesIdempotencyEndpoint",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestCasesIdempotencyResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/test-cases/json-array-binding-for-ienumerable-props": {
       "get": {
         "tags": [
@@ -5449,6 +5487,19 @@
       "TestCasesHydratedTestUrlGeneratorTestRequest": {
         "type": "object",
         "additionalProperties": false
+      },
+      "TestCasesIdempotencyResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "Id": {
+            "type": "string"
+          },
+          "Ticks": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
       },
       "TestCasesJsonArrayBindingForIEnumerablePropsResponse": {
         "allOf": [

--- a/Tests/UnitTests/FastEndpoints.Swagger/ParamCreationContextTests.cs
+++ b/Tests/UnitTests/FastEndpoints.Swagger/ParamCreationContextTests.cs
@@ -1,0 +1,133 @@
+using FastEndpoints.Swagger;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace SchemaNameGen;
+
+public class ParamCreationContextTests
+{
+    const string ParamName = "param";
+    const string OtherParam = "otherParam";
+
+    [Theory]
+    [InlineData("int", typeof(int))]
+    [InlineData("bool", typeof(bool))]
+    [InlineData("datetime", typeof(DateTime))]
+    [InlineData("decimal", typeof(decimal))]
+    [InlineData("double", typeof(double))]
+    [InlineData("float", typeof(float))]
+    [InlineData("guid", typeof(Guid))]
+    [InlineData("long", typeof(long))]
+    [InlineData("min", typeof(long))]
+    [InlineData("max", typeof(long))]
+    [InlineData("range", typeof(long))]
+    public void ShouldBuildParamMapCorrectly_WhenKnownTypeIsSpecified(string paramType, Type expectedType)
+    {
+        string operationPath = $"/route/{{{ParamName}:{paramType}}}/";
+        OperationProcessor.ParamCreationContext sut = new OperationProcessor.ParamCreationContext(
+            null,
+            null,
+            JsonSerializer.CreateDefault(),
+            null,
+            operationPath);
+
+        sut.TypeForRouteParam(ParamName).Should().Be(expectedType);
+    }
+
+    [Fact]
+    public void ShouldBuildParamMapCorrectly_WhenNoTypeSpecified()
+    {
+        string operationPath = $"/route/{{{ParamName}}}/";
+        OperationProcessor.ParamCreationContext sut = new OperationProcessor.ParamCreationContext(
+            null,
+            null,
+            JsonSerializer.CreateDefault(),
+            null,
+            operationPath);
+
+        sut.TypeForRouteParam(ParamName).Should().Be(typeof(string));
+    }
+
+    [Fact]
+    public void ShouldBuildParamMapCorrectly_WhenUnknownTypeIsSpecified()
+    {
+        string operationPath = $"/route/{{{ParamName}:unknownType}}/";
+        OperationProcessor.ParamCreationContext sut = new OperationProcessor.ParamCreationContext(
+            null,
+            null,
+            JsonSerializer.CreateDefault(),
+            null,
+            operationPath);
+
+        sut.TypeForRouteParam(ParamName).Should().Be(typeof(string));
+    }
+
+    [Theory]
+    [InlineData("int", typeof(int))]
+    [InlineData("bool", typeof(bool))]
+    [InlineData("datetime", typeof(DateTime))]
+    [InlineData("decimal", typeof(decimal))]
+    [InlineData("double", typeof(double))]
+    [InlineData("float", typeof(float))]
+    [InlineData("guid", typeof(Guid))]
+    [InlineData("long", typeof(long))]
+    [InlineData("min", typeof(long))]
+    [InlineData("max", typeof(long))]
+    [InlineData("range", typeof(long))]
+    public void ShouldBuildParamMapCorrectly_WhenMixedParamTypesSpecified(string paramType, Type expectedType)
+    {
+        string operationPath = $"/route/{{{ParamName}:{paramType}}}/{{{OtherParam}:unknownType}}/";
+
+        OperationProcessor.ParamCreationContext sut = new OperationProcessor.ParamCreationContext(
+            null,
+            null,
+            JsonSerializer.CreateDefault(),
+            null,
+            operationPath);
+
+        sut.TypeForRouteParam(ParamName).Should().Be(expectedType);
+        sut.TypeForRouteParam(OtherParam).Should().Be(typeof(string));
+    }
+
+    [Theory]
+    [InlineData("int", typeof(int))]
+    [InlineData("bool", typeof(bool))]
+    [InlineData("datetime", typeof(DateTime))]
+    [InlineData("decimal", typeof(decimal))]
+    [InlineData("double", typeof(double))]
+    [InlineData("float", typeof(float))]
+    [InlineData("guid", typeof(Guid))]
+    [InlineData("long", typeof(long))]
+    [InlineData("min", typeof(long))]
+    [InlineData("max", typeof(long))]
+    [InlineData("range", typeof(long))]
+    [InlineData("unknownType", typeof(string))]
+    public void ShouldBuildParamMapCorrectly_WhenTypeIsSpecified_AndGoogleRestApiGuidelineRouteStyle(string paramType, Type expectedType)
+    {
+        string operationPath = $"/route/{{{ParamName}:{paramType}}}:deactivate";
+
+        OperationProcessor.ParamCreationContext sut = new OperationProcessor.ParamCreationContext(
+            null,
+            null,
+            JsonSerializer.CreateDefault(),
+            null,
+            operationPath);
+
+        sut.TypeForRouteParam(ParamName).Should().Be(expectedType);
+    }
+
+    [Fact]
+    public void ShouldBuildParamMapCorrectly_WhenTypeNotSpecified_AndGoogleRestApiGuidelineRouteStyle()
+    {
+        string operationPath = $"/route/{{{ParamName}}}:deactivate";
+
+        OperationProcessor.ParamCreationContext sut = new OperationProcessor.ParamCreationContext(
+            null,
+            null,
+            JsonSerializer.CreateDefault(),
+            null,
+            operationPath);
+
+        sut.TypeForRouteParam(ParamName).Should().Be(typeof(string));
+    }
+}

--- a/Tests/UnitTests/FastEndpoints.Swagger/ParamCreationContextTests.cs
+++ b/Tests/UnitTests/FastEndpoints.Swagger/ParamCreationContextTests.cs
@@ -1,8 +1,10 @@
+// ReSharper disable ArrangeAttributes
+
 using FastEndpoints.Swagger;
 using Newtonsoft.Json;
 using Xunit;
 
-namespace SchemaNameGen;
+namespace ParamCreationContext;
 
 public class ParamCreationContextTests
 {
@@ -23,13 +25,8 @@ public class ParamCreationContextTests
     [InlineData("range", typeof(long))]
     public void ShouldBuildParamMapCorrectly_WhenKnownTypeIsSpecified(string paramType, Type expectedType)
     {
-        string operationPath = $"/route/{{{ParamName}:{paramType}}}/";
-        OperationProcessor.ParamCreationContext sut = new OperationProcessor.ParamCreationContext(
-            null,
-            null,
-            JsonSerializer.CreateDefault(),
-            null,
-            operationPath);
+        var operationPath = $"/route/{{{ParamName}:{paramType}}}/";
+        var sut = new OperationProcessor.ParamCreationContext(null!, null!, null!, null, operationPath);
 
         sut.TypeForRouteParam(ParamName).Should().Be(expectedType);
     }
@@ -37,13 +34,8 @@ public class ParamCreationContextTests
     [Fact]
     public void ShouldBuildParamMapCorrectly_WhenNoTypeSpecified()
     {
-        string operationPath = $"/route/{{{ParamName}}}/";
-        OperationProcessor.ParamCreationContext sut = new OperationProcessor.ParamCreationContext(
-            null,
-            null,
-            JsonSerializer.CreateDefault(),
-            null,
-            operationPath);
+        var operationPath = $"/route/{{{ParamName}}}/";
+        var sut = new OperationProcessor.ParamCreationContext(null!, null!, null!, null, operationPath);
 
         sut.TypeForRouteParam(ParamName).Should().Be(typeof(string));
     }
@@ -51,13 +43,8 @@ public class ParamCreationContextTests
     [Fact]
     public void ShouldBuildParamMapCorrectly_WhenUnknownTypeIsSpecified()
     {
-        string operationPath = $"/route/{{{ParamName}:unknownType}}/";
-        OperationProcessor.ParamCreationContext sut = new OperationProcessor.ParamCreationContext(
-            null,
-            null,
-            JsonSerializer.CreateDefault(),
-            null,
-            operationPath);
+        var operationPath = $"/route/{{{ParamName}:unknownType}}/";
+        var sut = new OperationProcessor.ParamCreationContext(null!, null!, null!, null, operationPath);
 
         sut.TypeForRouteParam(ParamName).Should().Be(typeof(string));
     }
@@ -76,14 +63,8 @@ public class ParamCreationContextTests
     [InlineData("range", typeof(long))]
     public void ShouldBuildParamMapCorrectly_WhenMixedParamTypesSpecified(string paramType, Type expectedType)
     {
-        string operationPath = $"/route/{{{ParamName}:{paramType}}}/{{{OtherParam}:unknownType}}/";
-
-        OperationProcessor.ParamCreationContext sut = new OperationProcessor.ParamCreationContext(
-            null,
-            null,
-            JsonSerializer.CreateDefault(),
-            null,
-            operationPath);
+        var operationPath = $"/route/{{{ParamName}:{paramType}}}/{{{OtherParam}:unknownType}}/";
+        var sut = new OperationProcessor.ParamCreationContext(null!, null!, null!, null, operationPath);
 
         sut.TypeForRouteParam(ParamName).Should().Be(expectedType);
         sut.TypeForRouteParam(OtherParam).Should().Be(typeof(string));
@@ -104,14 +85,8 @@ public class ParamCreationContextTests
     [InlineData("unknownType", typeof(string))]
     public void ShouldBuildParamMapCorrectly_WhenTypeIsSpecified_AndGoogleRestApiGuidelineRouteStyle(string paramType, Type expectedType)
     {
-        string operationPath = $"/route/{{{ParamName}:{paramType}}}:deactivate";
-
-        OperationProcessor.ParamCreationContext sut = new OperationProcessor.ParamCreationContext(
-            null,
-            null,
-            JsonSerializer.CreateDefault(),
-            null,
-            operationPath);
+        var operationPath = $"/route/{{{ParamName}:{paramType}:min(10)}}:deactivate";
+        var sut = new OperationProcessor.ParamCreationContext(null!, null!, null!, null, operationPath);
 
         sut.TypeForRouteParam(ParamName).Should().Be(expectedType);
     }
@@ -119,15 +94,18 @@ public class ParamCreationContextTests
     [Fact]
     public void ShouldBuildParamMapCorrectly_WhenTypeNotSpecified_AndGoogleRestApiGuidelineRouteStyle()
     {
-        string operationPath = $"/route/{{{ParamName}}}:deactivate";
-
-        OperationProcessor.ParamCreationContext sut = new OperationProcessor.ParamCreationContext(
-            null,
-            null,
-            JsonSerializer.CreateDefault(),
-            null,
-            operationPath);
+        var operationPath = $"/route/{{{ParamName}}}:deactivate";
+        var sut = new OperationProcessor.ParamCreationContext(null!, null!, null!, null, operationPath);
 
         sut.TypeForRouteParam(ParamName).Should().Be(typeof(string));
+    }
+
+    [Fact]
+    public void ShouldBuildParamMapCorrectly_WhenTypeSpecified_AndHasMultipleConstraints_AndGoogleRestApiGuidelineRouteStyle()
+    {
+        var operationPath = $"/route/{{{ParamName}:min(5):max(10)}}:deactivate";
+        var sut = new OperationProcessor.ParamCreationContext(null!, null!, null!, null, operationPath);
+
+        sut.TypeForRouteParam(ParamName).Should().Be(typeof(long));
     }
 }


### PR DESCRIPTION
After upgrading to 5.25 our API crashed during startup. 
After investigation problem was detected in `OperationProcessor.ParamCreationContext`
Fixed it to allow routes named using google rest api guidelines
`/api/{id}:deactivate`
