### PR TITLE
Added closed generics support for command jobs

### DIFF
--- a/Src/Library/Messaging/Commands/CommandExtensions.cs
+++ b/Src/Library/Messaging/Commands/CommandExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace FastEndpoints;
@@ -106,6 +106,19 @@ public static class CommandExtensions
         {
             HandlerExecutor = new FakeCommandHandlerExecutor<TCommand, TResult>(handler)
         };
+    }
+
+    /// <summary>
+    /// register a generic command handler for a generic command
+    /// </summary>
+    /// <typeparam name="TCommand">the type of the command</typeparam>
+    /// <typeparam name="THandler">the type of the command handler</typeparam>
+    /// <returns></returns>
+    public static IServiceProvider RegisterGenericCommand<TCommand, THandler>(this IServiceProvider sp)
+        where TCommand : ICommand
+        where THandler : ICommandHandler
+    {
+        return RegisterGenericCommand(sp, typeof(TCommand), typeof(THandler));
     }
 
     /// <summary>

--- a/Src/Library/Messaging/Commands/CommandExtensions.cs
+++ b/Src/Library/Messaging/Commands/CommandExtensions.cs
@@ -114,12 +114,8 @@ public static class CommandExtensions
     /// <typeparam name="TCommand">the type of the command</typeparam>
     /// <typeparam name="THandler">the type of the command handler</typeparam>
     /// <returns></returns>
-    public static IServiceProvider RegisterGenericCommand<TCommand, THandler>(this IServiceProvider sp)
-        where TCommand : ICommand
-        where THandler : ICommandHandler
-    {
-        return RegisterGenericCommand(sp, typeof(TCommand), typeof(THandler));
-    }
+    public static IServiceProvider RegisterGenericCommand<TCommand, THandler>(this IServiceProvider sp) where TCommand : ICommand where THandler : ICommandHandler
+        => RegisterGenericCommand(sp, typeof(TCommand), typeof(THandler));
 
     /// <summary>
     /// register a generic command handler for a generic command

--- a/Src/Library/Messaging/Jobs/JobQueueExtensions.cs
+++ b/Src/Library/Messaging/Jobs/JobQueueExtensions.cs
@@ -44,15 +44,15 @@ public static class JobQueueExtensions
         var registry = app.ApplicationServices.GetRequiredService<CommandHandlerRegistry>();
 
         if (registry.IsEmpty)
-            throw new InvalidOperationException("No Commands/Handlers found in the system! Have you called AddFastEndpoints() yet?");
+            throw new InvalidOperationException("No Commands/Handlers found in the system! Have you called yet AddFastEndpoints() on the IServiceCollection, or RegisterGenericCommand previously on the WebApplication?");
 
         var opts = new JobQueueOptions();
         options?.Invoke(opts);
 
         foreach (var tCommand in registry.Keys.Where(t => t.IsAssignableTo(Types.ICommandBase)))
         {
-            if (tCommand.IsGenericType)
-                continue; //NOTE: no generic command support for jobs.
+            if (!tCommand.IsGenericTypeDefinition)
+                continue; //NOTE: no open generic command support for jobs.
 
             var tResult = tCommand.GetInterface(typeof(ICommand<>).Name)!.GetGenericArguments()[0];
 

--- a/Src/Library/Messaging/Jobs/JobQueueExtensions.cs
+++ b/Src/Library/Messaging/Jobs/JobQueueExtensions.cs
@@ -51,7 +51,7 @@ public static class JobQueueExtensions
 
         foreach (var tCommand in registry.Keys.Where(t => t.IsAssignableTo(Types.ICommandBase)))
         {
-            if (!tCommand.IsGenericTypeDefinition)
+            if (tCommand.ContainsGenericParameters)
                 continue; //NOTE: no open generic command support for jobs.
 
             var tResult = tCommand.GetInterface(typeof(ICommand<>).Name)!.GetGenericArguments()[0];

--- a/Tests/IntegrationTests/FastEndpoints/MessagingTests/JobQueueTests.cs
+++ b/Tests/IntegrationTests/FastEndpoints/MessagingTests/JobQueueTests.cs
@@ -1,4 +1,5 @@
-﻿using TestCases.JobQueueTest;
+using TestCases.EventHandlingTest;
+using TestCases.JobQueueTest;
 
 namespace Messaging;
 
@@ -181,5 +182,25 @@ public class JobQueueTests(Sut App) : TestBase<Sut>
         }
 
         res!.Result.ShouldBe(name);
+    }
+
+    [Fact, Priority(8)]
+    public async Task Job_Generic_Command()
+    {
+        var cts = new CancellationTokenSource(5000);
+        
+        var cmd = new JobTestGenericCommand<SomeEvent>
+        {
+            Id = 1,
+            Event = new SomeEvent()
+        };
+        await cmd.QueueJobAsync(ct: cts.Token);
+        
+        while (!cts.IsCancellationRequested && JobTestGenericCommand<SomeEvent>.CompletedIDs.Count == 0)
+            await Task.Delay(100, Cancellation);
+
+        JobTestGenericCommand<SomeEvent>.CompletedIDs.Count.ShouldBe(1);
+        JobTestGenericCommand<SomeEvent>.CompletedIDs.Contains(1);
+        JobStorage.Jobs.Clear();
     }
 }

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -5,6 +5,7 @@ using NSwag;
 using TestCases.ClientStreamingTest;
 using TestCases.CommandBusTest;
 using TestCases.CommandHandlerTest;
