### PR TITLE
Add generic interfaces for IRequestMapper<,> and IResponseMapper<,>

### DIFF
--- a/Src/Library/Endpoint/Mapper/IRequestMapper.cs
+++ b/Src/Library/Endpoint/Mapper/IRequestMapper.cs
@@ -1,37 +1,45 @@
-﻿namespace FastEndpoints;
+﻿// ReSharper disable UnusedParameter.Global
+
+namespace FastEndpoints;
 
 /// <summary>
 /// marker interface for request only mappers
 /// </summary>
 public interface IRequestMapper : IMapper;
 
+/// <summary>
+/// use this interface to implement a domain entity mapper for your endpoints that only has a request dto and no response dto.
+/// <para>HINT: entity mappers are used as singletons for performance reasons. do not maintain state in the mappers.</para>
+/// </summary>
+/// <typeparam name="TRequest">the type of request dto</typeparam>
+/// <typeparam name="TEntity">the type of domain entity to map to/from</typeparam>
 public interface IRequestMapper<in TRequest, TEntity> : IRequestMapper
 {
     /// <summary>
-    /// override this method and place the logic for mapping the request dto to the desired domain entity
+    /// implement this method and place the logic for mapping the request dto to the desired domain entity
     /// </summary>
     /// <param name="r">the request dto</param>
-    public TEntity ToEntity(TRequest r);
+    TEntity ToEntity(TRequest r);
 
     /// <summary>
-    /// override this method and place the logic for mapping the request dto to the desired domain entity
+    /// implement this method and place the logic for mapping the request dto to the desired domain entity
     /// </summary>
     /// <param name="r">the request dto to map from</param>
     /// <param name="ct">a cancellation token</param>
-    public Task<TEntity> ToEntityAsync(TRequest r, CancellationToken ct = default);
+    Task<TEntity> ToEntityAsync(TRequest r, CancellationToken ct);
 
     /// <summary>
-    /// override this method and place the logic for mapping the updated request dto to the desired domain entity
+    /// implement this method and place the logic for mapping the updated request dto to the desired domain entity
     /// </summary>
     /// <param name="r">the request dto to update from</param>
     /// <param name="e">the domain entity to update</param>
-    public TEntity UpdateEntity(TRequest r, TEntity e);
+    TEntity UpdateEntity(TRequest r, TEntity e);
 
     /// <summary>
-    /// override this method and place the logic for mapping the updated request dto to the desired domain entity
+    /// implement this method and place the logic for mapping the updated request dto to the desired domain entity
     /// </summary>
     /// <param name="r">the request dto to update from</param>
     /// <param name="e">the domain entity to update</param>
     /// <param name="ct">a cancellation token</param>
-    public Task<TEntity> UpdateEntityAsync(TRequest r, TEntity e, CancellationToken ct = default);
+    Task<TEntity> UpdateEntityAsync(TRequest r, TEntity e, CancellationToken ct);
 }

--- a/Src/Library/Endpoint/Mapper/IRequestMapper.cs
+++ b/Src/Library/Endpoint/Mapper/IRequestMapper.cs
@@ -4,3 +4,34 @@
 /// marker interface for request only mappers
 /// </summary>
 public interface IRequestMapper : IMapper;
+
+public interface IRequestMapper<in TRequest, TEntity> : IRequestMapper
+{
+    /// <summary>
+    /// override this method and place the logic for mapping the request dto to the desired domain entity
+    /// </summary>
+    /// <param name="r">the request dto</param>
+    public TEntity ToEntity(TRequest r);
+
+    /// <summary>
+    /// override this method and place the logic for mapping the request dto to the desired domain entity
+    /// </summary>
+    /// <param name="r">the request dto to map from</param>
+    /// <param name="ct">a cancellation token</param>
+    public Task<TEntity> ToEntityAsync(TRequest r, CancellationToken ct = default);
+
+    /// <summary>
+    /// override this method and place the logic for mapping the updated request dto to the desired domain entity
+    /// </summary>
+    /// <param name="r">the request dto to update from</param>
+    /// <param name="e">the domain entity to update</param>
+    public TEntity UpdateEntity(TRequest r, TEntity e);
+
+    /// <summary>
+    /// override this method and place the logic for mapping the updated request dto to the desired domain entity
+    /// </summary>
+    /// <param name="r">the request dto to update from</param>
+    /// <param name="e">the domain entity to update</param>
+    /// <param name="ct">a cancellation token</param>
+    public Task<TEntity> UpdateEntityAsync(TRequest r, TEntity e, CancellationToken ct = default);
+}

