### PR TITLE
Optimized item removal from collections

### DIFF
--- a/Src/Library/Binder/BinderExtensions.cs
+++ b/Src/Library/Binder/BinderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
@@ -361,12 +361,12 @@ static class BinderExtensions
                 if (ti.Kind != JsonTypeInfoKind.Object)
                     return;
 
-                for (var i = 0; i < ti.Properties.Count; i++)
+                for (var i = ti.Properties.Count - 1; i >= 0; i--)
                 {
                     var pi = ti.Properties[i];
 
                     if (pi.AttributeProvider?.IsDefined(Types.FromHeaderAttribute, true) is true && pi.PropertyType.Name.EndsWith("HeaderValue"))
-                        ti.Properties.Remove(pi);
+                        ti.Properties.RemoveAt(i);
                 }
             });
     }

--- a/Src/Library/Endpoint/Auxiliary/EndpointDefinition.cs
+++ b/Src/Library/Endpoint/Auxiliary/EndpointDefinition.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
@@ -175,8 +175,11 @@ public sealed class EndpointDefinition(Type endpointType, Type requestDtoType, T
               b.Add(
                   epBuilder =>
                   {
-                      foreach (var m in epBuilder.Metadata.Where(o => o.GetType().Name is ProducesMetadata or AcceptsMetaData).ToArray())
-                          epBuilder.Metadata.Remove(m);
+                      for (var i = epBuilder.Metadata.Count - 1; i >= 0; i--)
+                      {
+                          if (epBuilder.Metadata[i].GetType().Name is ProducesMetadata or AcceptsMetaData)
+                              epBuilder.Metadata.RemoveAt(i);
+                      }
                   });
           };
 

--- a/Src/Library/Endpoint/Endpoint.Setup.cs
+++ b/Src/Library/Endpoint/Endpoint.Setup.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.Json;
@@ -581,8 +581,11 @@ public abstract partial class Endpoint<TRequest, TResponse> where TRequest : not
                 b.Add(
                     eb =>
                     {
-                        foreach (var m in eb.Metadata.OfType<IProducesResponseTypeMetadata>().ToArray())
-                            eb.Metadata.Remove(m);
+                        for (var i = eb.Metadata.Count - 1; i >= 0; i--)
+                        {
+                            if (eb.Metadata[i] is IProducesResponseTypeMetadata)
+                                eb.Metadata.RemoveAt(i);
+                        }
                     });
 
                 var tRequest = typeof(TRequest);

--- a/Src/Library/Endpoint/Summary/EndpointSummary.cs
+++ b/Src/Library/Endpoint/Summary/EndpointSummary.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http.Metadata;
 using System.Linq.Expressions;
 
@@ -16,10 +16,10 @@ public class EndpointSummary
         = b => b.Add(
               epBuilder =>
               {
-                  foreach (var m in epBuilder.Metadata.OfType<IProducesResponseTypeMetadata>().ToArray())
+                  for (var i = epBuilder.Metadata.Count - 1; i >= 0; i--)
                   {
-                      if (m.StatusCode == 200)
-                          epBuilder.Metadata.Remove(m);
+                      if (epBuilder.Metadata[i] is IProducesResponseTypeMetadata m && m.StatusCode == 200)
+                          epBuilder.Metadata.RemoveAt(i);
                   }
               });
 

--- a/Src/Library/Main/RouteHandlerBuilderExtensions.cs
+++ b/Src/Library/Main/RouteHandlerBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
 
@@ -45,12 +45,10 @@ public static class RouteHandlerBuilderExtensions
         hb.Add(
             epBuilder =>
             {
-                var metaData = epBuilder.Metadata.ToArray(); //need to make a copy since we're modifying the list
-
-                for (var i = 0; i < metaData.Length; i++)
+                for (var i = epBuilder.Metadata.Count - 1; i >= 0; i--)
                 {
-                    if (metaData[i] is IAcceptsMetadata)
-                        epBuilder.Metadata.Remove(metaData[i]);
+                    if (epBuilder.Metadata[i] is IAcceptsMetadata)
+                        epBuilder.Metadata.RemoveAt(i);
                 }
             });
 
@@ -67,12 +65,10 @@ public static class RouteHandlerBuilderExtensions
         hb.Add(
             epBuilder =>
             {
-                var metaData = epBuilder.Metadata.ToArray(); //need to make a copy since we're modifying the list
-
-                for (var i = 0; i < metaData.Length; i++)
+                for (var i = epBuilder.Metadata.Count - 1; i >= 0; i--)
                 {
-                    if (metaData[i] is IProducesResponseTypeMetadata meta && (statusCodes.Length == 0 || statusCodes.Contains(meta.StatusCode)))
-                        epBuilder.Metadata.Remove(metaData[i]);
+                    if (epBuilder.Metadata[i] is IProducesResponseTypeMetadata meta && (statusCodes.Length == 0 || statusCodes.Contains(meta.StatusCode)))
+                        epBuilder.Metadata.RemoveAt(i);
                 }
             });
 

