### PR TITLE
Fix binding of DTOs with default struct parameters

### DIFF
--- a/Src/Library/Binder/BinderExtensions.cs
+++ b/Src/Library/Binder/BinderExtensions.cs
@@ -62,7 +62,7 @@ static class BinderExtensions
             for (var i = 0; i < args.Length; i++)
             {
                 argExpressions.Add(
-                    args[i].HasDefaultValue
+                    args[i].HasDefaultValue && args[i].DefaultValue is not null
                         ? Expression.Constant(args[i].DefaultValue, args[i].ParameterType)
                         : Expression.Default(args[i].ParameterType));
             }

--- a/Tests/UnitTests/FastEndpoints/RequestBinderTests.cs
+++ b/Tests/UnitTests/FastEndpoints/RequestBinderTests.cs
@@ -28,6 +28,19 @@ public class RequestBinderTests
     }
 
     [Fact]
+    public async Task CanBindClassDto_WithDefaultStructParameter() {
+        var hCtx = new DefaultHttpContext();
+        var binder = new RequestBinder<RequestClassWithDefaultStructParameter>();
+        var ctx = new BinderContext(hCtx, [], null, false, ((IRequestBinder<RequestClassWithDefaultStructParameter>)binder).RequiredProps);
+
+        var res = await binder.BindAsync(ctx, default);
+
+        // Should be a zeroed struct - not a default constructor call
+        res.SomeStruct.Value.ShouldBe(0);
+        res.SomeStruct.ConstructorCalled.ShouldBe(false);
+    }
+
+    [Fact]
     public async Task MissingInputThrowsFailure()
     {
         var hCtx = new DefaultHttpContext();
@@ -50,4 +63,26 @@ public class RequestBinderTests
         [RouteParam(IsRequired = true), BindFrom("req_quired")]
         public bool Required { get; set; }
     }
+
+    // ReSharper disable once ClassNeverInstantiated.Local
+    sealed class RequestClassWithDefaultStructParameter(SomeStruct someOptionalStruct = default) {
+
+        // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Local
+        public SomeStruct SomeStruct { get; set; } = someOptionalStruct;
+
+    }
+
+    struct SomeStruct {
+
+        public int Value;
+        public bool ConstructorCalled;
+
+        // ReSharper disable once UnusedMember.Local
+        public SomeStruct(int value) {
+            Value = value;
+            ConstructorCalled = true;
+        }
+
+    }
+
 }


### PR DESCRIPTION
Fixes #1033

## Summary
- Fixes an issue where binding a DTO with a constructor parameter that has a default struct value (e.g., `SomeStruct param = default`) would fail
- When `HasDefaultValue` is true but `DefaultValue` is null (which happens for default struct values), `Expression.Constant` would throw an exception
- Added a null check to use `Expression.Default` instead, which correctly produces a zeroed struct

## Test plan
- [x] Added unit test `CanBindClassDto_WithDefaultStructParameter` that verifies the fix works correctly