### PR TITLE
 JobQueues support for ICommand<>

### DIFF
--- a/Src/Library/Messaging/Jobs/IJobStorageProvider.cs
+++ b/Src/Library/Messaging/Jobs/IJobStorageProvider.cs
@@ -36,6 +36,12 @@ public interface IJobStorageProvider<TStorageRecord> where TStorageRecord : IJob
     Task CancelJobAsync(Guid trackingId, CancellationToken ct);
 
     /// <summary>
+    /// fetch the job storage record with the supplied search parameters.
+    /// </summary>
+    /// <param name="parameters">use these supplied search parameters to find the job record from your database</param>
+    Task<TStorageRecord?> GetJob(JobSearchParams<TStorageRecord> parameters);
+
+    /// <summary>
     /// this will only be triggered when a command handler (<see cref="ICommandHandler{TCommand}" />) associated with a command
     /// throws an exception. If you've set an execution time limit for the command, the thrown exception would be of type
     /// <see cref="OperationCanceledException" />.

--- a/Src/Library/Messaging/Jobs/IJobStorageProvider.cs
+++ b/Src/Library/Messaging/Jobs/IJobStorageProvider.cs
@@ -36,6 +36,8 @@ public interface IJobStorageProvider<TStorageRecord> where TStorageRecord : IJob
     Task CancelJobAsync(Guid trackingId, CancellationToken ct);
 
     /// <summary>
+    /// (OPTIONAL) If u want to use Queue for ICommand&lt;&gt; (with a result)
+    /// otherwise can throw NotImplementedException();
     /// fetch the job storage record with the supplied search parameters.
     /// </summary>
     /// <param name="parameters">use these supplied search parameters to find the job record from your database</param>

--- a/Src/Library/Messaging/Jobs/IJobStorageRecord.cs
+++ b/Src/Library/Messaging/Jobs/IJobStorageRecord.cs
@@ -22,13 +22,14 @@ public interface IJobStorageRecord
     /// 1. add a [NotMapped] attribute to this property.
     /// 2. add a new property, either a <c>string</c> or <c>byte[]</c>
     /// 3. implement both GetCommand() and SetCommand() methods to serialize/deserialize the command object back and forth and store it in the newly added property.
-    /// 4. (optional)implement both GetCommand<>() and SetCommand<>() methods to serialize/deserialize the command object with return value back and forth and store it in the newly added property.
+    /// 4. (optional)implement both GetCommand&lt;&gt;() and SetCommand&lt;&gt;() methods to serialize/deserialize the command object with return value back and forth and store it in the newly added property.
     /// </code>
     /// you may use any serializer you please. recommendation is to use MessagePack.
     /// </summary>
     object Command { get; set; }
 
     /// <summary>
+    /// (OPTIONAL) If u want to use Queue for ICommand&lt;&gt; (with a result)
     /// the actual result object that will be embedded in the storage record.
     /// if your database/orm (such as ef-core) doesn't support embedding objects, you can take the following steps:
     /// <code>
@@ -48,7 +49,7 @@ public interface IJobStorageRecord
     DateTime ExecuteAfter { get; set; }
 
     /// <summary>
-    /// the expiration date/time of job. if the job remains in an incomplete state past this time, the record is considered stale, and will be marked for removal from storage.
+    /// the expiration date/time of the job. if the job remains in an incomplete state past this time, the record is considered stale, and will be marked for removal from storage.
     /// </summary>
     DateTime ExpireOn { get; set; }
 
@@ -64,12 +65,14 @@ public interface IJobStorageRecord
         => (TCommand)Command;
 
     /// <summary>
+    /// (OPTIONAL) If u want to use Queue for ICommand&lt;&gt; (with a result)
     /// implement this function to customize command with return value deserialization.
     /// </summary>
     TCommand GetCommand<TCommand, TResult>() where TCommand : ICommand<TResult>
         => (TCommand)Command;
 
     /// <summary>
+    /// (OPTIONAL) If u want to use Queue for ICommand&lt;&gt; (with a result)
     /// implement this function to customize result deserialization.
     /// </summary>
     TResult? GetResult<TCommand, TResult>() where TCommand : ICommand<TResult>
@@ -82,12 +85,14 @@ public interface IJobStorageRecord
         => Command = command;
 
     /// <summary>
+    /// (OPTIONAL) If u want to use Queue for ICommand&lt;&gt; (with a result)
     /// implement this method to customize command with return value serialization.
     /// </summary>
     void SetCommand<TCommand, TResult>(TCommand command) where TCommand : ICommand<TResult>
         => Command = command;
 
     /// <summary>
+    /// (OPTIONAL) If u want to use Queue for ICommand&lt;&gt; (with a result)
     /// implement this method to customize result serialization.
     /// </summary>
     void SetResult<TCommand, TResult>(TResult result) where TCommand : ICommand<TResult>

