### PR TITLE
Simplify semaphore wait in JobQueue

### DIFF
--- a/Src/JobQueues/JobQueue.cs
+++ b/Src/JobQueues/JobQueue.cs
@@ -287,7 +287,7 @@ sealed class JobQueue<TCommand, TResult, TStorageRecord, TStorageProvider> : Job
 
             if (!records.Any())
             {
-                // if _isInUse is false, that means no job has been queued yet nor is there any incomplete jobs for the future. so, it's necessary for further
+                // if _isInUse is false, that means no job has been queued yet nor is there any incomplete jobs for the future. so, it's not necessary for further
                 // iterations within the loop until the semaphore is released upon queuing the first job.
                 //
                 // if _isInUse is true, it indicates that we must await the queuing of the next job or the passage of delay duration (default: 1 minute),
@@ -295,8 +295,8 @@ sealed class JobQueue<TCommand, TResult, TStorageRecord, TStorageProvider> : Job
                 // no new jobs are being queued. not doing this periodic check could result in future jobs only executing upon the arrival of new jobs,
                 // potentially leading to jobs being expired without being executed.
                 await (_isInUse is true
-                    ? _sem.WaitAsync(_semWaitLimit, _appCancellation)
-                    : _sem.WaitAsync(_appCancellation));
+                           ? _sem.WaitAsync(_semWaitLimit, _appCancellation)
+                           : _sem.WaitAsync(_appCancellation));
             }
             else
                 await Parallel.ForEachAsync(records, _parallelOptions, ExecuteCommand);


### PR DESCRIPTION
I noticed the waiting logic in the JobQueue class could be simplified a bit by just passing the _semWaitLimit TimeSpan directly to the WaitAsync call directly.

The WaitAsync also has an overload with an int parameter, the implementation internally casts the Milliseconds property of the TimeSpan to an int with some bounds checks, it would save a few CPU cycles by executing this logic only once per queue in the SetLimits method instead of inside the CommandExecutorTask loop. If you think that optimization makes sense then I can make that small addition.

Let me know what you think @dj-nitehawk 