### PR TITLE
Added extra regex source generators

### DIFF
--- a/Src/Generator/Extensions.cs
+++ b/Src/Generator/Extensions.cs
@@ -1,33 +1,41 @@
-﻿#pragma warning disable IDE1006
-    using System.Text;
-    using System.Text.RegularExpressions;
-    using Microsoft.CodeAnalysis;
+#pragma warning disable IDE1006
+using System.Text;
+using Microsoft.CodeAnalysis;
 
-    namespace FastEndpoints.Generator;
+namespace FastEndpoints.Generator;
 
-    static class Extensions
+static class Extensions
+{
+    // ReSharper disable once InconsistentNaming
+    internal static StringBuilder w(this StringBuilder sb, string? val)
     {
-        // ReSharper disable once InconsistentNaming
-        internal static StringBuilder w(this StringBuilder sb, string? val)
-        {
-            sb.Append(val);
+        sb.Append(val);
 
-            return sb;
-        }
-
-        static readonly Regex _regex = new("[^a-zA-Z0-9]+", RegexOptions.Compiled);
-
-        internal static string Sanitize(this string input, string replacement = "_")
-            => _regex.Replace(input, replacement);
-
-        internal static ITypeSymbol GetUnderlyingType(this ITypeSymbol symbol)
-        {
-            if (symbol is { IsReferenceType: true, NullableAnnotation: NullableAnnotation.Annotated })
-                return symbol.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
-
-            if (symbol.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T && symbol is INamedTypeSymbol namedTypeSymbol)
-                return namedTypeSymbol.TypeArguments[0];
-
-            return symbol;
-        }
+        return sb;
     }
+
+    internal static string Sanitize(this string input)
+    {
+        var result = new StringBuilder();
+        foreach (var c in input)
+        {
+            if (char.IsLetterOrDigit(c) || c == '_')
+            {
+                result.Append(c);
+            }
+        }
+
+        return result.ToString();
+    }
+
+    internal static ITypeSymbol GetUnderlyingType(this ITypeSymbol symbol)
+    {
+        if (symbol is { IsReferenceType: true, NullableAnnotation: NullableAnnotation.Annotated })
+            return symbol.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
+
+        if (symbol.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T && symbol is INamedTypeSymbol namedTypeSymbol)
+            return namedTypeSymbol.TypeArguments[0];
+
+        return symbol;
+    }
+}

--- a/Src/Generator/Extensions.cs
+++ b/Src/Generator/Extensions.cs
@@ -1,5 +1,5 @@
-#pragma warning disable IDE1006
 using System.Text;
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 
 namespace FastEndpoints.Generator;
@@ -14,19 +14,10 @@ static class Extensions
         return sb;
     }
 
