### PR TITLE
Handle ApplicationStopping in HttpResponse instead of in stream Handler

### DIFF
--- a/Src/Library/Extensions/HttpResponseExtensions.cs
+++ b/Src/Library/Extensions/HttpResponseExtensions.cs
@@ -538,7 +538,8 @@ public static class HttpResponseExtensions
     /// <param name="eventName">the name of the event stream</param>
     /// <param name="eventStream">an IAsyncEnumerable that is the source of the data</param>
     /// <param name="cancellation">optional cancellation token. if not specified, the <c>HttpContext.RequestAborted</c> token is used.</param>
-    public static Task SendEventStreamAsync<T>(this HttpResponse rsp, string eventName, IAsyncEnumerable<T> eventStream, CancellationToken cancellation = default) where T : notnull
+    public static Task SendEventStreamAsync<T>(this HttpResponse rsp, string eventName, IAsyncEnumerable<T> eventStream, CancellationToken cancellation = default)
+        where T : notnull
     {
         return SendEventStreamAsync(rsp, GetStreamItemAsyncEnumerable(eventName, eventStream, cancellation), cancellation);
 
@@ -573,14 +574,16 @@ public static class HttpResponseExtensions
         await rsp.Body.FlushAsync(ct);
 
         var applicationStopping = rsp.HttpContext.RequestServices.GetRequiredService<IHostApplicationLifetime>().ApplicationStopping;
+
         try
         {
             // Pass the ApplicationStopping CancellationToken to the IAsyncEnumerable, the framework will combine it automatically with any user provided token.
             // This makes sure that the stream at least stops when the host is shutting down.
             await foreach (var streamItem in eventStream.WithCancellation(applicationStopping))
-            {
-                await rsp.WriteAsync($"id: {streamItem.Id}\nevent: {streamItem.EventName}\ndata: {streamItem.GetDataString(SerOpts.Options)}\nretry: {streamItem.Retry}\n\n", Encoding.UTF8, ct);
-            }
+                await rsp.WriteAsync(
+                    $"id: {streamItem.Id}\nevent: {streamItem.EventName}\ndata: {streamItem.GetDataString(SerOpts.Options)}\nretry: {streamItem.Retry}\n\n",
+                    Encoding.UTF8,
+                    ct);
         }
         catch (OperationCanceledException) { }
         finally

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -55,9 +55,9 @@ yield return new StreamItem("my-event", myData, 3000);
 
 </details>
 
-<details><summary>Application host respecting shutdown when using SSE</summary>
+<details><summary>Respect app shutdown when using SSE</summary>
 
-The SSE implementation now passes the ApplicationStopping CancellationToken to your IAsyncEnumerable method. This means that streaming is cancelled at least when the application host is shutting down, and also when an user provided CancellationToken (if provided) triggeres it.
+The SSE implementation now passes the `ApplicationStopping` cancellation token to your `IAsyncEnumerable` method. This means that streaming is cancelled at least when the application host is shutting down, and also when a user provided `CancellationToken` (if provided) triggers it.
 
 ```csharp
 public override async Task HandleAsync(CancellationToken ct)
@@ -76,8 +76,6 @@ public override async Task HandleAsync(CancellationToken ct)
     }
 }
 ```
-
-</details>
 
 </details>
 

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -55,6 +55,32 @@ yield return new StreamItem("my-event", myData, 3000);
 
 </details>
 
+<details><summary>Application host respecting shutdown when using SSE</summary>
+
+The SSE implementation now passes the ApplicationStopping CancellationToken to your IAsyncEnumerable method. This means that streaming is cancelled at least when the application host is shutting down, and also when an user provided CancellationToken (if provided) triggeres it.
+
+```csharp
+public override async Task HandleAsync(CancellationToken ct)
+{
+    await Send.EventStreamAsync(GetMultiDataStream(ct), ct);
+
+    async IAsyncEnumerable<StreamItem> GetMultiDataStream([EnumeratorCancellation] CancellationToken ct)
+    {
+        // Here ct is now your user provided CancellationToken combined with the ApplicationStopping CancellationToken.
+        while (!ct.IsCancellationRequested)
+        {
+            await Task.Delay(1000, ct);
+
+            yield return new StreamItem(Guid.NewGuid(), "your-event-type", 42);
+        }
+    }
+}
+```
+
+</details>
+
+</details>
+
 ## Fixes 🪲
 
 <details><summary>Incorrect enum value for JWT security algorithm was used</summary>

--- a/Src/Messaging/Messaging.Remote/Server/Commands/ServerStreamHandlerExecutor.cs
+++ b/Src/Messaging/Messaging.Remote/Server/Commands/ServerStreamHandlerExecutor.cs
@@ -1,4 +1,4 @@
-﻿using Grpc.AspNetCore.Server.Model;
+using Grpc.AspNetCore.Server.Model;
 using Grpc.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/Tests/UnitTests/FastEndpoints/WebTests.cs
+++ b/Tests/UnitTests/FastEndpoints/WebTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using TestCases.EventStreamTest;
 using TestCases.ProcessorStateTest;
@@ -218,6 +219,12 @@ public class WebTests
             httpContext =>
             {
                 httpContext.Response.Body = responseStream;
+                httpContext.AddTestServices(s => s.AddSingleton(sp =>
+                {
+                    var fake = new Fake<IHostApplicationLifetime>();
+                    fake.CallsTo(x => x.ApplicationStopping).Returns(CancellationToken.None);
+                    return fake.FakedObject;
+                }));
             });
         var eventName = "some-notification";
         var notifications = new[]


### PR DESCRIPTION
While testing the SSE functionality in FE I found out that when I try to stop the host, it keeps running for 30 seconds before actually stopping. In my case we're using MediatR instead of the default message bus functionality provided by FE. MediatR was added because the original developers were unaware of the message bus functionality provided by FE.
The FE message bus ServerStreamHandlerExecutor links the ApplicationStopping cancellationToken together with the RequestAborted cancellationToken, and catches any OperationCanceledException, which causes the SendEventStreamAsync method to stop writing data when the client or the server stops. But since in my scenario we use MediatR, this functionality is not triggered. I've created a PR that moves the ApplicationStopping cancellationToken as well as the try..catch logic to the HttpResponseExtensions class so that this logic also is executed when the FE message bus functionality is not used.

Basically this fix would allow people to stop the host (respecting its cancellationtoken) while using the SSE functionality of FE without using the build-in message bus.

@dj-nitehawk let me know what are your thoughts.