### PR TITLE
Removed two redundant early-return guards in RequestBinder

### DIFF
--- a/Src/Library/Binder/RequestBinder.cs
+++ b/Src/Library/Binder/RequestBinder.cs
@@ -426,9 +426,6 @@ public class RequestBinder<TRequest> : IRequestBinder<TRequest> where TRequest :
 
     static void BindUserClaims(TRequest req, BinderContext ctx)
     {
-        if (_fromClaimProps.Count == 0)
-            return;
-
         var claimsDict = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var c in ctx.HttpContext.User.Claims)
@@ -530,9 +527,6 @@ public class RequestBinder<TRequest> : IRequestBinder<TRequest> where TRequest :
 
     static void BindHasPermissionProps(TRequest req, BinderContext ctx)
     {
-        if (_hasPermissionProps.Count == 0)
-            return;
-
         var permissionValues = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var claim in ctx.HttpContext.User.Claims)


### PR DESCRIPTION
Removed duplicate early-return guards in BindUserClaims and BindHasPermissionProps.

The Count == 0 checks inside these methods were dead code — both methods are only called when _bindUserClaims / _bindPermissions is true, which is already gated on _fromClaimProps.Count > 0 and _hasPermissionProps.Count > 0 respectively in the constructor.

```cs
call sites:
_bindUserClaims = _fromClaimProps.Count > 0;
if (_bindUserClaims)
    BindUserClaims(req, ctx);

_bindPermissions = _hasPermissionProps.Count > 0;
if (_bindPermissions)
    BindHasPermissionProps(req, ctx);
```