### PR TITLE
Allow HttpClientExtensions.ToForm to have nullable forms

### DIFF
--- a/Src/Library/Testing/HttpClientExtensions.cs
+++ b/Src/Library/Testing/HttpClientExtensions.cs
@@ -384,7 +384,7 @@ public static class HttpClientExtensions
                 continue;
 
             if (p.PropertyType.GetUnderlyingType() == Types.IFormFile)
-                AddFileToForm((IFormFile)p.GetValue(req)!, p);
+                AddFileToForm((IFormFile)p.GetValue(req), p);
 
             else if (p.PropertyType.IsAssignableTo(Types.IEnumerableOfIFormFile))
             {
@@ -404,8 +404,9 @@ public static class HttpClientExtensions
                    ? throw new InvalidOperationException("Converting the request DTO to MultipartFormDataContent was unsuccessful!")
                    : form;
 
-        void AddFileToForm(IFormFile file, MemberInfo prop)
+        void AddFileToForm(IFormFile? file, MemberInfo prop)
         {
+            if (file is null) return;
             var content = new StreamContent(file.OpenReadStream());
 
             // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract

--- a/Src/Library/Testing/HttpClientExtensions.cs
+++ b/Src/Library/Testing/HttpClientExtensions.cs
@@ -384,7 +384,7 @@ public static class HttpClientExtensions
                 continue;
 
             if (p.PropertyType.GetUnderlyingType() == Types.IFormFile)
-                AddFileToForm((IFormFile)p.GetValue(req), p);
+                AddFileToForm(p.GetValue(req) as IFormFile, p);
 
             else if (p.PropertyType.IsAssignableTo(Types.IEnumerableOfIFormFile))
             {
@@ -406,7 +406,9 @@ public static class HttpClientExtensions
 
         void AddFileToForm(IFormFile? file, MemberInfo prop)
         {
-            if (file is null) return;
+            if (file is null)
+                return;
+
             var content = new StreamContent(file.OpenReadStream());
 
             // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract

--- a/Web/[Features]/Uploads/Image/SaveTyped/Models.cs
+++ b/Web/[Features]/Uploads/Image/SaveTyped/Models.cs
@@ -11,6 +11,7 @@ public class Request
     public IFormFile File1 { get; set; }
     public IFormFile File2 { get; set; }
     public IFormFile? File3 { get; set; }
+    public IFormFile? File4 { get; set; }
 
     public IEnumerable<IFormFile> Cars { get; set; }
     public IFormFileCollection Jets { get; set; }
@@ -21,11 +22,11 @@ public class Validator : Validator<Request>
     public Validator()
     {
         RuleFor(i => i.Width)
-           .GreaterThan(10).WithMessage("Image width too small")
-           .LessThan(2000).WithMessage("Image width is too large");
+            .GreaterThan(10).WithMessage("Image width too small")
+            .LessThan(2000).WithMessage("Image width is too large");
 
         RuleFor(i => i.Height)
-           .GreaterThan(10).WithMessage("Image height too small")
-           .LessThan(2000).WithMessage("Image width is too large");
+            .GreaterThan(10).WithMessage("Image height too small")
+            .LessThan(2000).WithMessage("Image width is too large");
     }
 }


### PR DESCRIPTION
I have a use case where a file is submitted together with other form data. The file itself is optional. Updated the test extension method so it can handle null files.