### PR TITLE
FIX: param creation bug for api/a:{id1}:{id2} type routes

### DIFF
--- a/Src/Swagger/OperationProcessor.cs
+++ b/Src/Swagger/OperationProcessor.cs
@@ -706,6 +706,9 @@ sealed class OperationProcessor(DocumentOptions docOpts) : IOperationProcessor
 
         readonly Dictionary<string, Type> _paramMap;
 
+        //search min 1 `:` character between any `{` and `}` characters
+        const string ParamMapPattern = @"\{[^{}]*:[^{}]*\}";
+
         public ParamCreationContext(OperationProcessorContext opCtx,
                                     DocumentOptions docOpts,
                                     JsonSerializer serializer,
@@ -718,8 +721,7 @@ sealed class OperationProcessor(DocumentOptions docOpts) : IOperationProcessor
             Descriptions = descriptions;
             _paramMap = new(
                 operationPath.Split('/')
-                             .Where(s => s.Contains('{') && s.Contains(':') && s.Contains('}')) //include: api/{id:int:min(5)}:deactivate
-                             .Where(s => s.IndexOf(':') < s.IndexOf('}'))                       //exclude: api/{id}:deactivate
+                             .Where(s => Regex.IsMatch(s, ParamMapPattern)) //include: api/{id:int:min(5)}:deactivate
                              .Select(
                                  s =>
                                  {

--- a/Src/Swagger/OperationProcessor.cs
+++ b/Src/Swagger/OperationProcessor.cs
@@ -398,6 +398,7 @@ sealed class OperationProcessor(DocumentOptions docOpts) : IOperationProcessor
         }
 
     #if NET7_0_OR_GREATER
+
         //add idempotency header param if applicable
         if (epDef.IdempotencyOptions is not null)
         {

--- a/Tests/UnitTests/FastEndpoints.Swagger/ParamCreationContextTests.cs
+++ b/Tests/UnitTests/FastEndpoints.Swagger/ParamCreationContextTests.cs
@@ -1,7 +1,6 @@
 // ReSharper disable ArrangeAttributes
 
 using FastEndpoints.Swagger;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace ParamCreationContext;
@@ -34,7 +33,7 @@ public class ParamCreationContextTests
     [Fact]
     public void ShouldBuildParamMapCorrectly_WhenNoTypeSpecified()
     {
-        var operationPath = $"/route/{{{ParamName}}}/";
+        const string operationPath = $"/route/{{{ParamName}}}/";
         var sut = new OperationProcessor.ParamCreationContext(null!, null!, null!, null, operationPath);
 
         sut.TypeForRouteParam(ParamName).Should().Be(typeof(string));
@@ -43,7 +42,7 @@ public class ParamCreationContextTests
     [Fact]
     public void ShouldBuildParamMapCorrectly_WhenUnknownTypeIsSpecified()
     {
-        var operationPath = $"/route/{{{ParamName}:unknownType}}/";
+        const string operationPath = $"/route/{{{ParamName}:unknownType}}/";
         var sut = new OperationProcessor.ParamCreationContext(null!, null!, null!, null, operationPath);
 
         sut.TypeForRouteParam(ParamName).Should().Be(typeof(string));
@@ -94,7 +93,7 @@ public class ParamCreationContextTests
     [Fact]
     public void ShouldBuildParamMapCorrectly_WhenTypeNotSpecified_AndGoogleRestApiGuidelineRouteStyle()
     {
-        var operationPath = $"/route/{{{ParamName}}}:deactivate";
+        const string operationPath = $"/route/{{{ParamName}}}:deactivate";
         var sut = new OperationProcessor.ParamCreationContext(null!, null!, null!, null, operationPath);
 
         sut.TypeForRouteParam(ParamName).Should().Be(typeof(string));
@@ -103,9 +102,19 @@ public class ParamCreationContextTests
     [Fact]
     public void ShouldBuildParamMapCorrectly_WhenTypeSpecified_AndHasMultipleConstraints_AndGoogleRestApiGuidelineRouteStyle()
     {
-        var operationPath = $"/route/{{{ParamName}:min(5):max(10)}}:deactivate";
+        const string operationPath = $"/route/{{{ParamName}:min(5):max(10)}}:deactivate";
         var sut = new OperationProcessor.ParamCreationContext(null!, null!, null!, null, operationPath);
 
         sut.TypeForRouteParam(ParamName).Should().Be(typeof(long));
+    }
+
+    [Fact]
+    public async Task Multi_Semi_Colon_Route_Segments()
+    {
+        const string operationPath = $"api/a:{{{ParamName}}}:{{id2}}/{{{OtherParam}:long}}/";
+        var sut = new OperationProcessor.ParamCreationContext(null!, null!, null!, null, operationPath);
+
+        sut.TypeForRouteParam(ParamName).Should().Be(typeof(string));
+        sut.TypeForRouteParam(OtherParam).Should().Be(typeof(long));
     }
 }


### PR DESCRIPTION
This pull request aims to fix a bug in route creation for patterns like api/a:{id1}:{id2}.