### PR TITLE
Small extra IStreamCommandHandler improvements

### DIFF
--- a/Src/Library/Messaging/Commands/CommandHandler.cs
+++ b/Src/Library/Messaging/Commands/CommandHandler.cs
@@ -1,4 +1,6 @@
-﻿namespace FastEndpoints;
+using System.Runtime.CompilerServices;
+
+namespace FastEndpoints;
 
 /// <summary>
 /// the base class from which all <see cref="CommandHandler{TCommand}" /> classes inherit from
@@ -32,5 +34,7 @@ public abstract class CommandHandler<TCommand, TResult> : CommandHandlerBase<TCo
 /// <typeparam name="TResult">the type of the items in the result stream returned by this command handler</typeparam>
 public abstract class StreamCommandHandler<TCommand, TResult> : CommandHandlerBase<TCommand>, IStreamCommandHandler<TCommand, TResult> where TCommand : IStreamCommand<TResult>
 {
-    public abstract IAsyncEnumerable<TResult> ExecuteAsync(TCommand command, CancellationToken ct = default);
+#pragma warning disable CS8424
+    public abstract IAsyncEnumerable<TResult> ExecuteAsync(TCommand command, [EnumeratorCancellation] CancellationToken ct = default);
+#pragma warning restore CS8424
 }

--- a/Src/Messaging/Messaging/Commands/CommandExtensions.cs
+++ b/Src/Messaging/Messaging/Commands/CommandExtensions.cs
@@ -68,10 +68,10 @@ public static class CommandExtensions
         var registry = ServiceResolver.Instance.Resolve<CommandHandlerRegistry>();
         registry.TryGetValue(tCommand, out var def);
 
+        var tHandlerInterface = Types.IStreamCommandHandlerOf2.MakeGenericType(tCommand, typeof(TResult));
         if (def is null && tCommand.IsGenericType)
-            InitGenericHandlerCore(ref def, tCommand, registry, Types.IStreamCommandHandlerOf2.MakeGenericType(tCommand, typeof(TResult)));
-
-        var tHandler = PrepareExecution<TResult>(def, tCommand, Types.StreamCommandHandlerExecutorOf2, Types.IStreamCommandHandlerOf2.MakeGenericType(tCommand, typeof(TResult)));
+            InitGenericHandlerCore(ref def, tCommand, registry, tHandlerInterface);
+        var tHandler = PrepareExecution<TResult>(def, tCommand, Types.StreamCommandHandlerExecutorOf2, tHandlerInterface);
 
         return ((IStreamCommandHandlerExecutor<TResult>)def!.HandlerExecutor!).Execute(command, tHandler, ct);
     }

--- a/Src/Messaging/Messaging/Commands/CommandMiddlewareConfigBase.cs
+++ b/Src/Messaging/Messaging/Commands/CommandMiddlewareConfigBase.cs
@@ -17,7 +17,12 @@ public abstract class CommandMiddlewareConfigBase
             var tMiddleware = middlewareTypes[i];
 
             if (!IsValid(tMiddleware, OpenGenericInterface))
-                throw new ArgumentException($"{tMiddleware.Name} must be an open generic type implementing {OpenGenericInterface.Name}");
+            {
+                var args = OpenGenericInterface.GetGenericArguments();
+                var argNames = string.Join(", ", args.Select(a => a.Name));
+                var friendlyName = $"{OpenGenericInterface.Name.Split('`')[0]}<{argNames}>";
+                throw new ArgumentException($"{tMiddleware.Name} must be an open generic type implementing {friendlyName}");
+            }
 
             Middleware.Add((OpenGenericInterface, tMiddleware));
         }


### PR DESCRIPTION
Found some small additions for the previous PR.

- Removed duplicate  MakeGenericType call in CommandExtensions.ExecuteAsync<TResult>
- Improved the error message in CommandMiddlewareConfigBase to be human-readable
- Added [EnumeratorCancellation] to the abstract StreamCommandHandler as Intellisense hint

Let me know your thoughts @dj-nitehawk 