### PR TITLE
MAINT: update global config references to always use cfg

### DIFF
--- a/Src/Security/AuthExtensions.cs
+++ b/Src/Security/AuthExtensions.cs
@@ -70,8 +70,8 @@ public static class AuthExtensions
                         o.TokenValidationParameters.ValidateIssuer = false;
 
                         //set sensible defaults (based on configuration) for the claim mapping so tokens created with JWTBearer.CreateToken() will not be modified
-                        o.TokenValidationParameters.NameClaimType = Conf.SecOpts.NameClaimType;
-                        o.TokenValidationParameters.RoleClaimType = Conf.SecOpts.RoleClaimType;
+                        o.TokenValidationParameters.NameClaimType = Cfg.SecOpts.NameClaimType;
+                        o.TokenValidationParameters.RoleClaimType = Cfg.SecOpts.RoleClaimType;
                         o.MapInboundClaims = false;
 
                         bearerOptions?.Invoke(o);
@@ -183,7 +183,7 @@ public static class AuthExtensions
     /// </summary>
     /// <param name="permissionCode">the permission code to check for</param>
     public static bool HasPermission(this ClaimsPrincipal principal, string permissionCode)
-        => principal.FindAll(Conf.SecOpts.PermissionsClaimType).Select(c => c.Value).Contains(permissionCode);
+        => principal.FindAll(Cfg.SecOpts.PermissionsClaimType).Select(c => c.Value).Contains(permissionCode);
 
     /// <summary>
     /// determines if the current user principal has the given claim type

--- a/Src/Security/CookieAuth.cs
+++ b/Src/Security/CookieAuth.cs
@@ -18,9 +18,9 @@ public static class CookieAuth
     /// <exception cref="InvalidOperationException">thrown if the auth middleware hasn't been configure or method is used outside the scope of an http request</exception>
     public static Task SignInAsync(Action<UserPrivileges> privileges, Action<AuthenticationProperties>? properties = null)
     {
-        var svc = Conf.ServiceResolver.TryResolve<IAuthenticationService>() ?? throw new InvalidOperationException("Authentication middleware has not been configured!");
+        var svc = Cfg.ServiceResolver.TryResolve<IAuthenticationService>() ?? throw new InvalidOperationException("Authentication middleware has not been configured!");
 
-        var ctx = Conf.ServiceResolver.TryResolve<IHttpContextAccessor>()?.HttpContext ??
+        var ctx = Cfg.ServiceResolver.TryResolve<IHttpContextAccessor>()?.HttpContext ??
                   throw new InvalidOperationException("This operation is only valid during an http request!");
 
         var privs = new UserPrivileges();
@@ -32,15 +32,15 @@ public static class CookieAuth
             claimList.AddRange(privs.Claims);
 
         if (privs.Permissions.Count > 0)
-            claimList.AddRange(privs.Permissions.Select(p => new Claim(Conf.SecOpts.PermissionsClaimType, p)));
+            claimList.AddRange(privs.Permissions.Select(p => new Claim(Cfg.SecOpts.PermissionsClaimType, p)));
 
         if (privs.Roles.Count > 0)
-            claimList.AddRange(privs.Roles.Select(r => new Claim(Conf.SecOpts.RoleClaimType, r)));
+            claimList.AddRange(privs.Roles.Select(r => new Claim(Cfg.SecOpts.RoleClaimType, r)));
 
         var props = new AuthenticationProperties
         {
             IsPersistent = true,
-            IssuedUtc = (Conf.ServiceResolver.TryResolve<TimeProvider>() ?? TimeProvider.System).GetUtcNow()
+            IssuedUtc = (Cfg.ServiceResolver.TryResolve<TimeProvider>() ?? TimeProvider.System).GetUtcNow()
         };
 
         properties?.Invoke(props);
@@ -48,7 +48,7 @@ public static class CookieAuth
         return svc.SignInAsync(
             context: ctx,
             scheme: CookieAuthenticationDefaults.AuthenticationScheme,
-            principal: new(new ClaimsIdentity(claimList, CookieAuthenticationDefaults.AuthenticationScheme, null, Conf.SecOpts.RoleClaimType)),
+            principal: new(new ClaimsIdentity(claimList, CookieAuthenticationDefaults.AuthenticationScheme, null, Cfg.SecOpts.RoleClaimType)),
             properties: props);
     }
 