--- a/Src/Library/Messaging/Jobs/IJobStorageRecord.cs
+++ b/Src/Library/Messaging/Jobs/IJobStorageRecord.cs
@@ -22,10 +22,24 @@ public interface IJobStorageRecord
     /// 1. add a [NotMapped] attribute to this property.
     /// 2. add a new property, either a <c>string</c> or <c>byte[]</c>
     /// 3. implement both GetCommand() and SetCommand() methods to serialize/deserialize the command object back and forth and store it in the newly added property.
+    /// 4. (optional)implement both GetCommand<>() and SetCommand<>() methods to serialize/deserialize the command object with return value back and forth and store it in the newly added property.
     /// </code>
     /// you may use any serializer you please. recommendation is to use MessagePack.
     /// </summary>
     object Command { get; set; }
+
+    /// <summary>
+    /// the actual result object that will be embedded in the storage record.
+    /// if your database/orm (such as ef-core) doesn't support embedding objects, you can take the following steps:
+    /// <code>
+    /// 1. add a [NotMapped] attribute to this property.
+    /// 2. add a new property, either a <c>string</c> or <c>byte[]</c>
+    /// 3. implement both GetResult() and SetResult() methods to serialize/deserialize the result object back and forth and store it in the newly added property.
+    /// 4. point 4. from <see cref="Command"/>
+    /// </code>
+    /// you may use any serializer you please. recommendation is to use MessagePack.
+    /// </summary>
+    object? Result { get; set; }
 
     /// <summary>
     /// the job will not be executed before this date/time. by default, it will automatically be set to the time of creation allowing jobs to be executed as soon as they're
@@ -50,8 +64,32 @@ public interface IJobStorageRecord
         => (TCommand)Command;
 
     /// <summary>
+    /// implement this function to customize command with return value deserialization.
+    /// </summary>
+    TCommand GetCommand<TCommand, TResult>() where TCommand : ICommand<TResult>
+        => (TCommand)Command;
+
+    /// <summary>
+    /// implement this function to customize result deserialization.
+    /// </summary>
+    TResult? GetResult<TCommand, TResult>() where TCommand : ICommand<TResult>
+        => (TResult?)Result;
+
+    /// <summary>
     /// implement this method to customize command serialization.
     /// </summary>
     void SetCommand<TCommand>(TCommand command) where TCommand : ICommand
         => Command = command;
+
+    /// <summary>
+    /// implement this method to customize command with return value serialization.
+    /// </summary>
+    void SetCommand<TCommand, TResult>(TCommand command) where TCommand : ICommand<TResult>
+        => Command = command;
+
+    /// <summary>
+    /// implement this method to customize result serialization.
+    /// </summary>
+    void SetResult<TCommand, TResult>(TResult result) where TCommand : ICommand<TResult>
+        => Result = result;
 }

--- a/Src/Library/Messaging/Jobs/JobQueue.cs
+++ b/Src/Library/Messaging/Jobs/JobQueue.cs
@@ -15,11 +15,14 @@ abstract class JobQueueBase
     //see ctor in JobQueue<TCommand, TStorageRecord, TStorageProvider>
     protected static readonly ConcurrentDictionary<Type, JobQueueBase> JobQueues = new();
 
-    protected abstract Task<Guid> StoreJobAsync(ICommand command, DateTime? executeAfter, DateTime? expireOn, CancellationToken ct);
-
-    protected abstract Task CancelJobAsync(Guid trackingId, CancellationToken ct);
+    protected internal abstract Task CancelJobAsync(Guid trackingId, CancellationToken ct);
 
     internal abstract void SetLimits(int concurrencyLimit, TimeSpan executionTimeLimit, TimeSpan semWaitLimit);
+}
+
+abstract class JobQueueWithoutReturnValue : JobQueueBase
+{
+    protected abstract Task<Guid> StoreJobAsync(ICommand command, DateTime? executeAfter, DateTime? expireOn, CancellationToken ct);
 
     internal static Task<Guid> AddToQueueAsync(ICommand command, DateTime? executeAfter, DateTime? expireOn, CancellationToken ct)
     {
@@ -32,7 +35,9 @@ abstract class JobQueueBase
         return
             !JobQueues.TryGetValue(tCommand, out var queue)
                 ? throw new InvalidOperationException($"A job queue has not been registered for [{tCommand.FullName}]")
-                : queue.StoreJobAsync(command, executeAfter, expireOn, ct);
+                : queue is JobQueueWithoutReturnValue queueWithoutReturnValue
+                    ? queueWithoutReturnValue.StoreJobAsync(command, executeAfter, expireOn, ct)
+                    : throw new InvalidOperationException($"A job queue without return value has not been registered for [{tCommand.FullName}]");
     }
 
     internal static Task CancelJobAsync<TCommand>(Guid trackingId, CancellationToken ct) where TCommand : ICommand
@@ -46,10 +51,11 @@ abstract class JobQueueBase
     }
 }
 
+
 [SuppressMessage("Reliability", "CA2016:Forward the \'CancellationToken\' parameter to methods"), SuppressMessage("ReSharper", "MethodSupportsCancellation")]
 
 // created by DI as singleton