--- a/Src/Messaging/Messaging.Remote/Server/Events/EventHub.cs
+++ b/Src/Messaging/Messaging.Remote/Server/Events/EventHub.cs
@@ -329,12 +329,15 @@ sealed class EventHub<TEvent, TStorageRecord, TStorageProvider> : EventHubBase, 
             }
             catch (OverflowException) when (IsInMemoryProvider)
             {
-                foreach (var rec in records.Cast<InMemoryEventStorageRecord>().Where(r => r.QueueOverflowed))
+                foreach (var rec in records)
                 {
-                    _subscribers.Remove(rec.SubscriberID, out var sub);
-                    sub?.Sem.Dispose();
-                    _errors?.OnInMemoryQueueOverflow<TEvent>(rec, _appCancellation);
-                    _logger.QueueOverflowWarning(rec.SubscriberID, _tEvent.FullName!);
+                    if (rec is InMemoryEventStorageRecord storageRecord && storageRecord.QueueOverflowed)
+                    {
+                        _subscribers.Remove(rec.SubscriberID, out var sub);
+                        sub?.Sem.Dispose();
+                        _errors?.OnInMemoryQueueOverflow<TEvent>(rec, _appCancellation);
+                        _logger.QueueOverflowWarning(rec.SubscriberID, _tEvent.FullName!);
+                    }
                 }
 
                 break;

--- a/Src/Swagger/DocumentProcessor.cs
+++ b/Src/Swagger/DocumentProcessor.cs
@@ -1,4 +1,4 @@
-﻿using NSwag.Generation.Processors;
+using NSwag.Generation.Processors;
 using NSwag.Generation.Processors.Contexts;
 
 namespace FastEndpoints.Swagger;
@@ -88,7 +88,7 @@ sealed class DocumentProcessor : IDocumentProcessor
 
         foreach (var p in ctx.Document.Paths)
         {
-            var isFastEp = p.Value.SelectMany(o => o.Value.Tags).Any(t => t.StartsWith("|"));
+            var isFastEp = p.Value.SelectMany(o => o.Value.Tags).Any(t => t.StartsWith('|'));
 
             if (!isFastEp)
                 continue; //this isn't a fastendpoint. so don't remove it from the paths
@@ -98,7 +98,7 @@ sealed class DocumentProcessor : IDocumentProcessor
 
             foreach (var op in p.Value)
             {
-                var tagSegments = op.Value.Tags.SingleOrDefault(t => t.StartsWith("|"))?.Split("|");
+                var tagSegments = op.Value.Tags.SingleOrDefault(t => t.StartsWith('|'))?.Split('|');
                 var depVer = Convert.ToInt32(tagSegments?[4]);
 
                 // var epVer = Convert.ToInt32(tagSegments?[2]);
@@ -117,7 +117,7 @@ sealed class DocumentProcessor : IDocumentProcessor
                 if (isDeprecated && !_showDeprecated)
                     p.Value.Remove(op.Key);
 
-                op.Value.Tags.Remove(op.Value.Tags.SingleOrDefault(t => t.StartsWith("|")));
+                op.Value.Tags.Remove(op.Value.Tags.SingleOrDefault(t => t.StartsWith('|')));
             }
         }
 

--- a/Src/Swagger/OperationProcessor.cs
+++ b/Src/Swagger/OperationProcessor.cs
@@ -296,9 +296,11 @@ sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationPro
         if (GlobalConfig.IsUsingAspVersioning)
         {
             //because asp-versioning adds the version route segment as a path parameter
-            foreach (var prm in apiDescription.ParameterDescriptions.ToArray()
-                                              .Where(p => p.Source != Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource.Body))
-                apiDescription.ParameterDescriptions.Remove(prm);
+            for (var i = apiDescription.ParameterDescriptions.Count - 1; i >= 0; i--)
+            {
+                if (apiDescription.ParameterDescriptions[i].Source != Microsoft.AspNetCore.Mvc.ModelBinding.BindingSource.Body)
+                    apiDescription.ParameterDescriptions.RemoveAt(i);
+            }
         }
 
         var reqDtoType = apiDescription.ParameterDescriptions.FirstOrDefault()?.Type;
@@ -491,8 +493,12 @@ sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationPro
             if (GlobalConfig.IsUsingAspVersioning)
             {
                 //remove any duplicate params - ref: https://github.com/FastEndpoints/FastEndpoints/issues/560
-                foreach (var prm in op.Parameters.Where(prm => prm.Name == p.Name && prm.Kind == p.Kind).ToArray())
-                    op.Parameters.Remove(prm);
+                for (var i = op.Parameters.Count - 1; i >= 0; i--)
+                {
+                    var prm = op.Parameters[i];
+                    if (prm.Name == p.Name && prm.Kind == p.Kind)
+                        op.Parameters.RemoveAt(i);
+                }
             }
 
             op.Parameters.Add(p);
@@ -507,8 +513,11 @@ sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationPro
             if (reqDtoIsList is false)
             {
                 op.RequestBody = null;
-                foreach (var body in op.Parameters.Where(x => x.Kind == OpenApiParameterKind.Body).ToArray())
-                    op.Parameters.Remove(body);
+                for (var i = op.Parameters.Count - 1; i >= 0; i--)
+                {
+                    if (op.Parameters[i].Kind == OpenApiParameterKind.Body)
+                        op.Parameters.RemoveAt(i);
+                }
             }
         }
 


### PR DESCRIPTION
Changed the logic in various places for removing an item from a collection from using an foreach with an extra .ToArray() (needed because collections can't be modified while iterating), to just a reversed for loop. This reduces the need for the extra .ToArray() call. 

Also switched from using the .Remove(...) method to .RemoveAt(...) because .Remove(...) internally first has to do determine the index of the item using an .IndexOf call. Since we have the index available we can just use it directly with the .RemoveAt(...) call.

@dj-nitehawk let me know your thoughts.