### PR TITLE
Aligned [HasPermission] binder to use case-sensitive permission value comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ BenchmarkDotNet.Artifacts/
 *.tmp_proj
 *.log
 *.vspscc
+*.lscache
 publish/
 *.nupkg
 *.snupkg

--- a/Src/Library/Binder/RequestBinder.cs
+++ b/Src/Library/Binder/RequestBinder.cs
@@ -520,7 +520,7 @@ public class RequestBinder<TRequest> : IRequestBinder<TRequest> where TRequest :
             var prop = _hasPermissionProps[i];
             var hasPerm = ctx.HttpContext.User.Claims.Any(
                 c => string.Equals(c.Type, Cfg.SecOpts.PermissionsClaimType, StringComparison.OrdinalIgnoreCase) &&
-                     string.Equals(c.Value, prop.Identifier, StringComparison.OrdinalIgnoreCase));
+                     string.Equals(c.Value, prop.Identifier, StringComparison.Ordinal));
 
             switch (hasPerm)
             {

--- a/Tests/UnitTests/FastEndpoints/RequestBinderTests.cs
+++ b/Tests/UnitTests/FastEndpoints/RequestBinderTests.cs
@@ -1,5 +1,6 @@
 ﻿using FastEndpoints;
 using Microsoft.AspNetCore.Http;
+using System.Security.Claims;
 using Xunit;
 
 namespace RequestBinder;
@@ -51,6 +52,50 @@ public class RequestBinderTests
         ex.Failures!.ShouldContain(f => f.PropertyName == "req_quired");
     }
 
+    [Fact]
+    public async Task HasPermissionBindsWithExactClaimValueCasing()
+    {
+        var hCtx = new DefaultHttpContext
+        {
+            User = new(new ClaimsIdentity([new("permissions", "Admin")]))
+        };
+        var binder = new RequestBinder<PermissionRequest>();
+        var ctx = new BinderContext(hCtx, [], null, false, ((IRequestBinder<PermissionRequest>)binder).RequiredProps);
+
+        var res = await binder.BindAsync(ctx, default);
+
+        res.HasAdminPermission.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task HasPermissionDoesNotBindWithDifferentClaimValueCasing()
+    {
+        var hCtx = new DefaultHttpContext
+        {
+            User = new(new ClaimsIdentity([new("permissions", "Admin")]))
+        };
+        var binder = new RequestBinder<OptionalPermissionRequest>();
+        var ctx = new BinderContext(hCtx, [], null, false, ((IRequestBinder<OptionalPermissionRequest>)binder).RequiredProps);
+
+        var res = await binder.BindAsync(ctx, default);
+
+        res.HasAdminPermission.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task RequiredHasPermissionFailsWithDifferentClaimValueCasing()
+    {
+        var hCtx = new DefaultHttpContext
+        {
+            User = new(new ClaimsIdentity([new("permissions", "Admin")]))
+        };
+        var binder = new RequestBinder<RequiredPermissionRequest>();
+        var ctx = new BinderContext(hCtx, [], null, false, ((IRequestBinder<RequiredPermissionRequest>)binder).RequiredProps);
+
+        var ex = Should.Throw<ValidationFailureException>(async () => await binder.BindAsync(ctx, default));
+        ex.Failures!.ShouldContain(f => f.PropertyName == "admin");
+    }
+
     // ReSharper disable once ClassNeverInstantiated.Local
     sealed class RequestClass(int intgr, int optionalProp = 678)
     {
@@ -83,6 +128,24 @@ public class RequestBinderTests
             ConstructorCalled = true;
         }
 
+    }
+
+    sealed class PermissionRequest
+    {
+        [HasPermission("Admin", isRequired: false)]
+        public bool HasAdminPermission { get; set; }
+    }
+
+    sealed class OptionalPermissionRequest
+    {
+        [HasPermission("admin", isRequired: false)]
+        public bool HasAdminPermission { get; set; }
+    }
+
+    sealed class RequiredPermissionRequest
+    {
+        [HasPermission("admin")]
+        public bool HasAdminPermission { get; set; }
     }
 
 }


### PR DESCRIPTION
With some help I found a casing check mismatch between auth policies and permission bindings.

BindHasPermissionProps() in RequestBinder compared permission claim values using OrdinalIgnoreCase, while the authorization policies built in MainExtensions.AddSecurityPolicy() use Ordinal (case-sensitive) for the same values — both AllowAnyPermission (line 338) and AllowAllPermissions (line 346). This meant the [HasPermission] DTO binder and the endpoint authorization gate made opposite assumptions: a token carrying "Admin" would be rejected by an auth policy requiring "admin", but Request.IsAdmin would still be set to true by the binder.
- Changed the value comparison in BindHasPermissionProps from OrdinalIgnoreCase to Ordinal to match the auth policy.

I also extended the .gitignore for .lscache files which are generated by the C# Dev Kit extension in VSCode.

Let me know your thoughts @dj-nitehawk 