### PR TITLE
Made Endpoint Verbs method with Http methods public available

### DIFF
--- a/Src/Library/Config/EndpointOptions.cs
+++ b/Src/Library/Config/EndpointOptions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 
 namespace FastEndpoints;
 
@@ -16,10 +16,15 @@ public sealed class EndpointOptions
     static string EndpointNameGenerator(EndpointNameGenerationContext ctx)
     {
         ctx.TagPrefix = ctx is { PrefixNameWithFirstTag: true, TagPrefix: not null } ? $"{ctx.TagPrefix}_" : null;
-        ctx.HttpVerb = ctx.HttpVerb != null ? ctx.HttpVerb[0] + ctx.HttpVerb[1..].ToLowerInvariant() : null;
+        string? httpVerb = null;
+        if (ctx.HttpVerb.HasValue)
+        {
+            var httpVerbValue = ctx.HttpVerb.Value.ToString();
+            httpVerb = $"{httpVerbValue[0]}{httpVerbValue[1..].ToLowerInvariant()}";
+        }
         var ep = ctx.ShortEndpointNames ? ctx.EndpointType.Name : ctx.EndpointType.FullName!.Replace(".", string.Empty);
 
-        return $"{ctx.TagPrefix}{ctx.HttpVerb}{ep}{ctx.RouteNumber}";
+        return $"{ctx.TagPrefix}{httpVerb}{ep}{ctx.RouteNumber}";
     }
 
     /// <summary>
@@ -83,10 +88,10 @@ public sealed class EndpointOptions
     public Action<HttpContext, object?>? GlobalResponseModifier { internal get; set; }
 }
 
