### PR TITLE
Added TriggerJobExecution<TCommand> overload

### DIFF
--- a/Src/Library/Messaging/Jobs/JobQueue.cs
+++ b/Src/Library/Messaging/Jobs/JobQueue.cs
@@ -39,12 +39,10 @@ abstract class JobQueueBase
                    : (TStorageRecord)queue.CreateJob(command, executeAfter, expireOn);
     }
 
-    internal static void TriggerJobExecution(ICommandBase command)
+    internal static void TriggerJobExecution(Type commandType)
     {
-        var tCommand = command.GetType();
-
-        if (!JobQueues.TryGetValue(tCommand, out var queue))
-            throw new InvalidOperationException($"A job queue has not been registered for [{tCommand.FullName}]");
+        if (!JobQueues.TryGetValue(commandType, out var queue))
+            throw new InvalidOperationException($"A job queue has not been registered for [{commandType.FullName}]");
 
         queue.TriggerJob();
     }

--- a/Src/Library/Messaging/Jobs/JobQueueExtensions.cs
+++ b/Src/Library/Messaging/Jobs/JobQueueExtensions.cs
@@ -90,7 +90,14 @@ public static class JobQueueExtensions
     /// </summary>
     /// <param name="cmd">the command used to determine which queue to trigger</param>
     public static void TriggerJobExecution(this ICommandBase cmd)
-        => JobQueueBase.TriggerJobExecution(cmd);
+        => JobQueueBase.TriggerJobExecution(cmd.GetType());
+
+    /// <summary>
+    /// triggers the execution of jobs in the respective queue for that command type.
+    /// </summary>
+    /// <typeparam name="TCommand">the command type used to determine which queue to trigger</typeparam>
+    public static void TriggerJobExecution<TCommand>() where TCommand : ICommandBase
+        => JobQueueBase.TriggerJobExecution(typeof(TCommand));
 
     /// <summary>
     /// queues up a given command in the respective job queue for that command type.

--- a/Tests/IntegrationTests/FastEndpoints/MessagingTests/JobQueueTests.cs
+++ b/Tests/IntegrationTests/FastEndpoints/MessagingTests/JobQueueTests.cs
@@ -116,8 +116,9 @@ public class JobQueueTests(Sut App) : TestBase<Sut>
             };
             var job = cmd.CreateJob<Job>(executeAfter: i == 1 ? DateTime.UtcNow.AddDays(1) : DateTime.UtcNow);
             JobStorage.Jobs.Add(job);
-            cmd.TriggerJobExecution();
         }
+
+        JobQueueExtensions.TriggerJobExecution<JobTestCommand>();
 
         while (!cts.IsCancellationRequested && JobTestCommand.CompletedIDs.Count < 9)
             await Task.Delay(100, Cancellation);


### PR DESCRIPTION
Added an an extra overload, with just the command type as parameter, to trigger job executions.  With this overload you don't need to keep a reference to an job instance just to trigger them all, which is convenient when queueing multiple jobs. See the change in the JobQueueTests unit test class how it would benefit.
What are your thoughts @dj-nitehawk?