--- a/Src/Library/Endpoint/Mapper/IResponseMapper.cs
+++ b/Src/Library/Endpoint/Mapper/IResponseMapper.cs
@@ -1,22 +1,31 @@
-﻿namespace FastEndpoints;
+﻿// ReSharper disable UnusedMemberInSuper.Global
+// ReSharper disable UnusedParameter.Global
+
+namespace FastEndpoints;
 
 /// <summary>
 /// marker interface for response only mappers
 /// </summary>
 public interface IResponseMapper : IMapper;
 
+/// <summary>
+/// use this interface to implement a domain entity mapper for your endpoints that only has a response dto and no request dto.
+/// <para>HINT: entity mappers are used as singletons for performance reasons. do not maintain state in the mappers.</para>
+/// </summary>
+/// <typeparam name="TResponse">the type of response dto</typeparam>
+/// <typeparam name="TEntity">the type of domain entity to map to/from</typeparam>
 public interface IResponseMapper<TResponse, in TEntity> : IResponseMapper
 {
     /// <summary>
-    /// override this method and place the logic for mapping a domain entity to a response dto
+    /// implement this method and place the logic for mapping a domain entity to a response dto
     /// </summary>
     /// <param name="e">the domain entity to map from</param>
-    public TResponse FromEntity(TEntity e);
+    TResponse FromEntity(TEntity e);
 
     /// <summary>
-    /// override this method and place the logic for mapping a domain entity to a response dto
+    /// implement this method and place the logic for mapping a domain entity to a response dto
     /// </summary>
     /// <param name="e">the domain entity to map from</param>
     /// <param name="ct">a cancellation token</param>
-    public Task<TResponse> FromEntityAsync(TEntity e, CancellationToken ct = default);
+    Task<TResponse> FromEntityAsync(TEntity e, CancellationToken ct);
 }

--- a/Src/Library/Endpoint/Mapper/IResponseMapper.cs
+++ b/Src/Library/Endpoint/Mapper/IResponseMapper.cs
@@ -4,3 +4,19 @@
 /// marker interface for response only mappers
 /// </summary>
 public interface IResponseMapper : IMapper;
+
+public interface IResponseMapper<TResponse, in TEntity> : IResponseMapper
+{
+    /// <summary>
+    /// override this method and place the logic for mapping a domain entity to a response dto
+    /// </summary>
+    /// <param name="e">the domain entity to map from</param>
+    public TResponse FromEntity(TEntity e);
+
+    /// <summary>
+    /// override this method and place the logic for mapping a domain entity to a response dto
+    /// </summary>
+    /// <param name="e">the domain entity to map from</param>
+    /// <param name="ct">a cancellation token</param>
+    public Task<TResponse> FromEntityAsync(TEntity e, CancellationToken ct = default);
+}

--- a/Src/Library/Endpoint/Mapper/Mapper.cs
+++ b/Src/Library/Endpoint/Mapper/Mapper.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 
-// ReSharper disable UnusedParameter.Global
-
 namespace FastEndpoints;
 
 /// <summary>
@@ -11,59 +9,51 @@ namespace FastEndpoints;
 /// <typeparam name="TRequest">the type of request dto</typeparam>
 /// <typeparam name="TResponse">the type of response dto</typeparam>
 /// <typeparam name="TEntity">the type of domain entity to map to/from</typeparam>
