### PR TITLE
Also use IHasMapper<> to find Mapper type

### DIFF
--- a/Src/Library/Endpoint/Mapper/IHasMapper.cs
+++ b/Src/Library/Endpoint/Mapper/IHasMapper.cs
@@ -1,15 +1,10 @@
 ﻿namespace FastEndpoints;
 
 /// <summary>
-/// marker interface for endpoints that has a mapper
-/// </summary>
-public interface IHasMapper;
-
-/// <summary>
 /// marker/constraint for endpoints that have a mapper generic argument
 /// </summary>
 /// <typeparam name="TMapper">the type of the mapper</typeparam>
-public interface IHasMapper<TMapper> : IHasMapper where TMapper : IMapper
+public interface IHasMapper<TMapper> where TMapper : IMapper
 {
     /// <summary>
     /// the mapper property

--- a/Src/Library/Main/EndpointData.cs
+++ b/Src/Library/Main/EndpointData.cs
@@ -118,7 +118,8 @@ sealed class EndpointData
 
                     if (tInterfaces.Contains(Types.IHasMapper))
                     {
-                        var tMapper = t.GetGenericArgumentsOfType(Types.EndpointOf3)?[2] ??
+                        var tMapper = t.GetGenericArgumentsOfType(Types.IHasMapperOf1)?[0] ??
+                                      t.GetGenericArgumentsOfType(Types.EndpointOf3)?[2] ??
                                       t.GetGenericArgumentsOfType(Types.EndpointWithMapperOf2)?[1] ??
                                       t.GetGenericArgumentsOfType(Types.EndpointWithOutRequestOf2)?[1];
 

--- a/Src/Library/Testing/Factory.cs
+++ b/Src/Library/Testing/Factory.cs
@@ -53,20 +53,12 @@ public static class Factory
 
         static Type? GetMapperType(Type tEndpoint)
         {
-            var t = tEndpoint;
+            var tInterfaces = tEndpoint.GetInterfaces();
 
-            while (t is not null)
+            foreach (var ifc in tInterfaces)
             {
-                if (t.IsGenericType)
-                {
-                    foreach (var arg in t.GetGenericArguments())
-                    {
-                        if (Types.IMapper.IsAssignableFrom(arg))
-                            return arg;
-                    }
-                }
-
-                t = t.BaseType;
+                if (ifc.IsGenericType && ifc.GetGenericTypeDefinition() == Types.IHasMapperOf1)
+                    return ifc.GetGenericArguments()[0];
             }
 
             return null;

--- a/Src/Library/Types.cs
+++ b/Src/Library/Types.cs
@@ -45,7 +45,6 @@ static class Types
     internal static readonly Type IEventHandlerOf1 = typeof(IEventHandler<>);
     internal static readonly Type IFormatProvider = typeof(IFormatProvider);
     internal static readonly Type IFormFile = typeof(IFormFile);
-    internal static readonly Type IHasMapper = typeof(IHasMapper);
     internal static readonly Type IHasMapperOf1 = typeof(IHasMapper<>);
     internal static readonly Type IJobResultStorage = typeof(IJobResultStorage);
     internal static readonly Type IJobResultProvider = typeof(IJobResultProvider);

--- a/Src/Library/Types.cs
+++ b/Src/Library/Types.cs
@@ -46,6 +46,7 @@ static class Types
     internal static readonly Type IFormatProvider = typeof(IFormatProvider);
     internal static readonly Type IFormFile = typeof(IFormFile);
     internal static readonly Type IHasMapper = typeof(IHasMapper);
+    internal static readonly Type IHasMapperOf1 = typeof(IHasMapper<>);
     internal static readonly Type IJobResultStorage = typeof(IJobResultStorage);
     internal static readonly Type IJobResultProvider = typeof(IJobResultProvider);
     internal static readonly Type IMapper = typeof(IMapper);


### PR DESCRIPTION
For externally defined Endpoint types (to ie. use a different kind of mapping if wanted) it can be useful to still use the internal mapping.

At the moment this is not possible while using custom classes, only with the default Mapping classes. If this code is changed to also look for IHasMapper<> and get the type from there this would be fixed.

To me personally it also makes more sense to look for this interface as this explicitly and only defines which mapper the class uses. And since IHasMapper already enforces the Map property with the correct type this also means that it by proxy also enforces the Endpoint class to always have the same type as the IHasMapper interface, so this shouldn't cause any behavior changes in the code, and if wanted the other types it searches can even be removed.