### PR TITLE
Test helper methods serialize record query params as json

### DIFF
--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
 
-        <Version>6.3.0-beta.10</Version>
+        <Version>6.3.0-beta.11</Version>
 
         <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>

--- a/Src/Library/Testing/HttpClientExtensions.cs
+++ b/Src/Library/Testing/HttpClientExtensions.cs
@@ -551,11 +551,19 @@ public static class HttpClientExtensions
 
         var tValue = value.GetType();
         var stringVal = value.ToString();
+        var isTypeName = stringVal == tValue.ToString();
+        var isRecord = tValue.IsRecordType();
 
-        // Record type's ToString() overload returns a string in the format 'ClassName { Properties... }'.  It is not
-        // json and won't parse correctly.
-        return  (stringVal?.StartsWith($"{tValue.Name} {{") ?? false) || stringVal == tValue.ToString()
-                   ? JsonSerializer.Serialize(value, SerOpts.Options) //value is type name or record - serialize it
-                   : stringVal;                                       //not the type name - return it
+        if (isTypeName || isRecord)
+            return JsonSerializer.Serialize(value, SerOpts.Options);
+
+        return stringVal;
+    }
+
+    static bool IsRecordType(this Type type)
+    {
+        var cloneMethod = type.GetMethod("<Clone>$");
+
+        return cloneMethod is not null && cloneMethod.ReturnType == type;
     }
 }

--- a/Tests/IntegrationTests/FastEndpoints.Swagger/release-0.json
+++ b/Tests/IntegrationTests/FastEndpoints.Swagger/release-0.json
@@ -5509,20 +5509,19 @@
         "additionalProperties": false,
         "properties": {
           "nested": {
-            "$ref": "#/components/schemas/TestCasesHydratedQueryParamGeneratorTestRequest_NestedClass"
+            "type": "string"
           },
           "guids": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "guid"
-            }
+            "type": "string"
           },
           "some": {
-            "type": "string",
-            "nullable": true
+            "type": "string"
           }
         }
+      },
+      "TestCasesHydratedQueryParamGeneratorTestRequest": {
+        "type": "object",
+        "additionalProperties": false
       },
       "TestCasesHydratedQueryParamGeneratorTestRequest_NestedClass": {
         "type": "object",
@@ -5537,10 +5536,6 @@
             "format": "int32"
           }
         }
-      },
-      "TestCasesHydratedQueryParamGeneratorTestRequest": {
-        "type": "object",
-        "additionalProperties": false
       },
       "TestCasesHydratedTestUrlGeneratorTestRequest": {
         "type": "object",

--- a/Tests/IntegrationTests/FastEndpoints.Swagger/release-1.json
+++ b/Tests/IntegrationTests/FastEndpoints.Swagger/release-1.json
@@ -5634,20 +5634,19 @@
         "additionalProperties": false,
         "properties": {
           "nested": {
-            "$ref": "#/components/schemas/TestCasesHydratedQueryParamGeneratorTestRequest_NestedClass"
+            "type": "string"
           },
           "guids": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "guid"
-            }
+            "type": "string"
           },
           "some": {
-            "type": "string",
-            "nullable": true
+            "type": "string"
           }
         }
+      },
+      "TestCasesHydratedQueryParamGeneratorTestRequest": {
+        "type": "object",
+        "additionalProperties": false
       },
       "TestCasesHydratedQueryParamGeneratorTestRequest_NestedClass": {
         "type": "object",
@@ -5662,10 +5661,6 @@
             "format": "int32"
           }
         }
-      },
-      "TestCasesHydratedQueryParamGeneratorTestRequest": {
-        "type": "object",
-        "additionalProperties": false
       },
       "TestCasesHydratedTestUrlGeneratorTestRequest": {
         "type": "object",

--- a/Tests/IntegrationTests/FastEndpoints.Swagger/release-2.json
+++ b/Tests/IntegrationTests/FastEndpoints.Swagger/release-2.json
@@ -5718,20 +5718,19 @@
         "additionalProperties": false,
         "properties": {
           "nested": {
-            "$ref": "#/components/schemas/TestCasesHydratedQueryParamGeneratorTestRequest_NestedClass"
+            "type": "string"
           },
           "guids": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "guid"
-            }
+            "type": "string"
           },
           "some": {
-            "type": "string",
-            "nullable": true
+            "type": "string"
           }
         }
+      },
+      "TestCasesHydratedQueryParamGeneratorTestRequest": {
+        "type": "object",
+        "additionalProperties": false
       },
       "TestCasesHydratedQueryParamGeneratorTestRequest_NestedClass": {
         "type": "object",
@@ -5746,10 +5745,6 @@
             "format": "int32"
           }
         }
-      },
-      "TestCasesHydratedQueryParamGeneratorTestRequest": {
-        "type": "object",
-        "additionalProperties": false
       },
       "TestCasesHydratedTestUrlGeneratorTestRequest": {
         "type": "object",

--- a/Tests/IntegrationTests/FastEndpoints/EndpointTests/EndpointTests.cs
+++ b/Tests/IntegrationTests/FastEndpoints/EndpointTests/EndpointTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
+using System.Text.Json;
 using TestCases.EmptyRequestTest;
 using TestCases.Routing;
 
@@ -120,9 +121,9 @@ public class EndpointTests(Sut App) : TestBase<Sut>
                                   >(req);
 
         rsp.IsSuccessStatusCode.ShouldBeTrue();
-        res.Nested.ShouldBe(req.Nested);
+        res.Nested.ShouldBe(JsonSerializer.Serialize(req.Nested), StringCompareShould.IgnoreCase);
+        res.Guids.ShouldBe(JsonSerializer.Serialize(req.Guids), StringCompareShould.IgnoreCase);
         res.Some.ShouldBe(req.Some);
-        res.Guids.ShouldBe(req.Guids);
     }
 
     [Fact]

--- a/Web/[Features]/TestCases/Endpoints/HydratedQueryParamGeneratorTest/Endpoint.cs
+++ b/Web/[Features]/TestCases/Endpoints/HydratedQueryParamGeneratorTest/Endpoint.cs
@@ -2,7 +2,7 @@
 
 public sealed class Request
 {
-    [QueryParam]
+    [FromQuery] //this is the right way to bind complex data from query params
     public NestedClass Nested { get; set; }
 
     [QueryParam]
@@ -16,11 +16,9 @@ public sealed class Request
 
 public sealed class Response
 {
-    public Request.NestedClass Nested { get; set; }
-
-    public List<Guid> Guids { get; set; }
-
-    public string? Some { get; set; }
+    public string Nested { get; set; }
+    public string Guids { get; set; }
+    public string Some { get; set; }
 }
 
 sealed class Endpoint : Endpoint<Request, Response>
@@ -33,7 +31,14 @@ sealed class Endpoint : Endpoint<Request, Response>
 
     public override Task HandleAsync(Request r, CancellationToken c)
     {
-        Response = new Response { Nested = r.Nested, Guids = r.Guids, Some = r.Some };
+        //we only care about the correct querystring in this test
+        Response = new()
+        {
+            Nested = HttpContext.Request.Query["nested"]!,
+            Guids = HttpContext.Request.Query["guids"]!,
+            Some = HttpContext.Request.Query["some"]!
+        };
+
         return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
Updates the test of query param helper methods to echo back and assert the actual deserialized value to ensure that records are handled correctly.