### PR TITLE
Add support for annotation attributes ProducesResponseType and SwaggerResponse #924

### DIFF
--- a/Src/Library/Endpoint/Auxiliary/EndpointExtensions.cs
+++ b/Src/Library/Endpoint/Auxiliary/EndpointExtensions.cs
@@ -1,8 +1,9 @@
-﻿using System.Linq.Expressions;
+using System.Linq.Expressions;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using static FastEndpoints.Config;
 
 namespace FastEndpoints;
@@ -75,6 +76,21 @@ static partial class EndpointExtensions
 
                     case ThrottleAttribute thrtAttr:
                         def.Throttle(thrtAttr.HitLimit, thrtAttr.DurationSeconds, thrtAttr.HeaderName);
+
+                        break;
+
+                    // Add support for ProducesResponseTypeAttribute
+                    case ProducesResponseTypeAttribute prodAttr:
+                        if (def.EndpointSummary is null)
+                        {
+                            //def.Summary(s => s.Response(prodAttr.StatusCode));
+                            def.Summary(s => s.ProducesMetas.Add(new ProducesResponseTypeMetadata
+                            {
+                                StatusCode = prodAttr.StatusCode,
+                                Type = prodAttr.Type ?? typeof(void),
+                                ContentTypes = ["application/json"]
+                            }));
+                        }
 
                         break;
 

--- a/Src/Library/Endpoint/Endpoint.Setup.cs
+++ b/Src/Library/Endpoint/Endpoint.Setup.cs
@@ -693,6 +693,10 @@ public abstract partial class Endpoint<TRequest, TResponse> where TRequest : not
 
                 if (Definition.ExecuteAsyncReturnsIResult)
                     b.Add(eb => ProducesMetaForResultOfResponse.AddMetadata(eb, _tResponse));
+                else if ((Definition.EndpointSummary?.ProducesMetas?.Any(x => x.StatusCode == StatusCodes.Status201Created) ?? false))
+                {
+                    b.Produces(201);
+                }
                 else
                 {
                     if (_tResponse == Types.Object || _tResponse == Types.EmptyResponse)


### PR DESCRIPTION
Add support for annotation attributes `ProducesResponseType` and `SwaggerResponse` #924

SwaggerResponse is supported implicitly, as it generates ProducesResponseType metadata.

P.S. When an endpoint is annotated with 201, it will _NOT_ generate 204 for that endpoint.