### PR TITLE
Only retry EventHub init Tasks that failed

### DIFF
--- a/Src/Messaging/Messaging.Remote/LoggingExtensions.cs
+++ b/Src/Messaging/Messaging.Remote/LoggingExtensions.cs
@@ -4,6 +4,9 @@ namespace FastEndpoints.Messaging.Remote;
 
 static partial class LoggingExtensions
 {
+    [LoggerMessage(1, LogLevel.Error, "Event hub storage provider failed to restore {tEvent} event Subscriber IDs. Retrying in 5 seconds...")]
+    public static partial void RestoreSubscriberIDsError(this ILogger l, string tEvent);
+
     [LoggerMessage(2, LogLevel.Information, "Event subscriber connected! [id:{subscriberId}]({tEvent})")]
     public static partial void SubscriberConnected(this ILogger l, string subscriberId, string tEvent);
 

--- a/Src/Messaging/Messaging.Remote/LoggingExtensions.cs
+++ b/Src/Messaging/Messaging.Remote/LoggingExtensions.cs
@@ -4,7 +4,7 @@ namespace FastEndpoints.Messaging.Remote;
 
 static partial class LoggingExtensions
 {
-    [LoggerMessage(1, LogLevel.Error, "Event hub storage provider failed to restore {tEvent} event Subscriber IDs. Retrying in 5 seconds...")]
+    [LoggerMessage(1, LogLevel.Error, "Storage provider failed to restore Subscriber IDs for [{tEvent}]. Retrying in 5 seconds...")]
     public static partial void RestoreSubscriberIDsError(this ILogger l, string tEvent);
 
     [LoggerMessage(2, LogLevel.Information, "Event subscriber connected! [id:{subscriberId}]({tEvent})")]

--- a/Src/Messaging/Messaging.Remote/Server/Events/EventHubExceptionReceiver.cs
+++ b/Src/Messaging/Messaging.Remote/Server/Events/EventHubExceptionReceiver.cs
@@ -1,4 +1,4 @@
-﻿// ReSharper disable UnusedParameter.Global
+// ReSharper disable UnusedParameter.Global
 
 namespace FastEndpoints;
 
@@ -7,6 +7,18 @@ namespace FastEndpoints;
 /// </summary>
 public abstract class EventHubExceptionReceiver
 {
+    /// <summary>
+    /// this method is triggered when the storage provider has trouble restoring event subscribers.
+    /// </summary>
+    /// <param name="eventType">the type of the event</param>
+    /// <param name="attemptCount">the number of times the subscriber were attempted to be retrieved</param>
+    /// <param name="exception">the actual exception that was thrown by the operation</param>
+    /// <param name="ct">cancellation token</param>
+    public virtual Task OnRestoreSubscriberIDsError(Type eventType, int attemptCount,
+                                                          Exception exception,
+                                                          CancellationToken ct)
+        => Task.CompletedTask;
+
     /// <summary>
     /// this method is triggered when the storage provider has trouble retrieving the next event record.
     /// </summary>

--- a/Src/Messaging/Messaging.Remote/Server/Events/EventHubExceptionReceiver.cs
+++ b/Src/Messaging/Messaging.Remote/Server/Events/EventHubExceptionReceiver.cs
@@ -14,9 +14,7 @@ public abstract class EventHubExceptionReceiver
     /// <param name="attemptCount">the number of times the subscriber were attempted to be retrieved</param>
     /// <param name="exception">the actual exception that was thrown by the operation</param>
     /// <param name="ct">cancellation token</param>
-    public virtual Task OnRestoreSubscriberIDsError(Type eventType, int attemptCount,
-                                                          Exception exception,
-                                                          CancellationToken ct)
+    public virtual Task OnRestoreSubscriberIDsError(Type eventType, int attemptCount, Exception exception, CancellationToken ct)
         => Task.CompletedTask;
 
     /// <summary>
@@ -27,10 +25,8 @@ public abstract class EventHubExceptionReceiver
     /// <param name="attemptCount">the number of times the record was attempted to be retrieved</param>
     /// <param name="exception">the actual exception that was thrown by the operation</param>
     /// <param name="ct">cancellation token</param>
-    public virtual Task OnGetNextEventRecordError<TEvent>(string subscriberID,
-                                                          int attemptCount,
-                                                          Exception exception,
-                                                          CancellationToken ct) where TEvent : class, IEvent
+    public virtual Task OnGetNextEventRecordError<TEvent>(string subscriberID, int attemptCount, Exception exception, CancellationToken ct)
+        where TEvent : class, IEvent
         => Task.CompletedTask;
 
     /// <summary>
@@ -41,10 +37,8 @@ public abstract class EventHubExceptionReceiver
     /// <param name="attemptCount">the number of times the record was attempted to be marked complete</param>
     /// <param name="exception">the actual exception that was thrown by the operation</param>
     /// <param name="ct">cancellation token</param>
-    public virtual Task OnMarkEventAsCompleteError<TEvent>(IEventStorageRecord record,
-                                                           int attemptCount,
-                                                           Exception exception,
-                                                           CancellationToken ct) where TEvent : class, IEvent
+    public virtual Task OnMarkEventAsCompleteError<TEvent>(IEventStorageRecord record, int attemptCount, Exception exception, CancellationToken ct)
+        where TEvent : class, IEvent
         => Task.CompletedTask;
 
     /// <summary>
@@ -55,10 +49,8 @@ public abstract class EventHubExceptionReceiver
     /// <param name="attemptCount">the number of times the record was attempted to be persisted</param>
     /// <param name="exception">the actual exception that was thrown by the operation</param>
     /// <param name="ct">cancellation token</param>
-    public virtual Task OnStoreEventRecordError<TEvent>(IEventStorageRecord record,
-                                                        int attemptCount,
-                                                        Exception exception,
-                                                        CancellationToken ct) where TEvent : class, IEvent
+    public virtual Task OnStoreEventRecordError<TEvent>(IEventStorageRecord record, int attemptCount, Exception exception, CancellationToken ct)
+        where TEvent : class, IEvent
         => Task.CompletedTask;
 
     /// <summary>
@@ -67,7 +59,6 @@ public abstract class EventHubExceptionReceiver
     /// <typeparam name="TEvent">the type of the event</typeparam>
     /// <param name="record">the event storage record that was supposed to be added to the queue</param>
     /// <param name="ct">cancellation token</param>
-    public virtual Task OnInMemoryQueueOverflow<TEvent>(IEventStorageRecord record,
-                                                        CancellationToken ct) where TEvent : class, IEvent
+    public virtual Task OnInMemoryQueueOverflow<TEvent>(IEventStorageRecord record, CancellationToken ct) where TEvent : class, IEvent
         => Task.CompletedTask;
 }


### PR DESCRIPTION
Made some changes to only retry the failed EventHub initializations.
And some extra additions:
- Logging via source generator
- Added check if it is an in-memory storage provider and skipped initialization, since in that case it makes no sense
- Combined the 30 sec timeout CancellationToken together with the app shutdown CancellationToken
- Added an virtual OnRestoreSubscriberIDsError (for consistency with other places in the class)