### PR TITLE
FastEndpoints.Testing.TestBase class documentation fix

### DIFF
--- a/Src/Testing/TestBase.cs
+++ b/Src/Testing/TestBase.cs
@@ -25,14 +25,14 @@ public abstract class TestBase : IAsyncLifetime, IFaker
 
     /// <summary>
     /// override this method if you'd like to do some one-time setup for the test-class.
-    /// it is run before any of the test-methods of the class is executed.
+    /// it is run before each of the test-methods of the class is executed.
     /// </summary>
     protected virtual ValueTask SetupAsync()
         => ValueTask.CompletedTask;
 
     /// <summary>
     /// override this method if you'd like to do some one-time teardown for the test-class.
-    /// it is run after all test-methods have executed.
+    /// it is run after each of the test-methods of the class is executed.
     /// </summary>
     protected virtual ValueTask TearDownAsync()
         => ValueTask.CompletedTask;


### PR DESCRIPTION
This pull request includes a minor but important update to the documentation comments in the `Src/Testing/TestBase.cs` file. The changes clarify the behavior of the `SetupAsync` and `TearDownAsync` methods.

Documentation updates:

* [`Src/Testing/TestBase.cs`](diffhunk://#diff-af5a4b9f14706af44f5e5dac2b3173e2111af5d297ed5c22a35ad7f51a9c9569L28-R35): Updated comments to specify that `SetupAsync` and `TearDownAsync` are run before and after each test method, respectively, instead of once for the entire test class.

fixes #865 