### PR TITLE
Flush response stream after SSE item write

### DIFF
--- a/Src/Library/Extensions/HttpResponseExtensions.cs
+++ b/Src/Library/Extensions/HttpResponseExtensions.cs
@@ -388,12 +388,6 @@ public static class HttpResponseExtensions
             }
         }
         catch (OperationCanceledException) { }
-        finally
-        {
-            // Flush the buffer only if the client did not trigger the cancellation
-            if (!ct.IsCancellationRequested)
-                await rsp.Body.FlushAsync(ct);
-        }
 
         return Void.Instance;
     }


### PR DESCRIPTION
After testing the Server Events Streaming functionality I noticed that sometimes there is a delay on the client-side for reading the messages. 

Reading every line and writing it to the console results in this behavior:

> 12/1/2025 2:25:06 PM Reading line...0 id: 
> 12/1/2025 2:25:06 PM Reading line...1 event: SomeEventTypeName
> 12/1/2025 2:25:06 PM Reading line...2 data: {"$type":"SomeEventTypeName","tenantId":1234,"name":"MyPcName"}
> 12/1/2025 2:25:36 PM Reading line...0 id: 
> 12/1/2025 2:26:01 PM Reading line...1 event: SomeOtherEventTypeName
> 12/1/2025 2:26:01 PM Reading line...2 data: {"$type":"SomeOtherEventTypeName","tenantId":1234,"name":"MyPcName"}

In this example the first message (id + data + event) is read instantly, in the second message however there is a delay between reading the id and event, even if server-side this is written all at once to the response stream. The delay seems to happen at random between properties of the same message. I suspect this behavior is caused because the default buffering mechanism in the response stream.
The fix would be to simply flush the response stream after a write.
Let me know your thoughts @dj-nitehawk 
