### PR TITLE
Fix multipart form data when it consists for JSON objects

### DIFF
--- a/Src/Library/Testing/HttpClientExtensions.cs
+++ b/Src/Library/Testing/HttpClientExtensions.cs
@@ -422,7 +422,11 @@ public static class HttpClientExtensions
                     AddFileToForm(file, p);
             }
             else
-                form.Add(new StringContent(p.GetValue(req)?.ToString() ?? ""), p.Name);
+            {
+                var value = p.GetValue(req);
+                var stringValue = value is not null ? JsonSerializer.Serialize(value) : null;
+                form.Add(new StringContent(stringValue ?? ""), p.Name);
+            }
         }
 
         return !form.Any()

--- a/Src/Library/Testing/HttpClientExtensions.cs
+++ b/Src/Library/Testing/HttpClientExtensions.cs
@@ -424,8 +424,8 @@ public static class HttpClientExtensions
             else
             {
                 var value = p.GetValue(req);
-                var stringValue = value is not null ? JsonSerializer.Serialize(value) : null;
-                form.Add(new StringContent(stringValue ?? ""), p.Name);
+                if (value is not null)
+                    form.Add(new StringContent(JsonSerializer.Serialize(value, SerOpts.Options)), p.Name);
             }
         }
 

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -70,4 +70,28 @@ This has been fixed by implementing a caching mechanism per property type.
 
 </details>
 
+<details><summary>Complex DTO handling in routeless testing extensions</summary>
+
+If the request DTO is a complex structure, testing with routeless test extensions like the following did not work correctly:
+
+```cs
+[Fact]
+public async Task FormDataTest()
+{
+    var book = new Book
+    {
+        BarCodes = [1, 2, 3],
+        CoAuthors = [new Author { Name = "a1" }, new Author { Name = "a2" }],
+        MainAuthor = new() { Name = "main" }
+    };
+
+    var (rsp, res) = await App.GuestClient.PUTAsync<MyEndpoint, Book, Book>(book, sendAsFormData: true);
+
+    rsp.IsSuccessStatusCode.Should().BeTrue();
+    res.Should().BeEquivalentTo(book);    
+}
+```
+
+</details>
+
 ## Minor Breaking Changes ⚠️

--- a/Tests/IntegrationTests/FastEndpoints.Swagger/release-0.json
+++ b/Tests/IntegrationTests/FastEndpoints.Swagger/release-0.json
@@ -1933,6 +1933,37 @@
             "description": "No Content"
           }
         }
+      },
+      "put": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesFormBindingComplexDtosToFormEndpoint",
+        "requestBody": {
+          "x-name": "Book",
+          "description": "",
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesFormBindingComplexDtosBook"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestCasesFormBindingComplexDtosBook"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/api/test-cases/form-file-collection-binding": {

--- a/Tests/IntegrationTests/FastEndpoints.Swagger/release-1.json
+++ b/Tests/IntegrationTests/FastEndpoints.Swagger/release-1.json
@@ -1998,6 +1998,37 @@
             "description": "No Content"
           }
         }
+      },
+      "put": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesFormBindingComplexDtosToFormEndpoint",
+        "requestBody": {
+          "x-name": "Book",
+          "description": "",
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesFormBindingComplexDtosBook"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestCasesFormBindingComplexDtosBook"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/api/test-cases/form-file-collection-binding": {

--- a/Tests/IntegrationTests/FastEndpoints.Swagger/release-2.json
+++ b/Tests/IntegrationTests/FastEndpoints.Swagger/release-2.json
@@ -2148,6 +2148,37 @@
             "description": "No Content"
           }
         }
+      },
+      "put": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesFormBindingComplexDtosToFormEndpoint",
+        "requestBody": {
+          "x-name": "Book",
+          "description": "",
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesFormBindingComplexDtosBook"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestCasesFormBindingComplexDtosBook"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/api/test-cases/form-file-collection-binding": {

--- a/Tests/IntegrationTests/FastEndpoints/BindingTests/BindingTests.cs
+++ b/Tests/IntegrationTests/FastEndpoints/BindingTests/BindingTests.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using TestCases.CustomRequestBinder;
+using TestCases.FormBindingComplexDtos;
 using TestCases.QueryObjectWithObjectsArrayBindingTest;
 using ByteEnum = TestCases.QueryObjectBindingTest.ByteEnum;
 using Endpoint = TestCases.JsonArrayBindingToListOfModels.Endpoint;
@@ -656,6 +657,22 @@ public class BindingTests(Sut App) : TestBase<Sut>
         res.File2Name.Should().Be("test2.png");
         res.CarNames.Should().Equal("car1.png", "car2.png");
         res.JetNames.Should().Equal("jet1.png", "jet2.png");
+    }
+
+    [Fact]
+    public async Task ComplexFormDataBindingViaSendAsFormData()
+    {
+        var book = new Book
+        {
+            BarCodes = [1, 2, 3],
+            CoAuthors = [new Author { Name = "a1" }, new Author { Name = "a2" }],
+            MainAuthor = new() { Name = "main" }
+        };
+
+        var (rsp, res) = await App.GuestClient.PUTAsync<ToFormEndpoint, Book, Book>(book, sendAsFormData: true);
+
+        rsp.IsSuccessStatusCode.Should().BeTrue();
+        res.Should().BeEquivalentTo(book);
     }
 
     [Fact]

--- a/Web/[Features]/TestCases/Binding/FormBindingComplexDtos/Endpoint.cs
+++ b/Web/[Features]/TestCases/Binding/FormBindingComplexDtos/Endpoint.cs
@@ -50,3 +50,18 @@ sealed class Endpoint : Endpoint<Request>
         return Task.CompletedTask;
     }
 }
+
+sealed class ToFormEndpoint : Endpoint<Book, Book>
+{
+    public override void Configure()
+    {
+        Put("test-cases/form-binding-complex-dtos");
+        AllowAnonymous();
+        AllowFileUploads();
+    }
+
+    public override async Task HandleAsync(Book r, CancellationToken ct)
+    {
+        await SendAsync(r);
+    }
+}


### PR DESCRIPTION
I have recently faced a problem POSTing multipart form data using client.POSTAsync<TEndpoint, TRequest, TResponse>(...).
The problem is caused by the .ToString() call that just saves the object type name instead of serializing it. Therefore, it's better to call JsonSerializer.Serialize() instead of .ToString(), so that complex values can be handled properly.  

How to reproduce:
1. Prepare a request containing complex values, for example an array of other objects
2. Send the request using POSTAsync

Actual result: A validation error happens "MyType[] is not valid for a property MyType[]"
Expected result: No validation errors 