### PR TITLE
Update kiota to 1.16.0

### DIFF
--- a/Src/ClientGen.Kiota/FastEndpoints.ClientGen.Kiota.csproj
+++ b/Src/ClientGen.Kiota/FastEndpoints.ClientGen.Kiota.csproj
@@ -12,7 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="NSwag.Generation.AspNetCore" Version="14.0.8"/>
-        <PackageReference Include="Microsoft.OpenApi.Kiota.Builder" Version="1.15.0"/>
+        <PackageReference Include="Microsoft.OpenApi.Kiota.Builder" Version="1.16.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     </ItemGroup>
 


### PR DESCRIPTION
There's an important update in 1.16.0 of Kiota that fixes name collisions

References to C# types generated by kiota are prefixed with `global::` to avoid name collisions. https://github.com/microsoft/kiota/issues/4796

https://github.com/microsoft/kiota/releases/tag/v1.16.0