### PR TITLE
Small RequestBinder optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ BenchmarkDotNet.Artifacts/
 *.tmp_proj
 *.log
 *.vspscc
+*.lscache
 publish/
 *.nupkg
 *.snupkg

--- a/Src/Library/Binder/RequestBinder.cs
+++ b/Src/Library/Binder/RequestBinder.cs
@@ -423,7 +423,11 @@ public class RequestBinder<TRequest> : IRequestBinder<TRequest> where TRequest :
 
     static void BindUserClaims(TRequest req, BinderContext ctx)
     {
+        if (_fromClaimProps.Count == 0)
+            return;
+
         var claimsDict = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
         foreach (var c in ctx.HttpContext.User.Claims)
         {
             if (!claimsDict.TryGetValue(c.Type, out var list))
@@ -431,7 +435,7 @@ public class RequestBinder<TRequest> : IRequestBinder<TRequest> where TRequest :
                 list = [];
                 claimsDict[c.Type] = list;
             }
-                
+
             list.Add(c.Value);
         }
 
@@ -443,8 +447,8 @@ public class RequestBinder<TRequest> : IRequestBinder<TRequest> where TRequest :
             if (claimsDict.TryGetValue(prop.Identifier, out var values))
             {
                 claimVal = prop.IsCollection || values.Count > 1
-                    ? values.ToArray()
-                    : values[0];
+                               ? values.ToArray()
+                               : values[0];
             }
 
             switch (claimVal.Count)
@@ -523,7 +527,11 @@ public class RequestBinder<TRequest> : IRequestBinder<TRequest> where TRequest :
 
     static void BindHasPermissionProps(TRequest req, BinderContext ctx)
     {
+        if (_hasPermissionProps.Count == 0)
+            return;
+
         var permissionValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         foreach (var claim in ctx.HttpContext.User.Claims)
         {
             if (string.Equals(claim.Type, Cfg.SecOpts.PermissionsClaimType, StringComparison.OrdinalIgnoreCase))

--- a/Src/Library/Binder/RequestBinder.cs
+++ b/Src/Library/Binder/RequestBinder.cs
@@ -423,20 +423,28 @@ public class RequestBinder<TRequest> : IRequestBinder<TRequest> where TRequest :
 
     static void BindUserClaims(TRequest req, BinderContext ctx)
     {
+        var claimsDict = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var c in ctx.HttpContext.User.Claims)
+        {
+            if (!claimsDict.TryGetValue(c.Type, out var list))
+            {
+                list = [];
+                claimsDict[c.Type] = list;
+            }
+                
+            list.Add(c.Value);
+        }
+
         for (var i = 0; i < _fromClaimProps.Count; i++)
         {
             var prop = _fromClaimProps[i];
             StringValues claimVal = default;
 
-            foreach (var g in ctx.HttpContext.User.Claims.GroupBy(c => c.Type, c => c.Value))
+            if (claimsDict.TryGetValue(prop.Identifier, out var values))
             {
-                if (g.Key.Equals(prop.Identifier, StringComparison.OrdinalIgnoreCase))
-                {
-                    claimVal =
-                        prop.IsCollection || g.Count() > 1
-                            ? g.Select(v => v).ToArray()
-                            : g.FirstOrDefault();
-                }
+                claimVal = prop.IsCollection || values.Count > 1
+                    ? values.ToArray()
+                    : values[0];
             }
 
             switch (claimVal.Count)
@@ -515,12 +523,17 @@ public class RequestBinder<TRequest> : IRequestBinder<TRequest> where TRequest :
 
     static void BindHasPermissionProps(TRequest req, BinderContext ctx)
     {
+        var permissionValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var claim in ctx.HttpContext.User.Claims)
+        {
+            if (string.Equals(claim.Type, Cfg.SecOpts.PermissionsClaimType, StringComparison.OrdinalIgnoreCase))
+                permissionValues.Add(claim.Value);
+        }
+
         for (var i = 0; i < _hasPermissionProps.Count; i++)
         {
             var prop = _hasPermissionProps[i];
-            var hasPerm = ctx.HttpContext.User.Claims.Any(
-                c => string.Equals(c.Type, Cfg.SecOpts.PermissionsClaimType, StringComparison.OrdinalIgnoreCase) &&
-                     string.Equals(c.Value, prop.Identifier, StringComparison.OrdinalIgnoreCase));
+            var hasPerm = permissionValues.Contains(prop.Identifier);
 
             switch (hasPerm)
             {


### PR DESCRIPTION
With some help I found some room for some small optimizations in the claim/permission binding logic (executed per request).

- BindUserClaims: replaced a per-property GroupBy + Count() + FirstOrDefault() chain with a single upfront pass that builds a Dictionary<string, List<string>>. Per-property lookup is now O(1) instead of re-enumerating the claims collection on every iteration.
- BindHasPermissionProps: replaced a per-property Claims.Any(...) (O(n) per property) with a single upfront pass that collects matching permission claim values into a HashSet<string>. Each permission check is then O(1).
Both methods are only entered when the request type has the relevant bound properties (_bindUserClaims / _bindPermissions guards at the call site), so the upfront allocation is never wasted.

I also extended the .gitignore for .lscache files which are generated by the C# Dev Kit extension in VSCode.

Let me know your thoughts @dj-nitehawk 