### PR TITLE
Fix package versioning and remove weird reflection

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,10 +34,7 @@
         <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2"/>
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive"/>
     </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-        <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9"/>
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'netstandard2.0'">
         <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.25"/>
         <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.25"/>
         <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.25"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,7 @@
         <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5"/>
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0"/>
         <PackageVersion Include="Microsoft.OpenApi.Kiota.Builder" Version="1.30.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.5"/>
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201"/>
         <PackageVersion Include="NSwag.AspNetCore" Version="14.6.3"/>
         <PackageVersion Include="NSwag.CodeGeneration.CSharp" Version="14.6.3"/>
@@ -34,22 +35,19 @@
         <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2"/>
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive"/>
     </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'netstandard2.0'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
         <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.25"/>
         <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.25"/>
         <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.25"/>
-        <PackageVersion Include="Microsoft.Extensions.Primitives" Version="8.0.0"/>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
         <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.14"/>
         <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.14"/>
         <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.14"/>
-        <PackageVersion Include="Microsoft.Extensions.Primitives" Version="9.0.14"/>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
         <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5"/>
         <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5"/>
         <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.5"/>
-        <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.5"/>
     </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,6 @@
         <PackageVersion Include="Grpc.Net.Client" Version="2.76.0"/>
         <PackageVersion Include="Grpc.Net.Client.Web" Version="2.76.0"/>
         <PackageVersion Include="MessagePack" Version="3.1.4"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9"/>
         <PackageVersion Include="Microsoft.AspNetCore.OData" Version="9.4.1"/>
         <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0"/>
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="[4.11.0]"/><!-- not upgradeable for net8 compatibility -->
@@ -34,6 +33,9 @@
         <PackageVersion Include="xunit.v3" Version="3.2.2"/>
         <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2"/>
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive"/>
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+        <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9"/>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1'">
         <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.25"/>

--- a/Src/Core/FastEndpoints.Core.csproj
+++ b/Src/Core/FastEndpoints.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Description>Core service resolution and other shared functionality of FastEndpoints.</Description>
         <PackageIcon>icon.png</PackageIcon>
@@ -11,8 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Condition=" '$(TargetFramework)'=='netstandard2.1' " Include="Microsoft.AspNetCore.Http.Abstractions"/>
-        <FrameworkReference Condition=" '$(TargetFramework)'!='netstandard2.1' " Include="Microsoft.AspNetCore.App"/>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"/>
         <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
     </ItemGroup>

--- a/Src/Core/FastEndpoints.Core.csproj
+++ b/Src/Core/FastEndpoints.Core.csproj
@@ -11,7 +11,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions"/>
+        <PackageReference Condition=" '$(TargetFramework)'=='netstandard2.1' " Include="Microsoft.AspNetCore.Http.Abstractions"/>
+        <FrameworkReference Condition=" '$(TargetFramework)'!='netstandard2.1' " Include="Microsoft.AspNetCore.App"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"/>
         <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
     </ItemGroup>