-sealed class JobQueue<TCommand, TStorageRecord, TStorageProvider> : JobQueueBase
+sealed class JobQueue<TCommand, TStorageRecord, TStorageProvider> : JobQueueWithoutReturnValue
     where TCommand : ICommand
     where TStorageRecord : IJobStorageRecord, new()
     where TStorageProvider : IJobStorageProvider<TStorageRecord>
@@ -110,7 +116,7 @@ sealed class JobQueue<TCommand, TStorageRecord, TStorageProvider> : JobQueueBase
         return job.TrackingID;
     }
 
-    protected override async Task CancelJobAsync(Guid trackingId, CancellationToken ct)
+    protected internal override async Task CancelJobAsync(Guid trackingId, CancellationToken ct)
     {
         _ = AttemptCancellationTask(trackingId, _cancellations, _cancellationExpiry);
         await _storage.CancelJobAsync(trackingId, ct);
@@ -210,6 +216,275 @@ sealed class JobQueue<TCommand, TStorageRecord, TStorageProvider> : JobQueueBase
                 var cmd = record.GetCommand<TCommand>();
                 record.Command = cmd; //needed in case user does whole record (non-partial) updates via storage provider.
                 await cmd.ExecuteAsync(cts.Token);
+                _cancellations.Remove(record.TrackingID); //remove entry on completion. cancellations are not possible/valid after this point.
+            }
+            catch (Exception x)
+            {
+                _cancellations.Remove(record.TrackingID); //remove entry on execution error to allow obtaining a new cts on retry/reentry
+                _log.CommandExecutionCritical(_tCommandName, x.Message);
+
+                while (!_appCancellation.IsCancellationRequested)
+                {
+                    try
+                    {
+                        await _storage.OnHandlerExecutionFailureAsync(record, x, _appCancellation);
+
+                        break;
+                    }
+                    catch (Exception xx)
+                    {
+                        _log.StorageOnExecutionFailureError(QueueID, _tCommandName, xx.Message);
+                        await Task.Delay(5000);
+                    }
+                }
+
+                return; //abort execution here
+            }
+
+            while (!_appCancellation.IsCancellationRequested)
+            {
+                try
+                {
+                    record.IsComplete = true;
+                    await _storage.MarkJobAsCompleteAsync(record, _appCancellation);
+
+                    break;
+                }
+                catch (Exception x)
+                {
+                    _log.StorageMarkAsCompleteError(QueueID, _tCommandName, x.Message);
+                    await Task.Delay(5000);
+                }
+            }
+        }
+    }
+}
+
+
+abstract class JobQueueWithReturnValue<TResult> : JobQueueBase
+{
+
+    protected abstract Task<Guid> StoreJobAsync(ICommand<TResult> command, DateTime? executeAfter, DateTime? expireOn, CancellationToken ct);
+    protected abstract Task<TResult?> GetJobResult(Guid trackingId, CancellationToken ct);
+
+    internal static Task<Guid> AddToQueueAsync(ICommand<TResult> command, DateTime? executeAfter, DateTime? expireOn, CancellationToken ct)
+    {
+        if (executeAfter?.Kind is not null and not DateTimeKind.Utc ||
+            expireOn?.Kind is not null and not DateTimeKind.Utc)
+            throw new ArgumentException($"Only UTC dates are accepted for '{nameof(executeAfter)}' & '{nameof(expireOn)}' parameters!");
+
+        var tCommand = command.GetType();
+
+        return
+            !JobQueues.TryGetValue(tCommand, out var queue)
+                ? throw new InvalidOperationException($"A job queue has not been registered for [{tCommand.FullName}]")
+                : queue is JobQueueWithReturnValue<TResult> queueWithReturnValue
+                    ? queueWithReturnValue.StoreJobAsync(command, executeAfter, expireOn, ct)
+                    : throw new InvalidOperationException($"A job queue with return value [{typeof(TResult).FullName}] has not been registered for [{tCommand.FullName}]");
+    }
+
+    internal static Task CancelJobAsync<TCommand>(Guid trackingId, CancellationToken ct) where TCommand : ICommand<TResult>
+    {
+        var tCommand = typeof(TCommand);
+
+        return
+            !JobQueues.TryGetValue(tCommand, out var queue)
+                ? throw new InvalidOperationException($"A job queue has not been registered for [{tCommand.FullName}]")
+                : queue.CancelJobAsync(trackingId, ct);
+    }
+
+    internal static Task<TResult?> GetJobResultAsync<TCommand>(Guid trackingId, CancellationToken ct) where TCommand : ICommand<TResult>
+    {
+        var tCommand = typeof(TCommand);
+
+        return
+            !JobQueues.TryGetValue(tCommand, out var queue)
+                ? throw new InvalidOperationException($"A job queue has not been registered for [{tCommand.FullName}]")
+                : queue is JobQueueWithReturnValue<TResult> queueWithReturnValue
+                    ? queueWithReturnValue.GetJobResult(trackingId, ct)
+                    : throw new InvalidOperationException($"A job queue with return value [{typeof(TResult).FullName}] has not been registered for [{tCommand.FullName}]");
+    }
+}
+
+// created by DI as singleton
+// this is a copy of above code
+sealed class JobQueue<TCommand, TResult, TStorageRecord, TStorageProvider> : JobQueueWithReturnValue<TResult>
+    where TCommand : ICommand<TResult>
+    where TStorageRecord : IJobStorageRecord, new()
+    where TStorageProvider : IJobStorageProvider<TStorageRecord>
+{
+    static readonly Type _tCommand = typeof(TCommand);
+    static readonly string _tCommandName = _tCommand.FullName!;
+
+    //public due to: https://github.com/FastEndpoints/FastEndpoints/issues/468
+    public static readonly string QueueID = _tCommandName.ToHash();
+
+    readonly MemoryCache _cancellations = new(new MemoryCacheOptions());
+    readonly ParallelOptions _parallelOptions = new() { MaxDegreeOfParallelism = Environment.ProcessorCount };
+    readonly CancellationToken _appCancellation;
+    readonly TStorageProvider _storage;
+    readonly SemaphoreSlim _sem = new(0);
+    readonly ILogger _log;
+    TimeSpan _executionTimeLimit;
+    TimeSpan _cancellationExpiry;
+    TimeSpan _semWaitLimit;
+    bool _isInUse;
+
+    public JobQueue(TStorageProvider storageProvider,
+                    IHostApplicationLifetime appLife,
+                    ILogger<JobQueue<TCommand, TResult, TStorageRecord, TStorageProvider>> logger)
+    {
+        JobQueues[_tCommand] = this;
+        _storage = storageProvider;
+        _appCancellation = appLife.ApplicationStopping;
+        _parallelOptions.CancellationToken = _appCancellation;
+        _log = logger;
+        JobStorage<TStorageRecord, TStorageProvider>.Provider = _storage;
+        JobStorage<TStorageRecord, TStorageProvider>.AppCancellation = _appCancellation;
+    }
+
+    internal override void SetLimits(int concurrencyLimit, TimeSpan executionTimeLimit, TimeSpan semWaitLimit)
+    {
+        _parallelOptions.MaxDegreeOfParallelism = concurrencyLimit;
+        _executionTimeLimit = executionTimeLimit;
+        _cancellationExpiry = executionTimeLimit + TimeSpan.FromHours(1);
+        _semWaitLimit = semWaitLimit;
+        _ = CommandExecutorTask();
+    }
+
+    protected override async Task<Guid> StoreJobAsync(ICommand<TResult> command, DateTime? executeAfter, DateTime? expireOn, CancellationToken ct)
+    {
+        _isInUse = true;
+        var job = new TStorageRecord
+        {
+            TrackingID = Guid.NewGuid(),
+            QueueID = QueueID,
+            ExecuteAfter = executeAfter ?? DateTime.UtcNow,
+            ExpireOn = expireOn ?? DateTime.UtcNow.AddHours(4)
+        };
+        job.SetCommand<TCommand,TResult>((TCommand)command);
+        await _storage.StoreJobAsync(job, ct);
+        _sem.Release();
+
+        return job.TrackingID;
+    }
+
+    protected override async Task<TResult?> GetJobResult(Guid trackingId, CancellationToken ct)
+    {
+        var job = await _storage.GetJob(
+                      new()
+                      {
+                          TrackingID = trackingId,
+                          CancellationToken = _appCancellation,
+                          Match = r => r.QueueID == QueueID &&
+                                       r.TrackingID == trackingId &&
+                                       r.IsComplete == true
+                      });
+
+        return job is null ? default(TResult?) : job.GetResult<TCommand, TResult>();
+    }
+
+    protected internal override async Task CancelJobAsync(Guid trackingId, CancellationToken ct)
+    {
+        _ = AttemptCancellationTask(trackingId, _cancellations, _cancellationExpiry);
+        await _storage.CancelJobAsync(trackingId, ct);
+
+        static async Task AttemptCancellationTask(Guid trackingId, MemoryCache cancellations, TimeSpan cancelExpiry)
+        {
+            var cts = cancellations.GetOrCreate<CancellationTokenSource?>(
+                trackingId,
+                e =>
+                {
+                    e.SlidingExpiration = cancelExpiry;
+
+                    return null;
+                });
+
+            var startTime = DateTime.Now;
+
+            //this is probably unnecessary. but could come in handy in case there's some delays (or race condition) in
+            //marking the job as complete via the storage provider and the job gets picked up for execution in the meantime.
+            while (DateTime.Now.Subtract(startTime).TotalMilliseconds <= 10000)
+            {
+                if (cts is not null) //job execution has started and cts is available
+                {
+                    if (!cts.IsCancellationRequested)
+                        cts.Cancel(false);
+
+                    return; //we're done!
+                }
+                await Task.Delay(1000);
+            }
+        }
+    }
+
+    async Task CommandExecutorTask()
+    {
+        while (!_appCancellation.IsCancellationRequested)
+        {
+            IEnumerable<TStorageRecord> records;
+
+            try
+            {
+                records = await _storage.GetNextBatchAsync(
+                              new()
+                              {
+                                  Limit = _parallelOptions.MaxDegreeOfParallelism,
+                                  QueueID = QueueID,
+                                  CancellationToken = _appCancellation,
+                                  Match = r => r.QueueID == QueueID &&
+                                               r.IsComplete == false &&
+                                               DateTime.UtcNow >= r.ExecuteAfter &&
+                                               DateTime.UtcNow <= r.ExpireOn
+                              });
+            }
+            catch (Exception x)
+            {
+                _log.StorageRetrieveError(QueueID, _tCommandName, x.Message);
+                await Task.Delay(5000);
+
+                continue;
+            }
+
+            if (!records.Any())
+            {
+                // If _isInUse is false, it signifies that no job has been queued yet.
+                // Therefore, there is no necessity for further iterations within the loop until the semaphore is released upon queuing the first job.
+                //
+                // If _isInUse is true, it indicates that we must await the queuing of the next job or the passage of delay duration (default: 1 minute), whichever comes first.
+                // We must periodically reevaluate the storage status to ascertain if the user has rescheduled any previous jobs while no new jobs are being queued.
+                // Failure to conduct this periodic check could result in rescheduled jobs only executing upon the arrival of new jobs, potentially leading to expired job executions.
+                await (_isInUse
+                           ? Task.WhenAny(_sem.WaitAsync(_appCancellation), Task.Delay(_semWaitLimit))
+                           : _sem.WaitAsync(_appCancellation));
+            }
+            else
+                await Parallel.ForEachAsync(records, _parallelOptions, ExecuteCommand);
+        }
+
+        async ValueTask ExecuteCommand(TStorageRecord record, CancellationToken _)
+        {
+            using var cts = _cancellations.GetOrCreate<CancellationTokenSource?>(
+                record.TrackingID,
+                e =>
+                {
+                    e.AbsoluteExpirationRelativeToNow = _cancellationExpiry;
+                    var s = new CancellationTokenSource(_executionTimeLimit);
+
+                    return s;
+                });
+
+            if (cts is null) //don't execute this job because cancellation has been requested already
+                return;      //the cts will be null if the entry was created by a call to CancelJobAsync() before the job was picked up for execution
+
+            //if cts is not null, proceed with job execution as cancellation has not been requested yet.
+
+            try
+            {
+                var cmd = record.GetCommand<TCommand, TResult>();
+                record.Command = cmd; //needed in case user does whole record (non-partial) updates via storage provider.
+                var result = await cmd.ExecuteAsync(cts.Token);
+                record.SetResult<TCommand, TResult>(result);
                 _cancellations.Remove(record.TrackingID); //remove entry on completion. cancellations are not possible/valid after this point.
             }
             catch (Exception x)

--- a/Src/Library/Messaging/Jobs/JobQueueOptions.cs
+++ b/Src/Library/Messaging/Jobs/JobQueueOptions.cs
@@ -43,6 +43,10 @@ public class JobQueueOptions
     {
         _limitOverrides[typeof(TCommand)] = new(maxConcurrency, timeLimit);
     }
+    public void LimitsFor<TCommand, TResult>(int maxConcurrency, TimeSpan timeLimit) where TCommand : ICommand<TResult>
+    {
+        _limitOverrides[typeof(TCommand)] = new(maxConcurrency, timeLimit);
+    }
 
     internal void SetLimits(Type tCommand, JobQueueBase jobQueue)
     {

--- a/Src/Library/Messaging/Jobs/JobSearchParams.cs
+++ b/Src/Library/Messaging/Jobs/JobSearchParams.cs
@@ -1,0 +1,29 @@
+﻿using System.Linq.Expressions;
+
+namespace FastEndpoints;
+
+/// <summary>
+/// a dto representing search parameters for job storage record
+/// </summary>
+/// <typeparam name="TStorageRecord">the type of storage record</typeparam>
+public struct JobSearchParams<TStorageRecord> where TStorageRecord : IJobStorageRecord
+{
+    /// <summary>
+    /// the ID of the specific job
+    /// </summary>
+    public Guid TrackingID { get; internal set; }
+
+    /// <summary>
+    /// a boolean lambda expression to match the next batch of records
+    /// <code>
+    /// 	r => r.QueueID == "xxx" &amp;&amp;
+    /// 	     r.TrackingID == <see cref="TrackingID"/>
+    /// </code>
+    /// </summary>
+    public Expression<Func<TStorageRecord, bool>> Match { get; internal set; }
+
+    /// <summary>
+    /// cancellation token
+    /// </summary>
+    public CancellationToken CancellationToken { get; internal set; }
+}

--- a/Src/Library/Messaging/Jobs/JobTracker.cs
+++ b/Src/Library/Messaging/Jobs/JobTracker.cs
@@ -18,7 +18,7 @@ public interface IJobTracker<TCommand> where TCommand : ICommand
     /// method repeatedly with the same tracking id.
     /// </exception>
     public Task CancelJobAsync(Guid trackingId, CancellationToken ct)
-        => JobQueueBase.CancelJobAsync<TCommand>(trackingId, ct);
+        => JobQueueWithoutReturnValue.CancelJobAsync<TCommand>(trackingId, ct);
 }
 
 /// <summary>
@@ -39,5 +39,56 @@ public class JobTracker<TCommand> : IJobTracker<TCommand> where TCommand : IComm
     /// method repeatedly with the same tracking id.
     /// </exception>
     public static Task CancelJobAsync(Guid trackingId, CancellationToken ct = default)
-        => JobQueueBase.CancelJobAsync<TCommand>(trackingId, ct);
+        => JobQueueWithoutReturnValue.CancelJobAsync<TCommand>(trackingId, ct);
+}
+
+/// <summary>
+/// the interface defining a job tracker
+/// </summary>
+/// <typeparam name="TCommand">the command type of the job</typeparam>
+/// <typeparam name="TResult">the result type of the job</typeparam>
+public interface IJobTracker<TCommand, TResult> where TCommand : ICommand<TResult>
+{
+    /// <summary>
+    /// cancel a job by its tracking id. if the job is currently executing, the cancellation token passed down to the command handler method will be notified of the
+    /// cancellation. the job storage record will also be marked complete via <see cref="IJobStorageProvider{TStorageRecord}.CancelJobAsync" /> method of the job storage
+    /// provider, which will prevent the job from being picked up for execution.
+    /// </summary>
+    /// <param name="trackingId">the job tracking id</param>
+    /// <param name="ct">optional cancellation token</param>
+    /// <exception cref="Exception">
+    /// this method will throw any exceptions that the job storage provider may throw in case of transient errors. you can safely retry calling this
+    /// method repeatedly with the same tracking id.
+    /// </exception>
+    public Task CancelJobAsync(Guid trackingId, CancellationToken ct)
+        => JobQueueWithReturnValue<TResult>.CancelJobAsync<TCommand>(trackingId, ct);
+
+    /// <summary>
+    /// get mapped completed job result. the job storage record will be obtained via <see cref="IJobStorageProvider{TStorageRecord}.GetJob" /> method of the job storage
+    /// provider, which require <see cref="IJobStorageRecord.IsComplete"/> to be true
+    /// </summary>
+    /// <param name="trackingId">the job tracking id</param>
+    /// <param name="ct">optional cancellation token</param>
+    /// <returns>nullable <typeparamref name="TResult"/></returns>
+    /// <exception cref="Exception">
+    /// this method will throw any exceptions that the job storage provider may throw in case of transient errors.
+    /// </exception>
+    public Task<TResult?> GetJobResultAsync(Guid trackingId, CancellationToken ct)
+        => JobQueueWithReturnValue<TResult>.GetJobResultAsync<TCommand>(trackingId, ct);
+}
+
+/// <summary>
+/// a <see cref="IJobTracker{TCommand,TResult}" /> implementation used for tracking queued jobs
+/// </summary>
+/// <typeparam name="TCommand">the command type of the job</typeparam>
+/// <typeparam name="TResult">the result type of the job</typeparam>
+public class JobTracker<TCommand, TResult> : IJobTracker<TCommand, TResult> where TCommand : ICommand<TResult>
+{
+    /// <inheritdoc />
+    public static Task CancelJobAsync(Guid trackingId, CancellationToken ct = default)
+        => JobQueueWithReturnValue<TResult>.CancelJobAsync<TCommand>(trackingId, ct);
+
+    /// <inheritdoc />
+    public Task<TResult?> GetJobResultAsync(Guid trackingId, CancellationToken ct)
+        => JobQueueWithReturnValue<TResult>.GetJobResultAsync<TCommand>(trackingId, ct);
 }

--- a/Src/Library/Types.cs
+++ b/Src/Library/Types.cs
@@ -31,6 +31,7 @@ static class Types
     internal static readonly Type HideFromDocsAttribute = typeof(HideFromDocsAttribute);
     internal static readonly Type Http = typeof(Http);
     internal static readonly Type ICommand = typeof(ICommand);
+    internal static readonly Type ICommandOf1 = typeof(ICommand<>);
     internal static readonly Type ICommandHandler = typeof(ICommandHandler);
     internal static readonly Type ICommandHandlerOf1 = typeof(ICommandHandler<>);
     internal static readonly Type ICommandHandlerOf2 = typeof(ICommandHandler<,>);
@@ -51,6 +52,7 @@ static class Types
     internal static readonly Type IValidator = typeof(IValidator);
     internal static readonly Type JsonIgnoreAttribute = typeof(JsonIgnoreAttribute);
     internal static readonly Type JobQueueOf3 = typeof(JobQueue<,,>);
+    internal static readonly Type JobQueueOf4 = typeof(JobQueue<,,,>);
     internal static readonly Type NotImplementedAttribute = typeof(NotImplementedAttribute);
     internal static readonly Type Null = typeof(Null);
     internal static readonly Type Object = typeof(object);

--- a/Tests/IntegrationTests/FastEndpoints/MessagingTests/JobQueueTests.cs
+++ b/Tests/IntegrationTests/FastEndpoints/MessagingTests/JobQueueTests.cs
@@ -36,7 +36,39 @@ public class JobQueueTests(Sut App) : TestBase<Sut>
         JobStorage.Jobs.Clear();
     }
 
-    [Fact, Priority(2)]
+    [Fact, Priority(2), Trait("ExcludeInCiCd", "Yes")]
+    public async Task Job_Cancellation_With_Result()
+    {
+        var cts = new CancellationTokenSource(5000);
+        var jobs = new List<JobCancelWithResultTestCommand>();
+
+        await Parallel.ForAsync(
+            0,
+            99,
+            cts.Token,
+            async (_, ct) =>
+            {
+                var job = new JobCancelWithResultTestCommand();
+                jobs.Add(job);
+                job.TrackingId = await job.QueueJobAsync(ct: ct);
+            });
+
+        while (!cts.IsCancellationRequested && !jobs.TrueForAll(j => j.Counter > 0))
+            await Task.Delay(100, cts.Token);
+
+        var jt = App.Services.GetRequiredService<IJobTracker<JobCancelWithResultTestCommand, object>>();
+
+        foreach (var j in jobs)
+            _ = jt.CancelJobAsync(j.TrackingId, cts.Token);
+
+        while (!cts.IsCancellationRequested && !jobs.TrueForAll(j => j.IsCancelled))
+            await Task.Delay(100, cts.Token);
+
+        jobs.Should().OnlyContain(j => j.IsCancelled && j.Counter > 0);
+        JobStorage.Jobs.Clear();
+    }
+
+    [Fact, Priority(3)]
     public async Task Jobs_Execution()
     {
         var cts = new CancellationTokenSource(5000);
@@ -52,11 +84,44 @@ public class JobQueueTests(Sut App) : TestBase<Sut>
         }
 
         while (!cts.IsCancellationRequested && JobTestCommand.CompletedIDs.Count < 9)
-            await Task.Delay(100);
+            await Task.Delay(1000);
 
         JobTestCommand.CompletedIDs.Count.Should().Be(9);
         var expected = new[] { 0, 2, 3, 4, 5, 6, 7, 8, 9 };
         JobTestCommand.CompletedIDs.Except(expected).Any().Should().BeFalse();
+        JobStorage.Jobs.Clear();
+    }
+
+    [Fact, Priority(4)]
+    public async Task Jobs_With_Result_Execution()
+    {
+        var cts = new CancellationTokenSource(5000);
+        var dictionaryCommandIdTrackingId = new Dictionary<int, Guid>();
+
+        for (var i = 0; i < 10; i++)
+        {
+            var cmd = new JobWithResultTestCommand
+            {
+                Id = i,
+                ShouldThrow = i == 0
+            };
+            var trackingId = await cmd.QueueJobAsync(executeAfter: i == 1 ? DateTime.UtcNow.AddDays(1) : DateTime.UtcNow);
+            if(i != 1)
+                dictionaryCommandIdTrackingId.Add(i, trackingId);
+        }
+
+        while (!cts.IsCancellationRequested && JobWithResultTestCommand.CompletedIDs.Count < 9)
+            await Task.Delay(1000);
+
+        JobWithResultTestCommand.CompletedIDs.Count.Should().Be(9);
+        var expected = dictionaryCommandIdTrackingId.Select(x=>x.Key).ToArray();
+        JobWithResultTestCommand.CompletedIDs.Except(expected).Any().Should().BeFalse();
+        var jt = App.Services.GetRequiredService<IJobTracker<JobWithResultTestCommand, object>>();
+        foreach (var trackingId in dictionaryCommandIdTrackingId.Select(x=>x.Value))
+        {
+            var result = await jt.GetJobResultAsync(trackingId, cts.Token);
+            result.Should().NotBeNull();
+        }
         JobStorage.Jobs.Clear();
     }
 }

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -172,7 +172,9 @@ app.UseJobQueues(
     {
         o.MaxConcurrency = 4;
         o.LimitsFor<JobTestCommand>(1, TimeSpan.FromSeconds(1));
+        o.LimitsFor<JobWithResultTestCommand, object>(1, TimeSpan.FromSeconds(1));
         o.LimitsFor<JobCancelTestCommand>(100, TimeSpan.FromSeconds(60));
+        o.LimitsFor<JobCancelWithResultTestCommand, object>(100, TimeSpan.FromSeconds(60));
         o.StorageProbeDelay = TimeSpan.FromMilliseconds(100);
     });
 