-public struct EndpointNameGenerationContext(Type endpointType, string? httpVerb, int? routeNumber, string? tagPrefix)
+public struct EndpointNameGenerationContext(Type endpointType, Http? httpVerb, int? routeNumber, string? tagPrefix)
 {
     public Type EndpointType { get; internal init; } = endpointType;
-    public string? HttpVerb { get; internal set; } = httpVerb;
+    public Http? HttpVerb { get; internal set; } = httpVerb;
     public int? RouteNumber { get; internal init; } = routeNumber;
     public string? TagPrefix { get; internal set; } = tagPrefix;
     public bool PrefixNameWithFirstTag => Cfg.EpOpts.PrefixNameWithFirstTag;

--- a/Src/Library/Endpoint/Auxiliary/EndpointDefinition.cs
+++ b/Src/Library/Endpoint/Auxiliary/EndpointDefinition.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
@@ -27,7 +27,7 @@ public sealed class EndpointDefinition(Type endpointType, Type requestDtoType, T
     public string[] Routes { get; internal set; } = [];
     public string SecurityPolicyName => $"epPolicy:{EndpointType.FullName}";
     public Type? ValidatorType { get; internal set; }
-    public string[] Verbs { get; internal set; } = [];
+    public Http[] Verbs { get; internal set; } = [];
     public EpVersion Version { get; } = new();
 
     //these props can be changed in global config using methods below
@@ -36,7 +36,7 @@ public sealed class EndpointDefinition(Type endpointType, Type requestDtoType, T
     public bool AllowAnyClaim { get; private set; }
     public List<string>? AllowedClaimTypes { get; private set; }
     public List<string>? AllowedRoles { get; private set; }
-    public string[]? AnonymousVerbs { get; private set; }
+    public Http[]? AnonymousVerbs { get; private set; }
     public bool AntiforgeryEnabled { get; private set; }
     public List<string>? AuthSchemeNames { get; private set; }
     public bool DontAutoSend { get; private set; }
@@ -90,16 +90,8 @@ public sealed class EndpointDefinition(Type endpointType, Type requestDtoType, T
     {
         AnonymousVerbs =
             verbs.Length > 0
-                ? verbs.Select(v => v.ToString("F")).ToArray()
-                : Enum.GetNames(Types.Http);
-    }
-
-    /// <summary>
-    /// allow unauthenticated requests to this endpoint for a specified set of http verbs.
-    /// </summary>
-    public void AllowAnonymous(string[] verbs)
-    {
-        AnonymousVerbs = verbs;
+                ? verbs
+                : Enum.GetValues<Http>();
     }
 
     /// <summary>
@@ -137,12 +129,6 @@ public sealed class EndpointDefinition(Type endpointType, Type requestDtoType, T
     /// specify extra http verbs in addition to the endpoint level verbs.
     /// </summary>
     public void AdditionalVerbs(params Http[] verbs)
-        => Verbs = [..Verbs, ..verbs.Select(m => m.ToString())];
-
-    /// <summary>
-    /// specify extra http verbs in addition to the endpoint level verbs.
-    /// </summary>
-    public void AdditionalVerbs(params string[] verbs)
         => Verbs = [..Verbs, ..verbs];
 
     /// <summary>

--- a/Src/Library/Endpoint/Auxiliary/EndpointExtensions.cs
+++ b/Src/Library/Endpoint/Auxiliary/EndpointExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq.Expressions;
+using System.Linq.Expressions;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Authorization;
@@ -46,7 +46,7 @@ static partial class EndpointExtensions
                 switch (att)
                 {
                     case HttpAttribute httpAttr:
-                        instance.Verbs(httpAttr.Verb.ToString("F"));
+                        instance.Verbs(httpAttr.Verb);
                         def.Routes = httpAttr.Routes;
 
                         break;

--- a/Src/Library/Endpoint/Endpoint.Base.cs
+++ b/Src/Library/Endpoint/Endpoint.Base.cs
@@ -35,7 +35,7 @@ public abstract partial class BaseEndpoint : IEndpoint
     public virtual void Configure()
         => throw new NotImplementedException();
 
-    public virtual void Verbs(params string[] methods)
+    public virtual void Verbs(params Http[] methods)
         => throw new NotImplementedException();
 
     [UsedImplicitly]

--- a/Src/Library/Endpoint/Endpoint.Setup.cs
+++ b/Src/Library/Endpoint/Endpoint.Setup.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.Json;
@@ -73,14 +73,6 @@ public abstract partial class Endpoint<TRequest, TResponse> where TRequest : not
     /// authentication.
     /// </summary>
     protected void AllowAnonymous(params Http[] verbs)
-        => Definition.AllowAnonymous(verbs);
-
-    /// <summary>
-    /// allow unauthenticated requests to this endpoint for a specified set of http verbs.
-    /// i.e. if the endpoint is listening to POST, PUT &amp; PATCH and you specify AllowAnonymous(Http.POST), then only PUT &amp; PATCH will require
-    /// authentication.
-    /// </summary>
-    protected void AllowAnonymous(string[] verbs)
         => Definition.AllowAnonymous(verbs);
 
     /// <summary>
@@ -598,13 +590,7 @@ public abstract partial class Endpoint<TRequest, TResponse> where TRequest : not
     /// <summary>
     /// specify one or more http method verbs this endpoint should be accepting requests for
     /// </summary>
-    protected void Verbs(params Http[] methods)
-        => Verbs(methods.Select(m => m.ToString()).ToArray());
-
-    /// <summary>
-    /// specify one or more http method verbs this endpoint should be accepting requests for
-    /// </summary>
-    public sealed override void Verbs(params string[] methods)
+    public sealed override void Verbs(params Http[] methods)
     {
         //note: this method is sealed to not allow user to override it because we need to perform
         //      the following setup activities, which require access to TRequest/TResponse
@@ -637,7 +623,7 @@ public abstract partial class Endpoint<TRequest, TResponse> where TRequest : not
 
                 if (tRequest != Types.EmptyRequest)
                 {
-                    if (methods.Any(m => m is "GET" or "HEAD" or "DELETE"))
+                    if (methods.Any(m => m is Http.GET or Http.HEAD or Http.DELETE))
                         b.Accepts<TRequest>("*/*", "application/json");
                     else
                         b.Accepts<TRequest>("application/json");

--- a/Src/Library/Extensions/HttpResponseExtensions.cs
+++ b/Src/Library/Extensions/HttpResponseExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using FluentValidation.Results;
@@ -82,7 +82,7 @@ public static class HttpResponseExtensions
                                                      CancellationToken cancellation = default) where TEndpoint : IEndpoint
         => SendCreatedAtAsync(
             rsp,
-            EpOpts.NameGenerator(new(typeof(TEndpoint), verb?.ToString("F"), routeNumber, null)),
+            EpOpts.NameGenerator(new(typeof(TEndpoint), verb, routeNumber, null)),
             routeValues,
             responseBody,
             jsonSerializerContext,

--- a/Src/Library/Main/MainExtensions.cs
+++ b/Src/Library/Main/MainExtensions.cs
@@ -137,7 +137,7 @@ public static class MainExtensions
                 {
                     var hb = app.MapMethods(
                         finalRoute,
-                        [verb],
+                        [verb.ToString()],
                         (HttpContext ctx, [FromServices] IEndpointFactory factory) => RequestHandler.Invoke(ctx, factory));
 
                     hb.WithName(


### PR DESCRIPTION
Made the Endpoint Verbs method with Http[] parameters public available and removed the one with string[] parameters, since in my opinion people should use the defined Http enum instead of passing in a magic string. Since the next version will be a major version bump 6.x I think a small breaking change is acceptable.
Maybe for completeness we could extend the Http enum with Connect and Trace since those are valid values for a Http Method, although I doubt FE users are using those. Let me know your thoughts about it @dj-nitehawk 