--- a/Src/JobQueues/FastEndpoints.JobQueues.csproj
+++ b/Src/JobQueues/FastEndpoints.JobQueues.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <Description>Command based background job queueing with scheduling and tracking for any .NET application</Description>
+        <Description>Command based background job queueing with scheduling and tracking for .NET 8 and newer</Description>
         <PackageIcon>icon.png</PackageIcon>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <IncludeSymbols>true</IncludeSymbols>

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -51,6 +51,14 @@ app.UseFastEndpoints(c =>
 
 ## Minor Breaking Changes ⚠️
 
+<details><summary>Dropped support for netstandard2.1</summary>
+
+`FastEndpoints.Core`, `FastEndpoints.Messaging.Core`, and `FastEndpoints.Messaging.Remote.Core` no longer target `netstandard2.1` and now support `net8.0+` only.
+
+If you consume these packages from shared libraries or older applications, retarget those projects to `net8.0` or newer before upgrading.
+
+</details>
+
 <details><summary>Undefined enum values are no longer accepted by default for non-STJ model binding</summary>
 
 The default behavior for non-JSON model binding has changed. Previously, enum values were accepted as long as `Enum.TryParse()` succeeded, which meant undefined numeric values such as `99` could still bind successfully. The new default rejects enum values unless they are explicitly defined by the target enum type.

--- a/Src/Messaging/Messaging.Core/FastEndpoints.Messaging.Core.csproj
+++ b/Src/Messaging/Messaging.Core/FastEndpoints.Messaging.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Description>Core messaging interfaces used by FastEndpoints.</Description>
         <PackageIcon>icon.png</PackageIcon>

--- a/Src/Messaging/Messaging.Remote.Core/FastEndpoints.Messaging.Remote.Core.csproj
+++ b/Src/Messaging/Messaging.Remote.Core/FastEndpoints.Messaging.Remote.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <NoWarn>CS1591</NoWarn>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Description>Core componets of the FastEndpoints remote messaging library</Description>

--- a/Src/Messaging/Messaging/FastEndpoints.Messaging.csproj
+++ b/Src/Messaging/Messaging/FastEndpoints.Messaging.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <NoWarn>CS1591</NoWarn>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <Description>Standalone messaging library for Command Bus/Event Bus implementations compatible with any .NET application.</Description>
+        <Description>Standalone messaging library for Command Bus/Event Bus implementations on .NET 8 and newer.</Description>
         <PackageIcon>icon.png</PackageIcon>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <IncludeSymbols>true</IncludeSymbols>

--- a/Src/Swagger/SystemTextJsonUtilities.cs
+++ b/Src/Swagger/SystemTextJsonUtilities.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="SystemTextJsonUtilities.cs" company="NJsonSchema">
 //     Copyright (c) Rico Suter. All rights reserved.
 // </copyright>
@@ -6,11 +6,9 @@
 // <author>Rico Suter, mail@rsuter.com</author>
 //-----------------------------------------------------------------------
 
-using Namotion.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
-using System.Collections;
 using System.Reflection;
 
 namespace NJsonSchema.Generation;
@@ -25,18 +23,14 @@ public static class SystemTextJsonUtilities
     /// </summary>
     /// <param name="serializerOptions">The options.</param>
     /// <returns>The settings.</returns>
-    public static JsonSerializerSettings ConvertJsonOptionsToNewtonsoftSettings(dynamic serializerOptions)
+    public static JsonSerializerSettings ConvertJsonOptionsToNewtonsoftSettings(System.Text.Json.JsonSerializerOptions serializerOptions)
     {
         var settings = new JsonSerializerSettings
         {
             ContractResolver = new SystemTextJsonContractResolver(serializerOptions)
         };
 
-        var jsonStringEnumConverter = ((IEnumerable)serializerOptions.Converters)
-                                      .OfType<object>()
-                                      .FirstOrDefault(
-                                          c => c.GetType()
-                                                .IsAssignableToTypeName("System.Text.Json.Serialization.JsonStringEnumConverter", TypeNameStyle.FullName));
+        var jsonStringEnumConverter = serializerOptions.Converters.OfType<System.Text.Json.Serialization.JsonStringEnumConverter>().FirstOrDefault();
 
         if (jsonStringEnumConverter == null)
             return settings;
@@ -47,16 +41,17 @@ public static class SystemTextJsonUtilities
         return settings;
     }
 
-    static bool IsCamelCaseEnumNamingPolicy(object jsonStringEnumConverter)
+    static bool IsCamelCaseEnumNamingPolicy(System.Text.Json.Serialization.JsonStringEnumConverter jsonStringEnumConverter)
     {
         try
         {
-            var enumNamingPolicy = jsonStringEnumConverter
+            var enumNamingPolicy = (System.Text.Json.JsonNamingPolicy?)(jsonStringEnumConverter
                                    .GetType().GetRuntimeFields()
                                    .FirstOrDefault(x => x.FieldType.FullName == "System.Text.Json.JsonNamingPolicy")?
-                                   .GetValue(jsonStringEnumConverter);
+                                   .GetValue(jsonStringEnumConverter));
 
-            return enumNamingPolicy is not null && enumNamingPolicy.GetType().FullName == "System.Text.Json.JsonCamelCaseNamingPolicy";
+            return enumNamingPolicy is not null && enumNamingPolicy == System.Text.Json.JsonNamingPolicy.CamelCase;
+
         }
         catch
         {
@@ -64,33 +59,24 @@ public static class SystemTextJsonUtilities
         }
     }
 
-    sealed class SystemTextJsonContractResolver(dynamic serializerOptions) : DefaultContractResolver
+    sealed class SystemTextJsonContractResolver(System.Text.Json.JsonSerializerOptions serializerOptions) : DefaultContractResolver
     {
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
-            var attributes = member.GetCustomAttributes(true);
+            var attributes = member.GetCustomAttributes<System.Text.Json.Serialization.JsonIgnoreAttribute>(true);
+
+            var propertyIgnored = attributes.Any(att => att.Condition == System.Text.Json.Serialization.JsonIgnoreCondition.Always);
+            var hasToHeaderAttribute = member.GetCustomAttributes<FastEndpoints.ToHeaderAttribute>(true).Any();
+            var hasJsonExtensionDataAttribute = member.GetCustomAttributes<System.Text.Json.Serialization.JsonExtensionDataAttribute>().Any();
 
             var property = base.CreateProperty(member, memberSerialization);
-
-            var propertyIgnored = false;
-            var jsonIgnoreAttribute = attributes.FirstAssignableToTypeNameOrDefault("System.Text.Json.Serialization.JsonIgnoreAttribute");
-
-            if (jsonIgnoreAttribute != null)
-            {
-                var condition = jsonIgnoreAttribute.TryGetPropertyValue<object>("Condition");
-                if (condition is null || condition.ToString() == "Always")
-                    propertyIgnored = true;
-            }
-
-            var hasToHeaderAttribute = attributes.FirstAssignableToTypeNameOrDefault("FastEndpoints.ToHeaderAttribute") is not null;
-            var hasJsonExtensionDataAttribute = attributes.FirstAssignableToTypeNameOrDefault("System.Text.Json.Serialization.JsonExtensionDataAttribute") is not null;
 
             property.Ignored = propertyIgnored || hasJsonExtensionDataAttribute || hasToHeaderAttribute;
 
             if (serializerOptions.PropertyNamingPolicy != null)
                 property.PropertyName = serializerOptions.PropertyNamingPolicy.ConvertName(member.Name);
 
-            dynamic? jsonPropertyNameAttribute = attributes.FirstAssignableToTypeNameOrDefault("System.Text.Json.Serialization.JsonPropertyNameAttribute");
+            var jsonPropertyNameAttribute = member.GetCustomAttributes<System.Text.Json.Serialization.JsonPropertyNameAttribute>(true).FirstOrDefault();
 
             if (jsonPropertyNameAttribute is not null && !string.IsNullOrEmpty(jsonPropertyNameAttribute.Name))
                 property.PropertyName = jsonPropertyNameAttribute?.Name;

--- a/Src/Swagger/SystemTextJsonUtilities.cs
+++ b/Src/Swagger/SystemTextJsonUtilities.cs
@@ -16,7 +16,7 @@ namespace NJsonSchema.Generation;
 /// <summary>
 /// Utility methods for dealing with System.Text.Json.
 /// </summary>
-public static class SystemTextJsonUtilities
+static class SystemTextJsonUtilities
 {
     /// <summary>
     /// Converts System.Text.Json serializer options to Newtonsoft JSON settings.
@@ -25,11 +25,7 @@ public static class SystemTextJsonUtilities
     /// <returns>The settings.</returns>
     public static JsonSerializerSettings ConvertJsonOptionsToNewtonsoftSettings(System.Text.Json.JsonSerializerOptions serializerOptions)
     {
-        var settings = new JsonSerializerSettings
-        {
-            ContractResolver = new SystemTextJsonContractResolver(serializerOptions)
-        };
-
+        var settings = new JsonSerializerSettings { ContractResolver = new SystemTextJsonContractResolver(serializerOptions) };
         var jsonStringEnumConverter = serializerOptions.Converters.OfType<System.Text.Json.Serialization.JsonStringEnumConverter>().FirstOrDefault();
 
         if (jsonStringEnumConverter == null)
@@ -45,13 +41,12 @@ public static class SystemTextJsonUtilities
     {
         try
         {
-            var enumNamingPolicy = (System.Text.Json.JsonNamingPolicy?)(jsonStringEnumConverter
-                                   .GetType().GetRuntimeFields()
-                                   .FirstOrDefault(x => x.FieldType.FullName == "System.Text.Json.JsonNamingPolicy")?
-                                   .GetValue(jsonStringEnumConverter));
+            var enumNamingPolicy = jsonStringEnumConverter.GetType()
+                                                          .GetRuntimeFields()
+                                                          .FirstOrDefault(x => x.FieldType == typeof(System.Text.Json.JsonNamingPolicy))?
+                                                          .GetValue(jsonStringEnumConverter) as System.Text.Json.JsonNamingPolicy;
 
-            return enumNamingPolicy is not null && enumNamingPolicy == System.Text.Json.JsonNamingPolicy.CamelCase;
-
+            return enumNamingPolicy == System.Text.Json.JsonNamingPolicy.CamelCase;
         }
         catch
         {
@@ -63,23 +58,18 @@ public static class SystemTextJsonUtilities
     {
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
-            var attributes = member.GetCustomAttributes<System.Text.Json.Serialization.JsonIgnoreAttribute>(true);
-
-            var propertyIgnored = attributes.Any(att => att.Condition == System.Text.Json.Serialization.JsonIgnoreCondition.Always);
-            var hasToHeaderAttribute = member.GetCustomAttributes<FastEndpoints.ToHeaderAttribute>(true).Any();
-            var hasJsonExtensionDataAttribute = member.GetCustomAttributes<System.Text.Json.Serialization.JsonExtensionDataAttribute>().Any();
-
             var property = base.CreateProperty(member, memberSerialization);
 
-            property.Ignored = propertyIgnored || hasJsonExtensionDataAttribute || hasToHeaderAttribute;
+            property.Ignored |=
+                member.GetCustomAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>(true)?.Condition == System.Text.Json.Serialization.JsonIgnoreCondition.Always ||
+                member.IsDefined(typeof(System.Text.Json.Serialization.JsonExtensionDataAttribute), true) ||
+                member.IsDefined(typeof(FastEndpoints.ToHeaderAttribute), true);
 
             if (serializerOptions.PropertyNamingPolicy != null)
                 property.PropertyName = serializerOptions.PropertyNamingPolicy.ConvertName(member.Name);
 
-            var jsonPropertyNameAttribute = member.GetCustomAttributes<System.Text.Json.Serialization.JsonPropertyNameAttribute>(true).FirstOrDefault();
-
-            if (jsonPropertyNameAttribute is not null && !string.IsNullOrEmpty(jsonPropertyNameAttribute.Name))
-                property.PropertyName = jsonPropertyNameAttribute?.Name;
+            if (member.GetCustomAttribute<System.Text.Json.Serialization.JsonPropertyNameAttribute>(true) is { Name: { Length: > 0 } name })
+                property.PropertyName = name;
 
             return property;
         }


### PR DESCRIPTION
I saw this article: https://devblogs.microsoft.com/dotnet/aspnet-core-2-3-end-of-support/
I try to help in removing the old dependency. Hopefully this will stop old dependency showing up on nuget website for the dotnet 10 version of FastEndpoints.Core:
<img width="512" height="93" alt="image" src="https://github.com/user-attachments/assets/e224be72-0d12-41fa-9d6d-9aec73ff6e5d" />


I also remove reflection from your newtonsoft -> STJ option converter. I couldn't manage to do it for one of the functions because there is no public API on the class that I could access.