+using TestCases.EventHandlingTest;
 using TestCases.EventQueueTest;
 using TestCases.JobQueueTest;
 using TestCases.KeyedServicesTests;
@@ -214,6 +215,7 @@ if (!app.Environment.IsProduction())
 
 app.Services.RegisterGenericCommand(typeof(GenericCommand<>), typeof(GenericCommandHandler<>));
 app.Services.RegisterGenericCommand(typeof(GenericNoResultCommand<>), typeof(GenericNoResultCommandHandler<>));
+app.Services.RegisterGenericCommand<JobTestGenericCommand<SomeEvent>, JobTestGenericCommandHandler<SomeEvent>>();
 
 app.MapHandlers(
     h =>

--- a/Web/[Features]/TestCases/Messaging/JobQueueTest/JobTestGenericCommand.cs
+++ b/Web/[Features]/TestCases/Messaging/JobQueueTest/JobTestGenericCommand.cs
@@ -1,0 +1,21 @@
+namespace TestCases.JobQueueTest;
+
+public class JobTestGenericCommand<TEvent> : ICommand
+    where TEvent : IEvent
+{
+    public static readonly List<int> CompletedIDs = [];
+
+    public int Id { get; set; }
+    public TEvent Event { get; set; }
+}
+
+public class JobTestGenericCommandHandler<TEvent> : ICommandHandler<JobTestGenericCommand<TEvent>>
+    where TEvent : IEvent
+{
+    public Task ExecuteAsync(JobTestGenericCommand<TEvent> cmd, CancellationToken ct)
+    {
+        JobTestGenericCommand<TEvent>.CompletedIDs.Add(cmd.Id);
+
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Currently the UseJobQueues registration ignores registered command types that are generic (both open and closed generics), because it wants to create a JobQueue<,,,> instance using the MakeGenericType method which does not support open generics type parameters. Actually the generic type check is too broad, since closed generic types are supported with the MakeGenericType method.

Making the generics check more specific to only allow closed generics, allows an user to register a closed generic command and use it as a job like this:

 ```cs
// Definitions
public class OrderCreatedEvent : IEvent;

public class QueueCommand<TEvent> : ICommand where TEvent : IEvent
{
    public required TEvent Event { get; set; }
}

public class QueueCommandHandler<TEvent> : ICommandHandler<QueueCommand<TEvent>> where TEvent : IEvent
{
    public async Task ExecuteAsync(QueueCommand<TEvent> command, CancellationToken ct)
    {
        // handle command
        await Task.Delay(1000);
    }
}

// DI registration
var app = bld.Build();
app.Services.RegisterGenericCommand(typeof(QueueCommand<OrderCreatedEvent>), typeof(QueueCommandHandler<OrderCreatedEvent>));
// or with the added overload
app.Services.RegisterGenericCommand<QueueCommand<OrderCreatedEvent>, QueueCommandHandler<OrderCreatedEvent>>();

// Usage
public override async Task HandleAsync(ExtraRequest req, CancellationToken ct)
{
    var queueCommand = new QueueCommand<OrderCreatedEvent>()
    { 
        Event = new OrderCreatedEvent() 
    };

    await queueCommand.QueueJobAsync();

    await SendAsync(req);
}
```