@@ -59,15 +59,15 @@ public static class CookieAuth
     /// <exception cref="InvalidOperationException">thrown if the auth middleware hasn't been configured or method is used outside the scope of a http request</exception>
     public static Task SignOutAsync(Action<AuthenticationProperties>? properties = null)
     {
-        var svc = Conf.ServiceResolver.TryResolve<IAuthenticationService>() ?? throw new InvalidOperationException("Authentication middleware has not been configured!");
+        var svc = Cfg.ServiceResolver.TryResolve<IAuthenticationService>() ?? throw new InvalidOperationException("Authentication middleware has not been configured!");
 
-        var ctx = Conf.ServiceResolver.TryResolve<IHttpContextAccessor>()?.HttpContext ??
+        var ctx = Cfg.ServiceResolver.TryResolve<IHttpContextAccessor>()?.HttpContext ??
                   throw new InvalidOperationException("This operation is only valid during an http request!");
 
         var props = new AuthenticationProperties
         {
             IsPersistent = true,
-            IssuedUtc = (Conf.ServiceResolver.TryResolve<TimeProvider>() ?? TimeProvider.System).GetUtcNow()
+            IssuedUtc = (Cfg.ServiceResolver.TryResolve<TimeProvider>() ?? TimeProvider.System).GetUtcNow()
         };
 
         properties?.Invoke(props);

--- a/Src/Security/JWTBearer.cs
+++ b/Src/Security/JWTBearer.cs
@@ -42,16 +42,16 @@ public static class JwtBearer
             claimList.AddRange(opts.User.Claims);
 
         if (opts.User.Permissions.Count > 0)
-            claimList.AddRange(opts.User.Permissions.Select(p => new Claim(Conf.SecOpts.PermissionsClaimType, p)));
+            claimList.AddRange(opts.User.Permissions.Select(p => new Claim(Cfg.SecOpts.PermissionsClaimType, p)));
 
         if (opts.User.Roles.Count > 0)
-            claimList.AddRange(opts.User.Roles.Select(r => new Claim(Conf.SecOpts.RoleClaimType, r)));
+            claimList.AddRange(opts.User.Roles.Select(r => new Claim(Cfg.SecOpts.RoleClaimType, r)));
 
         var descriptor = new SecurityTokenDescriptor
         {
             Issuer = opts.Issuer,
             Audience = opts.Audience,
-            IssuedAt = (Conf.ServiceResolver.TryResolve<TimeProvider>() ?? TimeProvider.System).GetUtcNow().UtcDateTime,
+            IssuedAt = (Cfg.ServiceResolver.TryResolve<TimeProvider>() ?? TimeProvider.System).GetUtcNow().UtcDateTime,
             Subject = new(claimList),
             Expires = opts.ExpireAt,
             SigningCredentials = GetSigningCredentials(opts)

--- a/Src/Security/RefreshTokens/RefreshTokenService.cs
+++ b/Src/Security/RefreshTokens/RefreshTokenService.cs
@@ -143,7 +143,7 @@ public abstract class RefreshTokenService<TRequest, TResponse> : Endpoint<TReque
         if (isRenewal && request is not null)
             await SetRenewalPrivilegesAsync((TRequest)request, privs);
 
-        var time = Conf.ServiceResolver.TryResolve<TimeProvider>() ?? TimeProvider.System;
+        var time = Cfg.ServiceResolver.TryResolve<TimeProvider>() ?? TimeProvider.System;
         var accessExpiry = time.GetUtcNow().Add(_opts.AccessTokenValidity).UtcDateTime;
         var refreshExpiry = time.GetUtcNow().Add(_opts.RefreshTokenValidity).UtcDateTime;
         var jOpts = new JwtCreationOptions

--- a/Src/Security/Usings.cs
+++ b/Src/Security/Usings.cs
@@ -1,1 +1,1 @@
-﻿global using Conf = FastEndpoints.Config;
+﻿global using Cfg = FastEndpoints.Config;

--- a/Src/Swagger/Extensions.cs
+++ b/Src/Swagger/Extensions.cs
@@ -41,7 +41,7 @@ public static class Extensions
         services.AddOpenApiDocument(
             (genSettings, serviceProvider) =>
             {
-                var stjOpts = new JsonSerializerOptions(Conf.SerOpts.Options);
+                var stjOpts = new JsonSerializerOptions(Cfg.SerOpts.Options);
                 SelectedJsonNamingPolicy = stjOpts.PropertyNamingPolicy;
                 doc.SerializerSettings?.Invoke(stjOpts);
                 var newtonsoftOpts = SystemTextJsonUtilities.ConvertJsonOptionsToNewtonsoftSettings(stjOpts);

--- a/Src/Swagger/GlobalConfig.cs
+++ b/Src/Swagger/GlobalConfig.cs
@@ -1,4 +1,4 @@
-﻿global using Conf = FastEndpoints.Config;
+﻿global using Cfg = FastEndpoints.Config;
 
 namespace FastEndpoints.Swagger;
 
@@ -10,22 +10,22 @@ public static class GlobalConfig
     /// <summary>
     /// the prefix used in front of the version (for example 'v' produces 'v{version}').
     /// </summary>
-    public static string? VersioningPrefix => Conf.VerOpts.Prefix;
+    public static string? VersioningPrefix => Cfg.VerOpts.Prefix;
 
     /// <summary>
     /// prefix for all routes (example 'api').
     /// </summary>
-    public static string? EndpointRoutePrefix => Conf.EpOpts.RoutePrefix;
+    public static string? EndpointRoutePrefix => Cfg.EpOpts.RoutePrefix;
 
     /// <summary>
     /// Asp.Versioning.Http library is being used for versioning
     /// </summary>
-    public static bool IsUsingAspVersioning => Conf.VerOpts.IsUsingAspVersioning;
+    public static bool IsUsingAspVersioning => Cfg.VerOpts.IsUsingAspVersioning;
 
     /// <summary>
     /// allows the use of empty request dtos
     /// </summary>
-    public static bool AllowEmptyRequestDtos => Conf.EpOpts.AllowEmptyRequestDtos;
+    public static bool AllowEmptyRequestDtos => Cfg.EpOpts.AllowEmptyRequestDtos;
 
     /// <summary>
     /// this route constraint type map will be used to determine the type for a route parameter if there's no matching property on the request dto.


### PR DESCRIPTION
Previously most areas of the code used cfg but two used Conf. This change is to sync up everything to use cfg.

This should address #756.