### PR TITLE
Various SSE comment fixes

### DIFF
--- a/Src/Library/DTOs/StreamItem.cs
+++ b/Src/Library/DTOs/StreamItem.cs
@@ -4,7 +4,7 @@ namespace FastEndpoints;
 
 public class StreamItem
 {
-    /// <summary>event id, omitted when NULL</summary>
+    /// <summary>event id</summary>
     public string? Id { get; init; }
 
     /// <summary>event name</summary>
@@ -29,7 +29,7 @@ public class StreamItem
     /// <param name="id">the id of the event</param>
     /// <param name="eventName">the name of the event</param>
     /// <param name="data">the event data</param>
-    /// <param name="retry">reconnection time in seconds</param>
+    /// <param name="retry">reconnection time in milliseconds</param>
     public StreamItem(string? id, string eventName, object data, int? retry = null)
     {
         Id = id;

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -14,10 +14,10 @@ Due to the current [unfortunate state of FOSS](https://www.youtube.com/watch?v=H
 
 <details><summary>SSE response standard compliance</summary>
 
-The SSE response implementation has been enhanced by making the `id` field in `StreamItem` optional, adding an optional `Retry` property for client-side reconnection control, as well as introducing an extra `StreamItem` constructor overload for better flexibility. Additionally, the `X-Accel-Buffering: no` response header is now automatically sent to improve compatibility with reverse proxies like NGINX, ensuring streamed data is delivered without buffering. You can now do the following when doing multi-type data responses:
+The SSE response implementation has been enhanced by making the `Id` property in `StreamItem` optional, adding an optional `Retry` property for client-side reconnection control, as well as introducing an extra `StreamItem` constructor overload for more flexibility. Additionally, the `X-Accel-Buffering: no` response header is now automatically sent to improve compatibility with reverse proxies like NGINX, ensuring streamed data is delivered without buffering. You can now do the following when doing multi-type data responses:
 
 ```csharp
-yield return new StreamItem("my-event", myData, 30);
+yield return new StreamItem("my-event", myData, 3000);
 ```
 
 </details>


### PR DESCRIPTION
I've made some small changes in the comments and changelog to remove some confusion:
- The id field and value is actually not omitted when NULL (that was an idea in my previous PR, but in the end I did not go with it)
- The retry field in a SSE stream should be specified in milliseconds

Let me know your thoughts @dj-nitehawk 