-public abstract class Mapper<TRequest, TResponse, TEntity> : IResponseMapper<TResponse, TEntity>, IRequestMapper<TRequest, TEntity>, IServiceResolverBase where TRequest : notnull where TResponse : notnull
+public abstract class Mapper<TRequest, TResponse, TEntity> : IRequestMapper<TRequest, TEntity>, IResponseMapper<TResponse, TEntity>, IServiceResolverBase
+    where TRequest : notnull where TResponse : notnull
 {
     public virtual TEntity ToEntity(TRequest r)
         => throw new NotImplementedException($"Please override the {nameof(ToEntity)} method!");
-    
-    public virtual Task<TEntity> ToEntityAsync(TRequest r, CancellationToken ct = default)
+
+    public virtual Task<TEntity> ToEntityAsync(TRequest r, CancellationToken ct)
         => throw new NotImplementedException($"Please override the {nameof(ToEntityAsync)} method!");
-    
-    public virtual TResponse FromEntity(TEntity e)
-        => throw new NotImplementedException($"Please override the {nameof(FromEntity)} method!");
-    
-    public virtual Task<TResponse> FromEntityAsync(TEntity e, CancellationToken ct = default)
-        => throw new NotImplementedException($"Please override the {nameof(FromEntityAsync)} method!");
-    
+
     public virtual TEntity UpdateEntity(TRequest r, TEntity e)
         => throw new NotImplementedException($"Please override the {nameof(UpdateEntity)} method!");
-    
-    public virtual Task<TEntity> UpdateEntityAsync(TRequest r, TEntity e, CancellationToken ct = default)
-        => throw new NotImplementedException($"Please override the {nameof(UpdateEntityAsync)} method!");    
 
-    /// <inheritdoc />
+    public virtual Task<TEntity> UpdateEntityAsync(TRequest r, TEntity e, CancellationToken ct)
+        => throw new NotImplementedException($"Please override the {nameof(UpdateEntityAsync)} method!");
+
+    public virtual TResponse FromEntity(TEntity e)
+        => throw new NotImplementedException($"Please override the {nameof(FromEntity)} method!");
+
+    public virtual Task<TResponse> FromEntityAsync(TEntity e, CancellationToken ct)
+        => throw new NotImplementedException($"Please override the {nameof(FromEntityAsync)} method!");
+
     public TService? TryResolve<TService>() where TService : class
         => Cfg.ServiceResolver.TryResolve<TService>();
 
-    /// <inheritdoc />
     public object? TryResolve(Type typeOfService)
         => Cfg.ServiceResolver.TryResolve(typeOfService);
 
-    /// <inheritdoc />
     public TService Resolve<TService>() where TService : class
         => Cfg.ServiceResolver.Resolve<TService>();
 
-    /// <inheritdoc />
     public object Resolve(Type typeOfService)
         => Cfg.ServiceResolver.Resolve(typeOfService);
 
-    /// <inheritdoc />
     public IServiceScope CreateScope()
         => Cfg.ServiceResolver.CreateScope();
 
-    /// <inheritdoc />
     public TService? TryResolve<TService>(string keyName) where TService : class
         => Cfg.ServiceResolver.TryResolve<TService>(keyName);
 
-    /// <inheritdoc />
     public object? TryResolve(Type typeOfService, string keyName)
         => Cfg.ServiceResolver.TryResolve(typeOfService, keyName);
 
-    /// <inheritdoc />
     public TService Resolve<TService>(string keyName) where TService : class
         => Cfg.ServiceResolver.Resolve<TService>(keyName);
 
-    /// <inheritdoc />
     public object Resolve(Type typeOfService, string keyName)
         => Cfg.ServiceResolver.Resolve(typeOfService, keyName);
 }