--- a/Web/[Features]/TestCases/Messaging/JobQueueTest/JobCancelTestCommand.cs
+++ b/Web/[Features]/TestCases/Messaging/JobQueueTest/JobCancelTestCommand.cs
@@ -19,3 +19,23 @@ public class JobCancelTestCommandHandler : ICommandHandler<JobCancelTestCommand>
         cmd.IsCancelled = true;
     }
 }
+public class JobCancelWithResultTestCommand : ICommand<object>
+{
+    public Guid TrackingId { get; set; }
+    public int Counter { get; set; }
+    public bool IsCancelled { get; set; }
+}
+
+public class JobCancelWithResultTestCommandHandler : ICommandHandler<JobCancelWithResultTestCommand, object>
+{
+    public async Task<object> ExecuteAsync(JobCancelWithResultTestCommand cmd, CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            cmd.Counter++;
+            await Task.Delay(100);
+        }
+        cmd.IsCancelled = true;
+        return new object();
+    }
+}

--- a/Web/[Features]/TestCases/Messaging/JobQueueTest/JobTestCommand.cs
+++ b/Web/[Features]/TestCases/Messaging/JobQueueTest/JobTestCommand.cs
@@ -26,3 +26,30 @@ public class JobTestCommandHandler : ICommandHandler<JobTestCommand>
         return Task.CompletedTask;
     }
 }