-    internal static string Sanitize(this string input)
-    {
-        var result = new StringBuilder();
-        foreach (var c in input)
-        {
-            if (char.IsLetterOrDigit(c) || c == '_')
-            {
-                result.Append(c);
-            }
-        }
+    static readonly Regex _regex = new("[^a-zA-Z0-9]+", RegexOptions.Compiled);
 
-        return result.ToString();
-    }
+    internal static string Sanitize(this string input, string replacement = "_")
+        => _regex.Replace(input, replacement);
 
     internal static ITypeSymbol GetUnderlyingType(this ITypeSymbol symbol)
     {

--- a/Src/Generator/ReflectionGenerator.cs
+++ b/Src/Generator/ReflectionGenerator.cs
@@ -65,7 +65,7 @@ public class ReflectionGenerator : IIncrementalGenerator
     {
         _assemblyName ??= "Assembly"; //when no endpoints are present
 
-        var sanitizedAssemblyName = _assemblyName.Sanitize(string.Empty);
+        var sanitizedAssemblyName = _assemblyName.Sanitize();
 
         b.Clear().w(
             """

--- a/Src/Generator/ReflectionGenerator.cs
+++ b/Src/Generator/ReflectionGenerator.cs
@@ -65,7 +65,7 @@ public class ReflectionGenerator : IIncrementalGenerator
     {
         _assemblyName ??= "Assembly"; //when no endpoints are present
 
-        var sanitizedAssemblyName = _assemblyName.Sanitize();
+        var sanitizedAssemblyName = _assemblyName.Sanitize(string.Empty);
 
         b.Clear().w(
             """

--- a/Src/Generator/ServiceRegistrationGenerator.cs
+++ b/Src/Generator/ServiceRegistrationGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -57,7 +57,7 @@ public class ServiceRegistrationGenerator : IIncrementalGenerator
 
               public static class ServiceRegistrationExtensions
               {
-                  public static IServiceCollection RegisterServicesFrom{{_assemblyName?.Sanitize(string.Empty) ?? "Assembly"}}(this IServiceCollection sc)
+                  public static IServiceCollection RegisterServicesFrom{{_assemblyName?.Sanitize() ?? "Assembly"}}(this IServiceCollection sc)
                   {
 
               """);

--- a/Src/Generator/ServiceRegistrationGenerator.cs
+++ b/Src/Generator/ServiceRegistrationGenerator.cs
@@ -57,7 +57,7 @@ public class ServiceRegistrationGenerator : IIncrementalGenerator
 
               public static class ServiceRegistrationExtensions
               {
-                  public static IServiceCollection RegisterServicesFrom{{_assemblyName?.Sanitize() ?? "Assembly"}}(this IServiceCollection sc)
+                  public static IServiceCollection RegisterServicesFrom{{_assemblyName?.Sanitize(string.Empty) ?? "Assembly"}}(this IServiceCollection sc)
                   {
 
               """);

--- a/Src/Library/Endpoint/Auxiliary/EndpointExtensions.cs
+++ b/Src/Library/Endpoint/Auxiliary/EndpointExtensions.cs
@@ -99,15 +99,13 @@ static partial class EndpointExtensions
         def.Version.Init();
     }
 
-    [GeneratedRegex("(@[\\w]*)", RegexOptions.Compiled)]
+    [GeneratedRegex("(@[\\w]*)")]
     private static partial Regex RouteBuilderRegex();
-
-    static readonly Regex _rgx = RouteBuilderRegex();
 
     internal static string BuildRoute<TRequest>(this Expression<Func<TRequest, object>> expr, string pattern) where TRequest : notnull
     {
         var sb = new StringBuilder(pattern);
-        var matches = _rgx.Matches(pattern);
+        var matches = RouteBuilderRegex().Matches(pattern);
         var i = 0;
 
         foreach (var prop in expr.PropNames())

--- a/Src/Library/Endpoint/Endpoint.Base.cs
+++ b/Src/Library/Endpoint/Endpoint.Base.cs
@@ -46,9 +46,7 @@ public abstract partial class BaseEndpoint : IEndpoint
     protected virtual void Group<TEndpointGroup>() where TEndpointGroup : Group, new()
         => throw new NotImplementedException();
 
-    static readonly Regex _letterOrDigitRegex = LetterOrDigitRegex();
-
-    [GeneratedRegex("[^a-zA-Z0-9]+", RegexOptions.Compiled)]
+    [GeneratedRegex("[^a-zA-Z0-9]+")]
     private static partial Regex LetterOrDigitRegex();
 
     protected static string GetAclHash(string input)
@@ -59,6 +57,6 @@ public abstract partial class BaseEndpoint : IEndpoint
         return new(base64Hash.Where(char.IsLetterOrDigit).Take(3).Select(char.ToUpper).ToArray());
 
         static string Sanitize(string input)
-            => _letterOrDigitRegex.Replace(input, "_");
+            => LetterOrDigitRegex().Replace(input, "_");
     }
 }

--- a/Src/Library/Endpoint/Endpoint.Base.cs
+++ b/Src/Library/Endpoint/Endpoint.Base.cs
@@ -1,9 +1,8 @@
 using FluentValidation.Results;
+using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
 using System.Security.Cryptography;
 using System.Text;
-using System.Text.RegularExpressions;
-using JetBrains.Annotations;
 
 namespace FastEndpoints;
 
@@ -46,11 +45,6 @@ public abstract partial class BaseEndpoint : IEndpoint
     protected virtual void Group<TEndpointGroup>() where TEndpointGroup : Group, new()
         => throw new NotImplementedException();
 
-    static readonly Regex _regex = LetterOrDigitRegex();
-
-    [GeneratedRegex("[^a-zA-Z0-9]+", RegexOptions.Compiled)]
-    private static partial Regex LetterOrDigitRegex();
-
     protected static string GetAclHash(string input)
     {
         //NOTE: if modifying this algo, update FastEndpoints.Generator.AccessControlGenerator.Permission.GetAclHash() method also!
@@ -59,6 +53,25 @@ public abstract partial class BaseEndpoint : IEndpoint
         return new(base64Hash.Where(char.IsLetterOrDigit).Take(3).Select(char.ToUpper).ToArray());
 
         static string Sanitize(string input)
-            => _regex.Replace(input, "_");
+        {
+            var result = new StringBuilder();
+            char? previousChar = null;
+            var replacement = '_';
+            foreach (var c in input)
+            {
+                if (char.IsLetterOrDigit(c))
+                {
+                    result.Append(c);
+                    previousChar = c;
+                }
+                else if (previousChar != replacement)
+                {
+                    result.Append(replacement);
+                    previousChar = replacement;
+                }
+            }
+
+            return result.ToString();
+        }
     }
 }

--- a/Src/Library/Endpoint/Endpoint.Base.cs
+++ b/Src/Library/Endpoint/Endpoint.Base.cs
@@ -1,4 +1,4 @@
-﻿using FluentValidation.Results;
+using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
 using System.Security.Cryptography;
 using System.Text;
@@ -10,7 +10,7 @@ namespace FastEndpoints;
 /// <summary>
 /// the base class all fast endpoints inherit from
 /// </summary>
-public abstract class BaseEndpoint : IEndpoint
+public abstract partial class BaseEndpoint : IEndpoint
 {
     List<ValidationFailure>? _failures;
 
@@ -46,7 +46,10 @@ public abstract class BaseEndpoint : IEndpoint
     protected virtual void Group<TEndpointGroup>() where TEndpointGroup : Group, new()
         => throw new NotImplementedException();
 
-    static readonly Regex _regex = new("[^a-zA-Z0-9]+", RegexOptions.Compiled);
+    static readonly Regex _regex = LetterOrDigitRegex();
+
+    [GeneratedRegex("[^a-zA-Z0-9]+", RegexOptions.Compiled)]
+    private static partial Regex LetterOrDigitRegex();
 
     protected static string GetAclHash(string input)
     {

--- a/Src/Library/Endpoint/Endpoint.Base.cs
+++ b/Src/Library/Endpoint/Endpoint.Base.cs
@@ -3,6 +3,7 @@ using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace FastEndpoints;
 
@@ -45,6 +46,11 @@ public abstract partial class BaseEndpoint : IEndpoint
     protected virtual void Group<TEndpointGroup>() where TEndpointGroup : Group, new()
         => throw new NotImplementedException();
 
+    static readonly Regex _letterOrDigitRegex = LetterOrDigitRegex();
+
+    [GeneratedRegex("[^a-zA-Z0-9]+", RegexOptions.Compiled)]
+    private static partial Regex LetterOrDigitRegex();
+
     protected static string GetAclHash(string input)
     {
         //NOTE: if modifying this algo, update FastEndpoints.Generator.AccessControlGenerator.Permission.GetAclHash() method also!
@@ -53,25 +59,6 @@ public abstract partial class BaseEndpoint : IEndpoint
         return new(base64Hash.Where(char.IsLetterOrDigit).Take(3).Select(char.ToUpper).ToArray());
 
         static string Sanitize(string input)
-        {
-            var result = new StringBuilder();
-            char? previousChar = null;
-            var replacement = '_';
-            foreach (var c in input)
-            {
-                if (char.IsLetterOrDigit(c))
-                {
-                    result.Append(c);
-                    previousChar = c;
-                }
-                else if (previousChar != replacement)
-                {
-                    result.Append(replacement);
-                    previousChar = replacement;
-                }
-            }
-
-            return result.ToString();
-        }
+            => _letterOrDigitRegex.Replace(input, "_");
     }
 }

--- a/Src/Library/FastEndpoints.csproj
+++ b/Src/Library/FastEndpoints.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <NoWarn>1701;1702;CS1591;CS1573,CA2254;RCS1079;CS8618;IDE0022</NoWarn>
-        <Description>A light-weight REST Api framework for ASP.Net 6 and newer that implements REPR (Request-Endpoint-Response) Pattern.</Description>
+        <Description>A light-weight REST Api framework for ASP.Net 8 and newer that implements REPR (Request-Endpoint-Response) Pattern.</Description>
         <PackageIcon>icon.png</PackageIcon>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>http, rest, rest-api, web-api, webapi, aspnet, aspnetcore, dotnet6, minimal-api, vertical-slice-architecture, repr-pattern</PackageTags>

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -42,6 +42,12 @@ sealed class MyPreProcessor<TRequest> : IPreProcessor<TRequest>
 
 ## Improvements 🚀
 
+<details><summary>Use source generated regex</summary>
+
+Source generated regex is now used whereever possible. Source generated regex was not used before due to having to support older SDK versions.
+
+</details>
+
 ## Fixes 🪲
 
 <details><summary>Contention issue in reflection source generator</summary>

--- a/Src/Swagger/OperationProcessor.cs
+++ b/Src/Swagger/OperationProcessor.cs
@@ -22,14 +22,12 @@ namespace FastEndpoints.Swagger;
 sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationProcessor
 {
     static readonly TextInfo _textInfo = CultureInfo.InvariantCulture.TextInfo;
-    static readonly Regex _routeParamsRegex = RouteParamsRegex();
-    static readonly Regex _routeConstraintsRegex = RouteConstraintsRegex();
     static readonly string[] _illegalHeaderNames = ["Accept", "Content-Type", "Authorization"];
 
-    [GeneratedRegex("(?<={)(?:.*?)*(?=})", RegexOptions.Compiled)]
+    [GeneratedRegex("(?<={)(?:.*?)*(?=})")]
     private static partial Regex RouteParamsRegex();
 
-    [GeneratedRegex("(?<={)([^?:}]+)[^}]*(?=})", RegexOptions.Compiled)]
+    [GeneratedRegex("(?<={)([^?:}]+)[^}]*(?=})")]
     private static partial Regex RouteConstraintsRegex();
 
     static readonly Dictionary<string, string> _defaultDescriptions = new()
@@ -141,7 +139,6 @@ sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationPro
             if (metas.Count > 0)
             {
             #if NET9_0_OR_GREATER
-
                 //remove this workaround when sdk bug is fixed: https://github.com/dotnet/aspnetcore/issues/57801#issuecomment-2439578287
                 foreach (var meta in metas.Where(m => m.Value.isIResult))
                 {
@@ -372,7 +369,7 @@ sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationPro
         var paramCtx = new ParamCreationContext(ctx, docOpts, serializer, reqParamDescriptions, apiDescription.RelativePath!);
 
         //add a path param for each route param such as /{xxx}/{yyy}/{zzz}
-        var reqParams = _routeParamsRegex
+        var reqParams = RouteParamsRegex()
                         .Matches(opPath)
                         .Select(
                             m =>
@@ -711,7 +708,7 @@ sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationPro
         var parts = relativePath.Split('/');
 
         for (var i = 0; i < parts.Length; i++)
-            parts[i] = _routeConstraintsRegex.Replace(parts[i], "$1");
+            parts[i] = RouteConstraintsRegex().Replace(parts[i], "$1");
 
         return string.Join("/", parts);
     }

--- a/Src/Swagger/OperationProcessor.cs
+++ b/Src/Swagger/OperationProcessor.cs
@@ -1,6 +1,5 @@
 using System.Collections;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using System.Text.Json.Serialization;
@@ -20,13 +19,18 @@ using JsonIgnoreAttribute = System.Text.Json.Serialization.JsonIgnoreAttribute;
 
 namespace FastEndpoints.Swagger;
 
-[SuppressMessage("Performance", "SYSLIB1045:Convert to \'GeneratedRegexAttribute\'.")]
-sealed class OperationProcessor(DocumentOptions docOpts) : IOperationProcessor
+sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationProcessor
 {
     static readonly TextInfo _textInfo = CultureInfo.InvariantCulture.TextInfo;
-    static readonly Regex _routeParamsRegex = new("(?<={)(?:.*?)*(?=})", RegexOptions.Compiled);
-    static readonly Regex _routeConstraintsRegex = new("(?<={)([^?:}]+)[^}]*(?=})", RegexOptions.Compiled);
+    static readonly Regex _routeParamsRegex = RouteParamsRegex();
+    static readonly Regex _routeConstraintsRegex = RouteConstraintsRegex();
     static readonly string[] _illegalHeaderNames = ["Accept", "Content-Type", "Authorization"];
+
+    [GeneratedRegex("(?<={)(?:.*?)*(?=})", RegexOptions.Compiled)]
+    private static partial Regex RouteParamsRegex();
+
+    [GeneratedRegex("(?<={)([^?:}]+)[^}]*(?=})", RegexOptions.Compiled)]
+    private static partial Regex RouteConstraintsRegex();
 
     static readonly Dictionary<string, string> _defaultDescriptions = new()
     {


### PR DESCRIPTION
Added a regex source generator in the BaseEndpoint and 2 in the OperationProcessor for Swagger.
Noticed that v6 will only support net8.0+ so I updated also the nuget package description.