@@ -78,49 +68,40 @@ public abstract class RequestMapper<TRequest, TEntity> : IRequestMapper<TRequest
 {
     public virtual TEntity ToEntity(TRequest r)
         => throw new NotImplementedException($"Please override the {nameof(ToEntity)} method!");
-    
+
     public virtual Task<TEntity> ToEntityAsync(TRequest r, CancellationToken ct = default)
         => throw new NotImplementedException($"Please override the {nameof(ToEntityAsync)} method!");
-    
+
     public virtual TEntity UpdateEntity(TRequest r, TEntity e)
         => throw new NotImplementedException($"Please override the {nameof(UpdateEntity)} method!");
-    
-    public virtual Task<TEntity> UpdateEntityAsync(TRequest r, TEntity e, CancellationToken ct = default)
-        => throw new NotImplementedException($"Please override the {nameof(UpdateEntityAsync)} method!");  
-        
-    /// <inheritdoc />
+
+    public virtual Task<TEntity> UpdateEntityAsync(TRequest r, TEntity e, CancellationToken ct)
+        => throw new NotImplementedException($"Please override the {nameof(UpdateEntityAsync)} method!");
+
     public TService? TryResolve<TService>() where TService : class
         => Cfg.ServiceResolver.TryResolve<TService>();
 
-    /// <inheritdoc />
     public object? TryResolve(Type typeOfService)
         => Cfg.ServiceResolver.TryResolve(typeOfService);
 
-    /// <inheritdoc />
     public TService Resolve<TService>() where TService : class
         => Cfg.ServiceResolver.Resolve<TService>();
 
-    /// <inheritdoc />
     public object Resolve(Type typeOfService)
         => Cfg.ServiceResolver.Resolve(typeOfService);
 
-    /// <inheritdoc />
     public IServiceScope CreateScope()
         => Cfg.ServiceResolver.CreateScope();
 
-    /// <inheritdoc />
     public TService? TryResolve<TService>(string keyName) where TService : class
         => Cfg.ServiceResolver.TryResolve<TService>(keyName);
 
-    /// <inheritdoc />
     public object? TryResolve(Type typeOfService, string keyName)
         => Cfg.ServiceResolver.TryResolve(typeOfService, keyName);
 
-    /// <inheritdoc />
     public TService Resolve<TService>(string keyName) where TService : class
         => Cfg.ServiceResolver.Resolve<TService>(keyName);
 
-    /// <inheritdoc />
     public object Resolve(Type typeOfService, string keyName)
         => Cfg.ServiceResolver.Resolve(typeOfService, keyName);
 }
@@ -135,43 +116,34 @@ public abstract class ResponseMapper<TResponse, TEntity> : IResponseMapper<TResp
 {
     public virtual TResponse FromEntity(TEntity e)
         => throw new NotImplementedException($"Please override the {nameof(FromEntity)} method!");
-    
-    public virtual Task<TResponse> FromEntityAsync(TEntity e, CancellationToken ct = default)
+
+    public virtual Task<TResponse> FromEntityAsync(TEntity e, CancellationToken ct)
         => throw new NotImplementedException($"Please override the {nameof(FromEntityAsync)} method!");
 
-    /// <inheritdoc />
     public TService? TryResolve<TService>() where TService : class
         => Cfg.ServiceResolver.TryResolve<TService>();
 
-    /// <inheritdoc />
     public object? TryResolve(Type typeOfService)
         => Cfg.ServiceResolver.TryResolve(typeOfService);
 
-    /// <inheritdoc />
     public TService Resolve<TService>() where TService : class
         => Cfg.ServiceResolver.Resolve<TService>();
 
-    /// <inheritdoc />
     public object Resolve(Type typeOfService)
         => Cfg.ServiceResolver.Resolve(typeOfService);
 
-    /// <inheritdoc />
     public IServiceScope CreateScope()
         => Cfg.ServiceResolver.CreateScope();
 
-    /// <inheritdoc />
     public TService? TryResolve<TService>(string keyName) where TService : class
         => Cfg.ServiceResolver.TryResolve<TService>(keyName);
 
-    /// <inheritdoc />
     public object? TryResolve(Type typeOfService, string keyName)
         => Cfg.ServiceResolver.TryResolve(typeOfService, keyName);
 
-    /// <inheritdoc />
     public TService Resolve<TService>(string keyName) where TService : class
         => Cfg.ServiceResolver.Resolve<TService>(keyName);
 
-    /// <inheritdoc />
     public object Resolve(Type typeOfService, string keyName)
         => Cfg.ServiceResolver.Resolve(typeOfService, keyName);
 }