+
+public class JobWithResultTestCommand : ICommand<object>
+{
+    public static List<int> CompletedIDs = new();
+
+    public int Id { get; set; }
+
+    public bool ShouldThrow { get; set; }
+    public int ThrowCount { get; set; }
+}
+
+public class JobWithResultTestCommandHandler : ICommandHandler<JobWithResultTestCommand, object>
+{
+    public Task<object> ExecuteAsync(JobWithResultTestCommand cmd, CancellationToken ct)
+    {
+        if (cmd is { ShouldThrow: true, ThrowCount: 0 })
+        {
+            cmd.ThrowCount++;
+
+            throw new InvalidOperationException();
+        }
+
+        JobWithResultTestCommand.CompletedIDs.Add(cmd.Id);
+
+        return Task.FromResult(new object());
+    }
+}

--- a/Web/[Features]/TestCases/Messaging/JobQueueTest/TestStorageProvider.cs
+++ b/Web/[Features]/TestCases/Messaging/JobQueueTest/TestStorageProvider.cs
@@ -6,6 +6,7 @@ public class Job : IJobStorageRecord
     public string QueueID { get; set; }
     public Guid TrackingID { get; set; }
     public object Command { get; set; }
+    public object? Result { get; set; }
     public DateTime ExecuteAfter { get; set; }
     public DateTime ExpireOn { get; set; }
     public bool IsComplete { get; set; }