--- a/Src/Library/Endpoint/Mapper/Mapper.cs
+++ b/Src/Library/Endpoint/Mapper/Mapper.cs
@@ -11,52 +11,23 @@ namespace FastEndpoints;
 /// <typeparam name="TRequest">the type of request dto</typeparam>
 /// <typeparam name="TResponse">the type of response dto</typeparam>
 /// <typeparam name="TEntity">the type of domain entity to map to/from</typeparam>
-public abstract class Mapper<TRequest, TResponse, TEntity> : IMapper, IServiceResolverBase where TRequest : notnull where TResponse : notnull
+public abstract class Mapper<TRequest, TResponse, TEntity> : IResponseMapper<TResponse, TEntity>, IRequestMapper<TRequest, TEntity>, IServiceResolverBase where TRequest : notnull where TResponse : notnull
 {
-    /// <summary>
-    /// override this method and place the logic for mapping the request dto to the desired domain entity
-    /// </summary>
-    /// <param name="r">the request dto</param>
     public virtual TEntity ToEntity(TRequest r)
         => throw new NotImplementedException($"Please override the {nameof(ToEntity)} method!");
-
-    /// <summary>
-    /// override this method and place the logic for mapping the request dto to the desired domain entity
-    /// </summary>
-    /// <param name="r">the request dto to map from</param>
-    /// <param name="ct">a cancellation token</param>
+    
     public virtual Task<TEntity> ToEntityAsync(TRequest r, CancellationToken ct = default)
         => throw new NotImplementedException($"Please override the {nameof(ToEntityAsync)} method!");
-
-    /// <summary>
-    /// override this method and place the logic for mapping a domain entity to a response dto
-    /// </summary>
-    /// <param name="e">the domain entity to map from</param>
+    
     public virtual TResponse FromEntity(TEntity e)
         => throw new NotImplementedException($"Please override the {nameof(FromEntity)} method!");
-
-    /// <summary>
-    /// override this method and place the logic for mapping a domain entity to a response dto
-    /// </summary>
-    /// <param name="e">the domain entity to map from</param>
-    /// <param name="ct">a cancellation token</param>
+    
     public virtual Task<TResponse> FromEntityAsync(TEntity e, CancellationToken ct = default)
         => throw new NotImplementedException($"Please override the {nameof(FromEntityAsync)} method!");
-
-    /// <summary>
-    /// override this method and place the logic for mapping the updated request dto to the desired domain entity
-    /// </summary>
-    /// <param name="r">the request dto to update from</param>
-    /// <param name="e">the domain entity to update</param>
+    
     public virtual TEntity UpdateEntity(TRequest r, TEntity e)
         => throw new NotImplementedException($"Please override the {nameof(UpdateEntity)} method!");
-
-    /// <summary>
-    /// override this method and place the logic for mapping the updated request dto to the desired domain entity
-    /// </summary>
-    /// <param name="r">the request dto to update from</param>
-    /// <param name="e">the domain entity to update</param>
-    /// <param name="ct">a cancellation token</param>
+    
     public virtual Task<TEntity> UpdateEntityAsync(TRequest r, TEntity e, CancellationToken ct = default)
         => throw new NotImplementedException($"Please override the {nameof(UpdateEntityAsync)} method!");    
 
@@ -103,37 +74,17 @@ public abstract class Mapper<TRequest, TResponse, TEntity> : IMapper, IServiceRe
 /// </summary>
 /// <typeparam name="TRequest">the type of request dto</typeparam>
 /// <typeparam name="TEntity">the type of domain entity to map to/from</typeparam>
-public abstract class RequestMapper<TRequest, TEntity> : IRequestMapper, IServiceResolverBase where TRequest : notnull
+public abstract class RequestMapper<TRequest, TEntity> : IRequestMapper<TRequest, TEntity>, IServiceResolverBase where TRequest : notnull
 {
-    /// <summary>
-    /// override this method and place the logic for mapping the request dto to the desired domain entity
-    /// </summary>
-    /// <param name="r">the request dto</param>
     public virtual TEntity ToEntity(TRequest r)
         => throw new NotImplementedException($"Please override the {nameof(ToEntity)} method!");
-
-    /// <summary>
-    /// override this method and place the logic for mapping the request dto to the desired domain entity
-    /// </summary>
-    /// <param name="r">the request dto to map from</param>
-    /// <param name="ct">a cancellation token</param>
+    
     public virtual Task<TEntity> ToEntityAsync(TRequest r, CancellationToken ct = default)
         => throw new NotImplementedException($"Please override the {nameof(ToEntityAsync)} method!");
-
-    /// <summary>
-    /// override this method and place the logic for mapping the updated request dto to the desired domain entity
-    /// </summary>
-    /// <param name="r">the request dto to update from</param>
-    /// <param name="e">the domain entity to update</param>
+    
     public virtual TEntity UpdateEntity(TRequest r, TEntity e)
         => throw new NotImplementedException($"Please override the {nameof(UpdateEntity)} method!");
-
-    /// <summary>
-    /// override this method and place the logic for mapping the updated request dto to the desired domain entity
-    /// </summary>
-    /// <param name="r">the request dto to update from</param>
-    /// <param name="e">the domain entity to update</param>
-    /// <param name="ct">a cancellation token</param>
+    
     public virtual Task<TEntity> UpdateEntityAsync(TRequest r, TEntity e, CancellationToken ct = default)
         => throw new NotImplementedException($"Please override the {nameof(UpdateEntityAsync)} method!");  
         
@@ -180,20 +131,11 @@ public abstract class RequestMapper<TRequest, TEntity> : IRequestMapper, IServic
 /// </summary>
 /// <typeparam name="TResponse">the type of response dto</typeparam>
 /// <typeparam name="TEntity">the type of domain entity to map to/from</typeparam>
-public abstract class ResponseMapper<TResponse, TEntity> : IResponseMapper, IServiceResolverBase where TResponse : notnull
+public abstract class ResponseMapper<TResponse, TEntity> : IResponseMapper<TResponse, TEntity>, IServiceResolverBase where TResponse : notnull
 {
-    /// <summary>
-    /// override this method and place the logic for mapping a domain entity to a response dto
-    /// </summary>
-    /// <param name="e">the domain entity to map from</param>
     public virtual TResponse FromEntity(TEntity e)
         => throw new NotImplementedException($"Please override the {nameof(FromEntity)} method!");
-
-    /// <summary>
-    /// override this method and place the logic for mapping a domain entity to a response dto
-    /// </summary>
-    /// <param name="e">the domain entity to map from</param>
-    /// <param name="ct">a cancellation token</param>
+    
     public virtual Task<TResponse> FromEntityAsync(TEntity e, CancellationToken ct = default)
         => throw new NotImplementedException($"Please override the {nameof(FromEntityAsync)} method!");
 

--- a/Src/Library/Types.cs
+++ b/Src/Library/Types.cs
@@ -48,7 +48,6 @@ static class Types
     internal static readonly Type IHasMapperOf1 = typeof(IHasMapper<>);
     internal static readonly Type IJobResultStorage = typeof(IJobResultStorage);
     internal static readonly Type IJobResultProvider = typeof(IJobResultProvider);
-    internal static readonly Type IMapper = typeof(IMapper);
     internal static readonly Type IPlainTextRequest = typeof(IPlainTextRequest);
     internal static readonly Type IResult = typeof(IResult);
     internal static readonly Type ISummary = typeof(ISummary);


### PR DESCRIPTION
Mapper now implements IResponseMapper<,> and IRequestMapper<,>

This allows code which wants to use the mappers to simply pattern match on the generic interfaces and then use them, instead of having to pattern match on Mapper, and then on Response/Request Mapper since the dependency trees for the mapper types are split, this resolves that and makes it one singular dependency tree.

This however might be considered an opiniated change, and I'm not sure if there's any implications for breaking changes for people relying on the specific interfaces, I did make sure that all interfaces still implement the simple marker interfaces, so nothing should break in that way.

But if this is not wanted in any way, feel free to simply close the pull request, I however do believe that this might be considered a better dependency layout for using the mappers.