@@ -51,6 +52,9 @@ public class JobStorage : IJobStorageProvider<Job>
 
         return Task.CompletedTask;
     }
+
+    public Task<Job?> GetJob(JobSearchParams<Job> parameters)
+        => Task.FromResult(Jobs.SingleOrDefault(parameters.Match.Compile()));
 
     public Task OnHandlerExecutionFailureAsync(Job r, Exception exception, CancellationToken ct)
         => Task.CompletedTask;


### PR DESCRIPTION
# JobQueues support for ICommand<>
[Enhancement]
It's my first contribution to the open source project.

## [TL:TR]
IJobStorageRecord receives fields and methods to store an optional result object.

IJobStoreProvider receives the optional method GetJob — used only to retrieve a job result from storage record.

JobQueueBase gets split into two classes:
- JobQueueWithoutReturnValue
- JobQueueWithReturnValue<>

New JobQueue instance with generic parameters <TCommand, TResult, TStorageRecord, TStorageProvider> to support TResult. Sadly, it's a copy of the above one.

JobQueueOptions gets LimitsFor<TCommand, TResult>.

New implementation for IJobTracker with support for return values and getting results by tracking id.

## [Why]
In my application I got asynchronous communication for commands between front and backend using JobQueues.
Now I need to implement a Result pattern that I achieved by doing some awful things like this 
![image](https://github.com/user-attachments/assets/3d9a9c43-d924-4f76-8f21-6d48b5be1cd0)


## Migration guide — if you don't want it (minimal)
- IJobStorageProvider.GetJob() ⇒ throw new NotImplementedException();
- add the field IJobStorageRecord.Result with [NotMapped] attribute


## Migration guide — normal
- implement IJobStorageProvider.GetJob()
- add the field IJobStorageRecord.Result
- if you want custom serialization and deserialization of a result, add [NotMapped] to the Result field and implement:
   * IJobStorageRecord.GetCommand<TCommand, TResult>()
   * IJobStorageRecord.GetResult<TCommand, TResult>()
   * IJobStorageRecord.SetCommand<TCommand, TResult>()
   * IJobStorageRecord.SetResult<TCommand, TResult>()
  
## Tests
Added two tests in JobQueueTests.
All tests passed.
Worked inside my private project.
