### PR TITLE
Fix: ValidationSchemaProcessor to prevent concurrent corruption and cross-document constraint loss

### DIFF
--- a/FastEndpoints.slnx
+++ b/FastEndpoints.slnx
@@ -29,10 +29,10 @@
         <Project Path="Src/ClientGen/FastEndpoints.ClientGen.csproj"/>
         <Project Path="Src/Swagger/FastEndpoints.Swagger.csproj"/>
     </Folder>
-    <Folder Name="/Legacy/Tests/">
-        <Project Path="Tests/IntegrationTests/FastEndpoints.Swagger/Int.Swagger.csproj"/>
-        <Project Path="Tests/UnitTests/FastEndpoints.Swagger/Unit.Swagger.csproj"/>
-    </Folder>
+    <!-- <Folder Name="/Legacy/Tests/"> -->
+    <!--     <Project Path="Tests/IntegrationTests/FastEndpoints.Swagger/Int.Swagger.csproj"/> -->
+    <!--     <Project Path="Tests/UnitTests/FastEndpoints.Swagger/Unit.Swagger.csproj"/> -->
+    <!-- </Folder> -->
     <Folder Name="/TestHarnesses/">
         <Project Path="TestHarness/OData/OData.csproj"/>
         <Project Path="TestHarness/OpenApi.Kiota/OpenApi.Kiota.csproj"/>
@@ -44,8 +44,8 @@
     </Folder>
     <Folder Name="/Tests/IntegrationTests/">
         <Project Path="Tests/IntegrationTests/FastEndpoints.Agents/Int.Agents.csproj"/>
-        <!-- <Project Path="Tests/IntegrationTests/FastEndpoints.OpenApi.Kiota/Int.OpenApi.Kiota.csproj"/> -->
-        <!-- <Project Path="Tests/IntegrationTests/FastEndpoints.OpenApi/Int.OpenApi.csproj"/> -->
+        <Project Path="Tests/IntegrationTests/FastEndpoints.OpenApi.Kiota/Int.OpenApi.Kiota.csproj"/>
+        <Project Path="Tests/IntegrationTests/FastEndpoints.OpenApi/Int.OpenApi.csproj"/>
         <Project Path="Tests/IntegrationTests/FastEndpoints/Int.FastEndpoints.csproj"/>
         <Project Path="Tests/IntegrationTests/FastEndpoints.OData/Int.OData.csproj"/>
     </Folder>

--- a/FastEndpoints.slnx
+++ b/FastEndpoints.slnx
@@ -29,10 +29,10 @@
         <Project Path="Src/ClientGen/FastEndpoints.ClientGen.csproj"/>
         <Project Path="Src/Swagger/FastEndpoints.Swagger.csproj"/>
     </Folder>
-    <!-- <Folder Name="/Legacy/Tests/"> -->
-    <!--     <Project Path="Tests/IntegrationTests/FastEndpoints.Swagger/Int.Swagger.csproj"/> -->
-    <!--     <Project Path="Tests/UnitTests/FastEndpoints.Swagger/Unit.Swagger.csproj"/> -->
-    <!-- </Folder> -->
+    <Folder Name="/Legacy/Tests/">
+        <Project Path="Tests/IntegrationTests/FastEndpoints.Swagger/Int.Swagger.csproj"/>
+        <Project Path="Tests/UnitTests/FastEndpoints.Swagger/Unit.Swagger.csproj"/>
+    </Folder>
     <Folder Name="/TestHarnesses/">
         <Project Path="TestHarness/OData/OData.csproj"/>
         <Project Path="TestHarness/OpenApi.Kiota/OpenApi.Kiota.csproj"/>
@@ -44,8 +44,8 @@
     </Folder>
     <Folder Name="/Tests/IntegrationTests/">
         <Project Path="Tests/IntegrationTests/FastEndpoints.Agents/Int.Agents.csproj"/>
-        <Project Path="Tests/IntegrationTests/FastEndpoints.OpenApi.Kiota/Int.OpenApi.Kiota.csproj"/>
-        <Project Path="Tests/IntegrationTests/FastEndpoints.OpenApi/Int.OpenApi.csproj"/>
+        <!-- <Project Path="Tests/IntegrationTests/FastEndpoints.OpenApi.Kiota/Int.OpenApi.Kiota.csproj"/> -->
+        <!-- <Project Path="Tests/IntegrationTests/FastEndpoints.OpenApi/Int.OpenApi.csproj"/> -->
         <Project Path="Tests/IntegrationTests/FastEndpoints/Int.FastEndpoints.csproj"/>
         <Project Path="Tests/IntegrationTests/FastEndpoints.OData/Int.OData.csproj"/>
     </Folder>

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -90,6 +90,20 @@ app.UseDefaultExceptionHandler(useProblemDetails: true)
 
 ## Fixes 🪲
 
+<details><summary>Nested validator property-level constraints missing from Swagger schema</summary>
+
+When a request DTO used a child validator (via `SetValidator(...)` / `RuleFor(x => x.Child).SetValidator(...)`), the property-level constraints defined in that child validator (such as `NotEmpty`, `MaxLength`, `InclusiveBetween`, etc.) were silently dropped from the generated Swagger schema for any request type processed after the first one that shared the same nested validator type.
+
+The root cause was that `ValidationSchemaProcessor` kept a `_childAdaptorValidators` dictionary as a singleton-level instance field. This dictionary is used to track already-seen child validator types to prevent infinite recursion. Because it was shared across all schema processing calls, a nested validator type recorded while processing request type `A` would be treated as "already seen" when encountered again during processing of request type `B`, and its rules would not be applied to `B`'s schema.
+
+</details>
+
+<details><summary>'ValidationSchemaProcessor' concurrency issue when generating multiple Swagger documents</summary>
+
+The `_childAdaptorValidators` instance field on the singleton `ValidationSchemaProcessor` was a plain non-thread-safe `Dictionary<string, IValidator>`. Concurrent Swagger document generation (e.g. multiple documents being built in parallel at startup) could cause race conditions on that shared dictionary. The field is now a local variable scoped to each `ProcessAsync` call, eliminating shared mutable state entirely.
+
+</details>
+
 <details><summary>Asymmetric JWT signing key updates no longer leak RSA handles</summary>
 
 Updating asymmetric JWT signing keys at runtime no longer keeps undisposed RSA instances alive after each key rotation. The validation key is now built from exported public key parameters instead of holding on to the temporary RSA instance used for import, avoiding unmanaged crypto handle leaks without disposing keys that may still be in use by concurrent token validations.

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -100,7 +100,7 @@ The root cause was that `ValidationSchemaProcessor` kept a `_childAdaptorValidat
 
 <details><summary>'ValidationSchemaProcessor' concurrency issue when generating multiple Swagger documents</summary>
 
-The `_childAdaptorValidators` instance field on the singleton `ValidationSchemaProcessor` was a plain non-thread-safe `Dictionary<string, IValidator>`. Concurrent Swagger document generation (e.g. multiple documents being built in parallel at startup) could cause race conditions on that shared dictionary. The field is now a local variable scoped to each `ProcessAsync` call, eliminating shared mutable state entirely.
+The `_childAdaptorValidators` instance field on the singleton `ValidationSchemaProcessor` was a plain non-thread-safe `Dictionary<string, IValidator>`. Concurrent Swagger document generation (e.g. multiple documents being built in parallel at startup) could cause race conditions on that shared dictionary. The field is now a local variable scoped to each `Process` call, eliminating shared mutable state entirely.
 
 </details>
 

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -152,14 +152,6 @@ If `AddFastEndpoints` is already called with the discovered types, `AddMessaging
 
 ## Fixes 🪲
 
-<details><summary>Nested validator property-level constraints missing from Swagger schema</summary>
-
-When a request DTO used a child validator (via `SetValidator(...)` / `RuleFor(x => x.Child).SetValidator(...)`), the property-level constraints defined in that child validator (such as `NotEmpty`, `MaxLength`, `InclusiveBetween`, etc.) were silently dropped from the generated Swagger schema for any request type processed after the first one that shared the same nested validator type.
-
-The root cause was that `ValidationSchemaProcessor` kept a `_childAdaptorValidators` dictionary as a singleton-level instance field. This dictionary is used to track already-seen child validator types to prevent infinite recursion. Because it was shared across all schema processing calls, a nested validator type recorded while processing request type `A` would be treated as "already seen" when encountered again during processing of request type `B`, and its rules would not be applied to `B`'s schema.
-
-</details>
-
 <details><summary>'ValidationSchemaProcessor' concurrency issue when generating multiple Swagger documents</summary>
 
 The `_childAdaptorValidators` instance field on the singleton `ValidationSchemaProcessor` was a plain non-thread-safe `Dictionary<string, IValidator>`. Concurrent Swagger document generation (e.g. multiple documents being built in parallel at startup) could cause race conditions on that shared dictionary. The field is now a local variable scoped to each `Process` call, eliminating shared mutable state entirely.
@@ -177,6 +169,14 @@ Updating asymmetric JWT signing keys at runtime no longer keeps undisposed RSA i
 Complex query/form binding now treats `DateOnly`, `TimeOnly`, `Half`, `Int128`, `UInt128`, `BigInteger`, `IPAddress`, and `IPEndPoint` as scalar values instead of recursively binding them as complex objects.
 
 This fixes nested `[FromQuery]` request DTO properties such as `DateOnly?` and `TimeOnly?` being left at their default values (`0001-01-01`, `00:00:00`, etc.) even when valid query string values were supplied.
+
+</details>
+
+<details><summary>'FastEndpoints.Swagger' nested validator issue</summary>
+
+When a request DTO used a child validator (via `SetValidator(...)` / `RuleFor(x => x.Child).SetValidator(...)`), the property-level constraints defined in that child validator (such as `NotEmpty`, `MaxLength`, `InclusiveBetween`, etc.) were silently dropped from the generated Swagger schema for any request type processed after the first one that shared the same nested validator type.
+
+The root cause was that `ValidationSchemaProcessor` kept a `_childAdaptorValidators` dictionary as a singleton-level instance field. This dictionary is used to track already-seen child validator types to prevent infinite recursion. Because it was shared across all schema processing calls, a nested validator type recorded while processing request type `A` would be treated as "already seen" when encountered again during processing of request type `B`, and its rules would not be applied to `B`'s schema.
 
 </details>
 

--- a/Src/Swagger/ValidationSchemaProcessor.cs
+++ b/Src/Swagger/ValidationSchemaProcessor.cs
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using FastEndpoints.Swagger.ValidationProcessor;
@@ -41,7 +42,7 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
     readonly ILogger<ValidationSchemaProcessor> _logger;
     static Type[]? _validatorTypes;
     readonly FluentValidationRule[] _rules;
-    readonly Dictionary<string, IValidator> _childAdaptorValidators = new();
+    readonly ConcurrentDictionary<string, IValidator> _childAdaptorValidators = new();
 
     public ValidationSchemaProcessor(IServiceResolver serviceResolver, ILogger<ValidationSchemaProcessor> logger)
     {

--- a/Src/Swagger/ValidationSchemaProcessor.cs
+++ b/Src/Swagger/ValidationSchemaProcessor.cs
@@ -64,7 +64,7 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
 
         var tRequest = context.ContextualType;
         using var scope = _serviceResolver.CreateScope();
-        var childAdaptorValidators = new Dictionary<string, IValidator>();
+        var activeChildValidators = new HashSet<Type>();
 
         foreach (var tValidator in _validatorTypes)
         {
@@ -74,7 +74,7 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
                 {
                     var validator = _serviceResolver.CreateInstance(tValidator, scope.ServiceProvider) ??
                                     throw new InvalidOperationException($"Unable to instantiate validator {tValidator.Name}!");
-                    ApplyValidator(context.Schema, (IValidator)validator, "", scope.ServiceProvider, childAdaptorValidators);
+                    ApplyValidator(context.Schema, (IValidator)validator, "", scope.ServiceProvider, activeChildValidators);
 
                     break;
                 }
@@ -86,19 +86,19 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
         }
     }
 
-    void ApplyValidator(JsonSchema schema, IValidator validator, string propertyPrefix, IServiceProvider services, Dictionary<string, IValidator> childAdaptorValidators)
+    void ApplyValidator(JsonSchema schema, IValidator validator, string propertyPrefix, IServiceProvider services, HashSet<Type> activeChildValidators)
     {
         // Create dict of rules for this validator
         var rulesDict = validator.GetDictionaryOfRules();
-        ApplyRulesToSchema(schema, rulesDict, propertyPrefix, services, childAdaptorValidators);
-        ApplyRulesFromIncludedValidators(schema, validator, services, childAdaptorValidators);
+        ApplyRulesToSchema(schema, rulesDict, propertyPrefix, services, activeChildValidators);
+        ApplyRulesFromIncludedValidators(schema, validator, services, activeChildValidators);
     }
 
     void ApplyRulesToSchema(JsonSchema? schema,
                             ReadOnlyDictionary<string, List<IValidationRule>> rulesDict,
                             string propertyPrefix,
                             IServiceProvider services,
-                            Dictionary<string, IValidator> childAdaptorValidators)
+                            HashSet<Type> activeChildValidators)
     {
         if (schema is null)
             return;
@@ -107,15 +107,15 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
         if (schema.ActualProperties != null)
         {
             foreach (var schemaProperty in schema.ActualProperties.Keys)
-                TryApplyValidation(schema, rulesDict, schemaProperty, propertyPrefix, services, childAdaptorValidators);
+                TryApplyValidation(schema, rulesDict, schemaProperty, propertyPrefix, services, activeChildValidators);
         }
 
         // Add properties from base class
-        ApplyRulesToSchema(schema.InheritedSchema, rulesDict, propertyPrefix, services, childAdaptorValidators);
+        ApplyRulesToSchema(schema.InheritedSchema, rulesDict, propertyPrefix, services, activeChildValidators);
     }
 
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(ChildValidatorAdaptor<,>))]
-    void ApplyRulesFromIncludedValidators(JsonSchema schema, IValidator validator, IServiceProvider services, Dictionary<string, IValidator> childAdaptorValidators)
+    void ApplyRulesFromIncludedValidators(JsonSchema schema, IValidator validator, IServiceProvider services, HashSet<Type> activeChildValidators)
     {
         if (validator is not IEnumerable<IValidationRule> rules)
             return;
@@ -141,8 +141,8 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
             if (adapterMethod.Invoke(adapter, [validationContext, null!]) is not IValidator includeValidator)
                 break;
 
-            ApplyRulesToSchema(schema, includeValidator.GetDictionaryOfRules(), string.Empty, services, childAdaptorValidators);
-            ApplyRulesFromIncludedValidators(schema, includeValidator, services, childAdaptorValidators);
+            ApplyRulesToSchema(schema, includeValidator.GetDictionaryOfRules(), string.Empty, services, activeChildValidators);
+            ApplyRulesFromIncludedValidators(schema, includeValidator, services, activeChildValidators);
         }
     }
 
@@ -151,7 +151,7 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
                             string propertyName,
                             string parameterPrefix,
                             IServiceProvider services,
-                            Dictionary<string, IValidator> childAdaptorValidators)
+                            HashSet<Type> activeChildValidators)
     {
         // Build the full property name with composition route: request.child.property
         var fullPropertyName = $"{parameterPrefix}{propertyName}";
@@ -161,17 +161,17 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
         {
             // Go through each rule and apply it to the schema
             foreach (var validationRule in validationRules)
-                ApplyValidationRule(schema, validationRule, propertyName, services, childAdaptorValidators);
+                ApplyValidationRule(schema, validationRule, propertyName, services, activeChildValidators);
         }
 
         // If the property is a child object, recursively apply validation to it adding prefix as we go down one level
         var property = schema.ActualProperties[propertyName];
         var propertySchema = property.ActualSchema;
         if (propertySchema.ActualProperties is not null && propertySchema.ActualProperties.Count > 0 && propertySchema != schema)
-            ApplyRulesToSchema(propertySchema, rulesDict, $"{fullPropertyName}.", services, childAdaptorValidators);
+            ApplyRulesToSchema(propertySchema, rulesDict, $"{fullPropertyName}.", services, activeChildValidators);
     }
 
-    void ApplyValidationRule(JsonSchema schema, IValidationRule validationRule, string propertyName, IServiceProvider services, Dictionary<string, IValidator> childAdaptorValidators)
+    void ApplyValidationRule(JsonSchema schema, IValidationRule validationRule, string propertyName, IServiceProvider services, HashSet<Type> activeChildValidators)
     {
         foreach (var ruleComponent in validationRule.Components)
         {
@@ -197,22 +197,23 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
                 if (validatorTypeObj is not Type validatorType)
                     throw new InvalidOperationException("ChildValidatorAdaptor.ValidatorType is null");
 
-                // Retrieve or create an instance of the validator
-                if (!validatorType.IsInterface &&                                                  //can't create instances of interfaces.
-                    !childAdaptorValidators.TryGetValue(validatorType.FullName!, out var childValidator))         //avoid infinite recursions if child validator seen.
-                {
-                    childValidator = childAdaptorValidators[validatorType.FullName!] =
-                                         (IValidator)_serviceResolver.CreateInstance(validatorType, services);
-                }
-                else
+                if (validatorType.IsInterface || !activeChildValidators.Add(validatorType))
                     continue;
 
-                // Apply the validator to the schema. Again, recursively
+                var childValidator = (IValidator)_serviceResolver.CreateInstance(validatorType, services);
                 var childSchema = schema.ActualProperties[propertyName].ActualSchema;
 
                 // Check if it is an array (RuleForEach()). In this case we need to apply validator to an Item Schema
                 childSchema = childSchema.Type == JsonObjectType.Array ? childSchema.Item!.ActualSchema : childSchema;
-                ApplyValidator(childSchema, childValidator, string.Empty, services, childAdaptorValidators);
+
+                try
+                {
+                    ApplyValidator(childSchema, childValidator, string.Empty, services, activeChildValidators);
+                }
+                finally
+                {
+                    activeChildValidators.Remove(validatorType);
+                }
 
                 continue;
             }

--- a/Src/Swagger/ValidationSchemaProcessor.cs
+++ b/Src/Swagger/ValidationSchemaProcessor.cs
@@ -20,7 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using FastEndpoints.Swagger.ValidationProcessor;
@@ -42,7 +41,6 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
     readonly ILogger<ValidationSchemaProcessor> _logger;
     static Type[]? _validatorTypes;
     readonly FluentValidationRule[] _rules;
-    readonly ConcurrentDictionary<string, IValidator> _childAdaptorValidators = new();
 
     public ValidationSchemaProcessor(IServiceResolver serviceResolver, ILogger<ValidationSchemaProcessor> logger)
     {
@@ -66,6 +64,7 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
 
         var tRequest = context.ContextualType;
         using var scope = _serviceResolver.CreateScope();
+        var childAdaptorValidators = new Dictionary<string, IValidator>();
 
         foreach (var tValidator in _validatorTypes)
         {
@@ -75,7 +74,7 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
                 {
                     var validator = _serviceResolver.CreateInstance(tValidator, scope.ServiceProvider) ??
                                     throw new InvalidOperationException($"Unable to instantiate validator {tValidator.Name}!");
-                    ApplyValidator(context.Schema, (IValidator)validator, "", scope.ServiceProvider);
+                    ApplyValidator(context.Schema, (IValidator)validator, "", scope.ServiceProvider, childAdaptorValidators);
 
                     break;
                 }
@@ -87,18 +86,19 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
         }
     }
 
-    void ApplyValidator(JsonSchema schema, IValidator validator, string propertyPrefix, IServiceProvider services)
+    void ApplyValidator(JsonSchema schema, IValidator validator, string propertyPrefix, IServiceProvider services, Dictionary<string, IValidator> childAdaptorValidators)
     {
         // Create dict of rules for this validator
         var rulesDict = validator.GetDictionaryOfRules();
-        ApplyRulesToSchema(schema, rulesDict, propertyPrefix, services);
-        ApplyRulesFromIncludedValidators(schema, validator, services);
+        ApplyRulesToSchema(schema, rulesDict, propertyPrefix, services, childAdaptorValidators);
+        ApplyRulesFromIncludedValidators(schema, validator, services, childAdaptorValidators);
     }
 
     void ApplyRulesToSchema(JsonSchema? schema,
                             ReadOnlyDictionary<string, List<IValidationRule>> rulesDict,
                             string propertyPrefix,
-                            IServiceProvider services)
+                            IServiceProvider services,
+                            Dictionary<string, IValidator> childAdaptorValidators)
     {
         if (schema is null)
             return;
@@ -107,15 +107,15 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
         if (schema.ActualProperties != null)
         {
             foreach (var schemaProperty in schema.ActualProperties.Keys)
-                TryApplyValidation(schema, rulesDict, schemaProperty, propertyPrefix, services);
+                TryApplyValidation(schema, rulesDict, schemaProperty, propertyPrefix, services, childAdaptorValidators);
         }
 
         // Add properties from base class
-        ApplyRulesToSchema(schema.InheritedSchema, rulesDict, propertyPrefix, services);
+        ApplyRulesToSchema(schema.InheritedSchema, rulesDict, propertyPrefix, services, childAdaptorValidators);
     }
 
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(ChildValidatorAdaptor<,>))]
-    void ApplyRulesFromIncludedValidators(JsonSchema schema, IValidator validator, IServiceProvider services)
+    void ApplyRulesFromIncludedValidators(JsonSchema schema, IValidator validator, IServiceProvider services, Dictionary<string, IValidator> childAdaptorValidators)
     {
         if (validator is not IEnumerable<IValidationRule> rules)
             return;
@@ -141,8 +141,8 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
             if (adapterMethod.Invoke(adapter, [validationContext, null!]) is not IValidator includeValidator)
                 break;
 
-            ApplyRulesToSchema(schema, includeValidator.GetDictionaryOfRules(), string.Empty, services);
-            ApplyRulesFromIncludedValidators(schema, includeValidator, services);
+            ApplyRulesToSchema(schema, includeValidator.GetDictionaryOfRules(), string.Empty, services, childAdaptorValidators);
+            ApplyRulesFromIncludedValidators(schema, includeValidator, services, childAdaptorValidators);
         }
     }
 
@@ -150,7 +150,8 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
                             ReadOnlyDictionary<string, List<IValidationRule>> rulesDict,
                             string propertyName,
                             string parameterPrefix,
-                            IServiceProvider services)
+                            IServiceProvider services,
+                            Dictionary<string, IValidator> childAdaptorValidators)
     {
         // Build the full property name with composition route: request.child.property
         var fullPropertyName = $"{parameterPrefix}{propertyName}";
@@ -160,17 +161,17 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
         {
             // Go through each rule and apply it to the schema
             foreach (var validationRule in validationRules)
-                ApplyValidationRule(schema, validationRule, propertyName, services);
+                ApplyValidationRule(schema, validationRule, propertyName, services, childAdaptorValidators);
         }
 
         // If the property is a child object, recursively apply validation to it adding prefix as we go down one level
         var property = schema.ActualProperties[propertyName];
         var propertySchema = property.ActualSchema;
         if (propertySchema.ActualProperties is not null && propertySchema.ActualProperties.Count > 0 && propertySchema != schema)
-            ApplyRulesToSchema(propertySchema, rulesDict, $"{fullPropertyName}.", services);
+            ApplyRulesToSchema(propertySchema, rulesDict, $"{fullPropertyName}.", services, childAdaptorValidators);
     }
 
-    void ApplyValidationRule(JsonSchema schema, IValidationRule validationRule, string propertyName, IServiceProvider services)
+    void ApplyValidationRule(JsonSchema schema, IValidationRule validationRule, string propertyName, IServiceProvider services, Dictionary<string, IValidator> childAdaptorValidators)
     {
         foreach (var ruleComponent in validationRule.Components)
         {
@@ -197,10 +198,10 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
                     throw new InvalidOperationException("ChildValidatorAdaptor.ValidatorType is null");
 
                 // Retrieve or create an instance of the validator
-                if (!validatorType.IsInterface &&                                                          //can't create instances of interfaces.
-                    !_childAdaptorValidators.TryGetValue(validatorType.FullName!, out var childValidator)) //avoid infinite recursions if child validator seen.
+                if (!validatorType.IsInterface &&                                                  //can't create instances of interfaces.
+                    !childAdaptorValidators.TryGetValue(validatorType.FullName!, out var childValidator))         //avoid infinite recursions if child validator seen.
                 {
-                    childValidator = _childAdaptorValidators[validatorType.FullName!] =
+                    childValidator = childAdaptorValidators[validatorType.FullName!] =
                                          (IValidator)_serviceResolver.CreateInstance(validatorType, services);
                 }
                 else
@@ -211,7 +212,7 @@ sealed class ValidationSchemaProcessor : ISchemaProcessor
 
                 // Check if it is an array (RuleForEach()). In this case we need to apply validator to an Item Schema
                 childSchema = childSchema.Type == JsonObjectType.Array ? childSchema.Item!.ActualSchema : childSchema;
-                ApplyValidator(childSchema, childValidator, string.Empty, services);
+                ApplyValidator(childSchema, childValidator, string.Empty, services, childAdaptorValidators);
 
                 continue;
             }

--- a/TestHarness/Web/DocumentRegistration.cs
+++ b/TestHarness/Web/DocumentRegistration.cs
@@ -1,0 +1,277 @@
+//using Microsoft.OpenApi;
+
+static class DocumentRegistration
+{
+    // public static IServiceCollection AddOpenApiDocuments(this IServiceCollection services)
+    // {
+    //     Func<EndpointDefinition, bool> excludeReviewAndReleaseVersioning = ep => ep.EndpointTags?.Contains("release_versioning") is not true &&
+    //                                                                              ep.EndpointTags?.Contains("swagger_review") is not true;
+    //     Func<EndpointDefinition, bool> includeReleaseVersioning = ep => ep.EndpointTags?.Contains("release_versioning") is true;
+    //     Func<EndpointDefinition, bool> includeSwaggerReview = ep => ep.EndpointTags?.Contains("swagger_review") is true;
+    //
+    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
+    //         services,
+    //         o =>
+    //         {
+    //             o.EndpointFilter = excludeReviewAndReleaseVersioning;
+    //             o.DocumentName = "Initial Release";
+    //             o.Title = "Web API";
+    //             o.Version = "v0.0";
+    //             o.TagCase = FastEndpoints.OpenApi.TagCase.TitleCase;
+    //             o.TagStripSymbols = true;
+    //         });
+    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
+    //         services,
+    //         o =>
+    //         {
+    //             o.EndpointFilter = excludeReviewAndReleaseVersioning;
+    //             o.DocumentName = "Release 1.0";
+    //             o.Title = "Web API";
+    //             o.Version = "v1.0";
+    //             o.AddAuth(
+    //                 "ApiKey",
+    //                 new()
+    //                 {
+    //                     Name = "api_key",
+    //                     In = ParameterLocation.Header,
+    //                     Type = SecuritySchemeType.ApiKey
+    //                 });
+    //             o.MaxEndpointVersion = 1;
+    //             o.TagStripSymbols = true;
+    //         });
+    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
+    //         services,
+    //         o =>
+    //         {
+    //             o.EndpointFilter = excludeReviewAndReleaseVersioning;
+    //             o.DocumentName = "Release 2.0";
+    //             o.Title = "FastEndpoints Sandbox";
+    //             o.Version = "v2.0";
+    //             o.MaxEndpointVersion = 2;
+    //             o.ShowDeprecatedOps = true;
+    //             o.TagStripSymbols = true;
+    //         });
+    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
+    //         services,
+    //         o => //only ver3 & only FastEndpoints
+    //         {
+    //             o.EndpointFilter = excludeReviewAndReleaseVersioning;
+    //             o.DocumentName = "Release 3.0";
+    //             o.Title = "FastEndpoints Sandbox ver3 only";
+    //             o.Version = "v3.0";
+    //             o.MinEndpointVersion = 3;
+    //             o.MaxEndpointVersion = 3;
+    //             o.ExcludeNonFastEndpoints = true;
+    //         });
+    //
+    //     //used for release versioning tests
+    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
+    //         services,
+    //         o =>
+    //         {
+    //             o.ExcludeNonFastEndpoints = true;
+    //             o.EndpointFilter = includeReleaseVersioning;
+    //             o.Title = "Web API";
+    //             o.DocumentName = "ReleaseVersioning - v0";
+    //             o.ReleaseVersion = 0;
+    //             o.ShowDeprecatedOps = true;
+    //         });
+    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
+    //         services,
+    //         o =>
+    //         {
+    //             o.ExcludeNonFastEndpoints = true;
+    //             o.EndpointFilter = includeReleaseVersioning;
+    //             o.Title = "Web API";
+    //             o.DocumentName = "ReleaseVersioning - v1";
+    //             o.ReleaseVersion = 1;
+    //             o.ShowDeprecatedOps = true;
+    //         });
+    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
+    //         services,
+    //         o =>
+    //         {
+    //             o.ExcludeNonFastEndpoints = true;
+    //             o.EndpointFilter = includeReleaseVersioning;
+    //             o.Title = "Web API";
+    //             o.DocumentName = "ReleaseVersioning - v2";
+    //             o.ReleaseVersion = 2;
+    //             o.ShowDeprecatedOps = true;
+    //         });
+    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
+    //         services,
+    //         o =>
+    //         {
+    //             o.ExcludeNonFastEndpoints = true;
+    //             o.EndpointFilter = includeReleaseVersioning;
+    //             o.Title = "Web API";
+    //             o.DocumentName = "ReleaseVersioning - v3";
+    //             o.ReleaseVersion = 3;
+    //             o.ShowDeprecatedOps = true;
+    //         });
+    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
+    //         services,
+    //         o =>
+    //         {
+    //             o.ExcludeNonFastEndpoints = true;
+    //             o.EndpointFilter = includeSwaggerReview;
+    //             o.Title = "Web API";
+    //             o.DocumentName = "Swagger Review";
+    //             o.TagStripSymbols = true;
+    //         });
+    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
+    //         services,
+    //         o =>
+    //         {
+    //             o.ExcludeNonFastEndpoints = true;
+    //             o.EndpointFilter = includeSwaggerReview;
+    //             o.Title = "Web API";
+    //             o.DocumentName = "Swagger Review Empty Schema";
+    //             o.TagStripSymbols = true;
+    //         });
+    //
+    //     return services;
+    // }
+
+    public static IServiceCollection AddSwaggerDocuments(this IServiceCollection services)
+    {
+        Func<EndpointDefinition, bool> excludeReviewAndReleaseVersioning = ep => ep.EndpointTags?.Contains("release_versioning") is not true &&
+                                                                                 ep.EndpointTags?.Contains("swagger_review") is not true;
+        Func<EndpointDefinition, bool> includeReleaseVersioning = ep => ep.EndpointTags?.Contains("release_versioning") is true;
+        Func<EndpointDefinition, bool> includeSwaggerReview = ep => ep.EndpointTags?.Contains("swagger_review") is true;
+
+        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+            services,
+            o =>
+            {
+                o.EndpointFilter = excludeReviewAndReleaseVersioning;
+                ConfigureSwaggerDocument(o, "Initial Release", "Web API", "v0.0");
+                o.TagCase = FastEndpoints.Swagger.TagCase.TitleCase;
+                o.TagStripSymbols = true;
+            });
+        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+            services,
+            o =>
+            {
+                o.EndpointFilter = excludeReviewAndReleaseVersioning;
+                ConfigureSwaggerDocument(
+                    o,
+                    "Release 1.0",
+                    "Web API",
+                    "v1.0",
+                    s => FastEndpoints.Swagger.Extensions.AddAuth(
+                        s,
+                        "ApiKey",
+                        new()
+                        {
+                            Name = "api_key",
+                            In = NSwag.OpenApiSecurityApiKeyLocation.Header,
+                            Type = NSwag.OpenApiSecuritySchemeType.ApiKey
+                        }));
+                o.MaxEndpointVersion = 1;
+                o.TagStripSymbols = true;
+            });
+        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+            services,
+            o =>
+            {
+                o.EndpointFilter = excludeReviewAndReleaseVersioning;
+                ConfigureSwaggerDocument(o, "Release 2.0", "FastEndpoints Sandbox", "v2.0");
+                o.MaxEndpointVersion = 2;
+                o.ShowDeprecatedOps = true;
+                o.TagStripSymbols = true;
+            });
+        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+            services,
+            o => //only ver3 & only FastEndpoints
+            {
+                o.EndpointFilter = excludeReviewAndReleaseVersioning;
+                ConfigureSwaggerDocument(o, "Release 3.0", "FastEndpoints Sandbox ver3 only", "v3.0");
+                o.MinEndpointVersion = 3;
+                o.MaxEndpointVersion = 3;
+                o.ExcludeNonFastEndpoints = true;
+            });
+
+        //used for release versioning tests
+        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+            services,
+            o =>
+            {
+                o.ExcludeNonFastEndpoints = true;
+                o.EndpointFilter = includeReleaseVersioning;
+                ConfigureSwaggerDocument(o, "ReleaseVersioning - v0", "Web API");
+                o.ReleaseVersion = 0;
+                o.ShowDeprecatedOps = true;
+            });
+        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+            services,
+            o =>
+            {
+                o.ExcludeNonFastEndpoints = true;
+                o.EndpointFilter = includeReleaseVersioning;
+                ConfigureSwaggerDocument(o, "ReleaseVersioning - v1", "Web API");
+                o.ReleaseVersion = 1;
+                o.ShowDeprecatedOps = true;
+            });
+        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+            services,
+            o =>
+            {
+                o.ExcludeNonFastEndpoints = true;
+                o.EndpointFilter = includeReleaseVersioning;
+                ConfigureSwaggerDocument(o, "ReleaseVersioning - v2", "Web API");
+                o.ReleaseVersion = 2;
+                o.ShowDeprecatedOps = true;
+            });
+        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+            services,
+            o =>
+            {
+                o.ExcludeNonFastEndpoints = true;
+                o.EndpointFilter = includeReleaseVersioning;
+                ConfigureSwaggerDocument(o, "ReleaseVersioning - v3", "Web API");
+                o.ReleaseVersion = 3;
+                o.ShowDeprecatedOps = true;
+            });
+        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+            services,
+            o =>
+            {
+                o.ExcludeNonFastEndpoints = true;
+                o.EndpointFilter = includeSwaggerReview;
+                ConfigureSwaggerDocument(o, "Swagger Review", "Web API");
+                o.TagStripSymbols = true;
+            });
+        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+            services,
+            o =>
+            {
+                o.ExcludeNonFastEndpoints = true;
+                o.EndpointFilter = includeSwaggerReview;
+                ConfigureSwaggerDocument(o, "Swagger Review Empty Schema", "Web API");
+                o.RemoveEmptyRequestSchema = true;
+                o.TagStripSymbols = true;
+            });
+
+        return services;
+
+        static void ConfigureSwaggerDocument(FastEndpoints.Swagger.DocumentOptions options,
+                                             string documentName,
+                                             string title,
+                                             string? version = null,
+                                             Action<NSwag.Generation.AspNetCore.AspNetCoreOpenApiDocumentGeneratorSettings>? configure = null)
+        {
+            options.DocumentSettings = s =>
+                                       {
+                                           s.DocumentName = documentName;
+                                           s.Title = title;
+
+                                           if (version is not null)
+                                               s.Version = version;
+
+                                           s.SchemaSettings.SchemaType = NJsonSchema.SchemaType.OpenApi3;
+                                           configure?.Invoke(s);
+                                       };
+        }
+    }
+}

--- a/TestHarness/Web/DocumentRegistration.cs
+++ b/TestHarness/Web/DocumentRegistration.cs
@@ -1,277 +1,277 @@
-//using Microsoft.OpenApi;
+using Microsoft.OpenApi;
 
 static class DocumentRegistration
 {
-    // public static IServiceCollection AddOpenApiDocuments(this IServiceCollection services)
-    // {
-    //     Func<EndpointDefinition, bool> excludeReviewAndReleaseVersioning = ep => ep.EndpointTags?.Contains("release_versioning") is not true &&
-    //                                                                              ep.EndpointTags?.Contains("swagger_review") is not true;
-    //     Func<EndpointDefinition, bool> includeReleaseVersioning = ep => ep.EndpointTags?.Contains("release_versioning") is true;
-    //     Func<EndpointDefinition, bool> includeSwaggerReview = ep => ep.EndpointTags?.Contains("swagger_review") is true;
-    //
-    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
-    //         services,
-    //         o =>
-    //         {
-    //             o.EndpointFilter = excludeReviewAndReleaseVersioning;
-    //             o.DocumentName = "Initial Release";
-    //             o.Title = "Web API";
-    //             o.Version = "v0.0";
-    //             o.TagCase = FastEndpoints.OpenApi.TagCase.TitleCase;
-    //             o.TagStripSymbols = true;
-    //         });
-    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
-    //         services,
-    //         o =>
-    //         {
-    //             o.EndpointFilter = excludeReviewAndReleaseVersioning;
-    //             o.DocumentName = "Release 1.0";
-    //             o.Title = "Web API";
-    //             o.Version = "v1.0";
-    //             o.AddAuth(
-    //                 "ApiKey",
-    //                 new()
-    //                 {
-    //                     Name = "api_key",
-    //                     In = ParameterLocation.Header,
-    //                     Type = SecuritySchemeType.ApiKey
-    //                 });
-    //             o.MaxEndpointVersion = 1;
-    //             o.TagStripSymbols = true;
-    //         });
-    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
-    //         services,
-    //         o =>
-    //         {
-    //             o.EndpointFilter = excludeReviewAndReleaseVersioning;
-    //             o.DocumentName = "Release 2.0";
-    //             o.Title = "FastEndpoints Sandbox";
-    //             o.Version = "v2.0";
-    //             o.MaxEndpointVersion = 2;
-    //             o.ShowDeprecatedOps = true;
-    //             o.TagStripSymbols = true;
-    //         });
-    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
-    //         services,
-    //         o => //only ver3 & only FastEndpoints
-    //         {
-    //             o.EndpointFilter = excludeReviewAndReleaseVersioning;
-    //             o.DocumentName = "Release 3.0";
-    //             o.Title = "FastEndpoints Sandbox ver3 only";
-    //             o.Version = "v3.0";
-    //             o.MinEndpointVersion = 3;
-    //             o.MaxEndpointVersion = 3;
-    //             o.ExcludeNonFastEndpoints = true;
-    //         });
-    //
-    //     //used for release versioning tests
-    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
-    //         services,
-    //         o =>
-    //         {
-    //             o.ExcludeNonFastEndpoints = true;
-    //             o.EndpointFilter = includeReleaseVersioning;
-    //             o.Title = "Web API";
-    //             o.DocumentName = "ReleaseVersioning - v0";
-    //             o.ReleaseVersion = 0;
-    //             o.ShowDeprecatedOps = true;
-    //         });
-    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
-    //         services,
-    //         o =>
-    //         {
-    //             o.ExcludeNonFastEndpoints = true;
-    //             o.EndpointFilter = includeReleaseVersioning;
-    //             o.Title = "Web API";
-    //             o.DocumentName = "ReleaseVersioning - v1";
-    //             o.ReleaseVersion = 1;
-    //             o.ShowDeprecatedOps = true;
-    //         });
-    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
-    //         services,
-    //         o =>
-    //         {
-    //             o.ExcludeNonFastEndpoints = true;
-    //             o.EndpointFilter = includeReleaseVersioning;
-    //             o.Title = "Web API";
-    //             o.DocumentName = "ReleaseVersioning - v2";
-    //             o.ReleaseVersion = 2;
-    //             o.ShowDeprecatedOps = true;
-    //         });
-    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
-    //         services,
-    //         o =>
-    //         {
-    //             o.ExcludeNonFastEndpoints = true;
-    //             o.EndpointFilter = includeReleaseVersioning;
-    //             o.Title = "Web API";
-    //             o.DocumentName = "ReleaseVersioning - v3";
-    //             o.ReleaseVersion = 3;
-    //             o.ShowDeprecatedOps = true;
-    //         });
-    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
-    //         services,
-    //         o =>
-    //         {
-    //             o.ExcludeNonFastEndpoints = true;
-    //             o.EndpointFilter = includeSwaggerReview;
-    //             o.Title = "Web API";
-    //             o.DocumentName = "Swagger Review";
-    //             o.TagStripSymbols = true;
-    //         });
-    //     FastEndpoints.OpenApi.Extensions.OpenApiDocument(
-    //         services,
-    //         o =>
-    //         {
-    //             o.ExcludeNonFastEndpoints = true;
-    //             o.EndpointFilter = includeSwaggerReview;
-    //             o.Title = "Web API";
-    //             o.DocumentName = "Swagger Review Empty Schema";
-    //             o.TagStripSymbols = true;
-    //         });
-    //
-    //     return services;
-    // }
-
-    public static IServiceCollection AddSwaggerDocuments(this IServiceCollection services)
+    public static IServiceCollection AddOpenApiDocuments(this IServiceCollection services)
     {
         Func<EndpointDefinition, bool> excludeReviewAndReleaseVersioning = ep => ep.EndpointTags?.Contains("release_versioning") is not true &&
                                                                                  ep.EndpointTags?.Contains("swagger_review") is not true;
         Func<EndpointDefinition, bool> includeReleaseVersioning = ep => ep.EndpointTags?.Contains("release_versioning") is true;
         Func<EndpointDefinition, bool> includeSwaggerReview = ep => ep.EndpointTags?.Contains("swagger_review") is true;
 
-        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+        FastEndpoints.OpenApi.Extensions.OpenApiDocument(
             services,
             o =>
             {
                 o.EndpointFilter = excludeReviewAndReleaseVersioning;
-                ConfigureSwaggerDocument(o, "Initial Release", "Web API", "v0.0");
-                o.TagCase = FastEndpoints.Swagger.TagCase.TitleCase;
+                o.DocumentName = "Initial Release";
+                o.Title = "Web API";
+                o.Version = "v0.0";
+                o.TagCase = FastEndpoints.OpenApi.TagCase.TitleCase;
                 o.TagStripSymbols = true;
             });
-        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+        FastEndpoints.OpenApi.Extensions.OpenApiDocument(
             services,
             o =>
             {
                 o.EndpointFilter = excludeReviewAndReleaseVersioning;
-                ConfigureSwaggerDocument(
-                    o,
-                    "Release 1.0",
-                    "Web API",
-                    "v1.0",
-                    s => FastEndpoints.Swagger.Extensions.AddAuth(
-                        s,
-                        "ApiKey",
-                        new()
-                        {
-                            Name = "api_key",
-                            In = NSwag.OpenApiSecurityApiKeyLocation.Header,
-                            Type = NSwag.OpenApiSecuritySchemeType.ApiKey
-                        }));
+                o.DocumentName = "Release 1.0";
+                o.Title = "Web API";
+                o.Version = "v1.0";
+                o.AddAuth(
+                    "ApiKey",
+                    new()
+                    {
+                        Name = "api_key",
+                        In = ParameterLocation.Header,
+                        Type = SecuritySchemeType.ApiKey
+                    });
                 o.MaxEndpointVersion = 1;
                 o.TagStripSymbols = true;
             });
-        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+        FastEndpoints.OpenApi.Extensions.OpenApiDocument(
             services,
             o =>
             {
                 o.EndpointFilter = excludeReviewAndReleaseVersioning;
-                ConfigureSwaggerDocument(o, "Release 2.0", "FastEndpoints Sandbox", "v2.0");
+                o.DocumentName = "Release 2.0";
+                o.Title = "FastEndpoints Sandbox";
+                o.Version = "v2.0";
                 o.MaxEndpointVersion = 2;
                 o.ShowDeprecatedOps = true;
                 o.TagStripSymbols = true;
             });
-        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+        FastEndpoints.OpenApi.Extensions.OpenApiDocument(
             services,
             o => //only ver3 & only FastEndpoints
             {
                 o.EndpointFilter = excludeReviewAndReleaseVersioning;
-                ConfigureSwaggerDocument(o, "Release 3.0", "FastEndpoints Sandbox ver3 only", "v3.0");
+                o.DocumentName = "Release 3.0";
+                o.Title = "FastEndpoints Sandbox ver3 only";
+                o.Version = "v3.0";
                 o.MinEndpointVersion = 3;
                 o.MaxEndpointVersion = 3;
                 o.ExcludeNonFastEndpoints = true;
             });
 
         //used for release versioning tests
-        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+        FastEndpoints.OpenApi.Extensions.OpenApiDocument(
             services,
             o =>
             {
                 o.ExcludeNonFastEndpoints = true;
                 o.EndpointFilter = includeReleaseVersioning;
-                ConfigureSwaggerDocument(o, "ReleaseVersioning - v0", "Web API");
+                o.Title = "Web API";
+                o.DocumentName = "ReleaseVersioning - v0";
                 o.ReleaseVersion = 0;
                 o.ShowDeprecatedOps = true;
             });
-        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+        FastEndpoints.OpenApi.Extensions.OpenApiDocument(
             services,
             o =>
             {
                 o.ExcludeNonFastEndpoints = true;
                 o.EndpointFilter = includeReleaseVersioning;
-                ConfigureSwaggerDocument(o, "ReleaseVersioning - v1", "Web API");
+                o.Title = "Web API";
+                o.DocumentName = "ReleaseVersioning - v1";
                 o.ReleaseVersion = 1;
                 o.ShowDeprecatedOps = true;
             });
-        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+        FastEndpoints.OpenApi.Extensions.OpenApiDocument(
             services,
             o =>
             {
                 o.ExcludeNonFastEndpoints = true;
                 o.EndpointFilter = includeReleaseVersioning;
-                ConfigureSwaggerDocument(o, "ReleaseVersioning - v2", "Web API");
+                o.Title = "Web API";
+                o.DocumentName = "ReleaseVersioning - v2";
                 o.ReleaseVersion = 2;
                 o.ShowDeprecatedOps = true;
             });
-        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+        FastEndpoints.OpenApi.Extensions.OpenApiDocument(
             services,
             o =>
             {
                 o.ExcludeNonFastEndpoints = true;
                 o.EndpointFilter = includeReleaseVersioning;
-                ConfigureSwaggerDocument(o, "ReleaseVersioning - v3", "Web API");
+                o.Title = "Web API";
+                o.DocumentName = "ReleaseVersioning - v3";
                 o.ReleaseVersion = 3;
                 o.ShowDeprecatedOps = true;
             });
-        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+        FastEndpoints.OpenApi.Extensions.OpenApiDocument(
             services,
             o =>
             {
                 o.ExcludeNonFastEndpoints = true;
                 o.EndpointFilter = includeSwaggerReview;
-                ConfigureSwaggerDocument(o, "Swagger Review", "Web API");
+                o.Title = "Web API";
+                o.DocumentName = "Swagger Review";
                 o.TagStripSymbols = true;
             });
-        FastEndpoints.Swagger.Extensions.SwaggerDocument(
+        FastEndpoints.OpenApi.Extensions.OpenApiDocument(
             services,
             o =>
             {
                 o.ExcludeNonFastEndpoints = true;
                 o.EndpointFilter = includeSwaggerReview;
-                ConfigureSwaggerDocument(o, "Swagger Review Empty Schema", "Web API");
-                o.RemoveEmptyRequestSchema = true;
+                o.Title = "Web API";
+                o.DocumentName = "Swagger Review Empty Schema";
                 o.TagStripSymbols = true;
             });
 
         return services;
-
-        static void ConfigureSwaggerDocument(FastEndpoints.Swagger.DocumentOptions options,
-                                             string documentName,
-                                             string title,
-                                             string? version = null,
-                                             Action<NSwag.Generation.AspNetCore.AspNetCoreOpenApiDocumentGeneratorSettings>? configure = null)
-        {
-            options.DocumentSettings = s =>
-                                       {
-                                           s.DocumentName = documentName;
-                                           s.Title = title;
-
-                                           if (version is not null)
-                                               s.Version = version;
-
-                                           s.SchemaSettings.SchemaType = NJsonSchema.SchemaType.OpenApi3;
-                                           configure?.Invoke(s);
-                                       };
-        }
     }
+
+    // public static IServiceCollection AddSwaggerDocuments(this IServiceCollection services)
+    // {
+    //     Func<EndpointDefinition, bool> excludeReviewAndReleaseVersioning = ep => ep.EndpointTags?.Contains("release_versioning") is not true &&
+    //                                                                              ep.EndpointTags?.Contains("swagger_review") is not true;
+    //     Func<EndpointDefinition, bool> includeReleaseVersioning = ep => ep.EndpointTags?.Contains("release_versioning") is true;
+    //     Func<EndpointDefinition, bool> includeSwaggerReview = ep => ep.EndpointTags?.Contains("swagger_review") is true;
+    //
+    //     FastEndpoints.Swagger.Extensions.SwaggerDocument(
+    //         services,
+    //         o =>
+    //         {
+    //             o.EndpointFilter = excludeReviewAndReleaseVersioning;
+    //             ConfigureSwaggerDocument(o, "Initial Release", "Web API", "v0.0");
+    //             o.TagCase = FastEndpoints.Swagger.TagCase.TitleCase;
+    //             o.TagStripSymbols = true;
+    //         });
+    //     FastEndpoints.Swagger.Extensions.SwaggerDocument(
+    //         services,
+    //         o =>
+    //         {
+    //             o.EndpointFilter = excludeReviewAndReleaseVersioning;
+    //             ConfigureSwaggerDocument(
+    //                 o,
+    //                 "Release 1.0",
+    //                 "Web API",
+    //                 "v1.0",
+    //                 s => FastEndpoints.Swagger.Extensions.AddAuth(
+    //                     s,
+    //                     "ApiKey",
+    //                     new()
+    //                     {
+    //                         Name = "api_key",
+    //                         In = NSwag.OpenApiSecurityApiKeyLocation.Header,
+    //                         Type = NSwag.OpenApiSecuritySchemeType.ApiKey
+    //                     }));
+    //             o.MaxEndpointVersion = 1;
+    //             o.TagStripSymbols = true;
+    //         });
+    //     FastEndpoints.Swagger.Extensions.SwaggerDocument(
+    //         services,
+    //         o =>
+    //         {
+    //             o.EndpointFilter = excludeReviewAndReleaseVersioning;
+    //             ConfigureSwaggerDocument(o, "Release 2.0", "FastEndpoints Sandbox", "v2.0");
+    //             o.MaxEndpointVersion = 2;
+    //             o.ShowDeprecatedOps = true;
+    //             o.TagStripSymbols = true;
+    //         });
+    //     FastEndpoints.Swagger.Extensions.SwaggerDocument(
+    //         services,
+    //         o => //only ver3 & only FastEndpoints
+    //         {
+    //             o.EndpointFilter = excludeReviewAndReleaseVersioning;
+    //             ConfigureSwaggerDocument(o, "Release 3.0", "FastEndpoints Sandbox ver3 only", "v3.0");
+    //             o.MinEndpointVersion = 3;
+    //             o.MaxEndpointVersion = 3;
+    //             o.ExcludeNonFastEndpoints = true;
+    //         });
+    //
+    //     //used for release versioning tests
+    //     FastEndpoints.Swagger.Extensions.SwaggerDocument(
+    //         services,
+    //         o =>
+    //         {
+    //             o.ExcludeNonFastEndpoints = true;
+    //             o.EndpointFilter = includeReleaseVersioning;
+    //             ConfigureSwaggerDocument(o, "ReleaseVersioning - v0", "Web API");
+    //             o.ReleaseVersion = 0;
+    //             o.ShowDeprecatedOps = true;
+    //         });
+    //     FastEndpoints.Swagger.Extensions.SwaggerDocument(
+    //         services,
+    //         o =>
+    //         {
+    //             o.ExcludeNonFastEndpoints = true;
+    //             o.EndpointFilter = includeReleaseVersioning;
+    //             ConfigureSwaggerDocument(o, "ReleaseVersioning - v1", "Web API");
+    //             o.ReleaseVersion = 1;
+    //             o.ShowDeprecatedOps = true;
+    //         });
+    //     FastEndpoints.Swagger.Extensions.SwaggerDocument(
+    //         services,
+    //         o =>
+    //         {
+    //             o.ExcludeNonFastEndpoints = true;
+    //             o.EndpointFilter = includeReleaseVersioning;
+    //             ConfigureSwaggerDocument(o, "ReleaseVersioning - v2", "Web API");
+    //             o.ReleaseVersion = 2;
+    //             o.ShowDeprecatedOps = true;
+    //         });
+    //     FastEndpoints.Swagger.Extensions.SwaggerDocument(
+    //         services,
+    //         o =>
+    //         {
+    //             o.ExcludeNonFastEndpoints = true;
+    //             o.EndpointFilter = includeReleaseVersioning;
+    //             ConfigureSwaggerDocument(o, "ReleaseVersioning - v3", "Web API");
+    //             o.ReleaseVersion = 3;
+    //             o.ShowDeprecatedOps = true;
+    //         });
+    //     FastEndpoints.Swagger.Extensions.SwaggerDocument(
+    //         services,
+    //         o =>
+    //         {
+    //             o.ExcludeNonFastEndpoints = true;
+    //             o.EndpointFilter = includeSwaggerReview;
+    //             ConfigureSwaggerDocument(o, "Swagger Review", "Web API");
+    //             o.TagStripSymbols = true;
+    //         });
+    //     FastEndpoints.Swagger.Extensions.SwaggerDocument(
+    //         services,
+    //         o =>
+    //         {
+    //             o.ExcludeNonFastEndpoints = true;
+    //             o.EndpointFilter = includeSwaggerReview;
+    //             ConfigureSwaggerDocument(o, "Swagger Review Empty Schema", "Web API");
+    //             o.RemoveEmptyRequestSchema = true;
+    //             o.TagStripSymbols = true;
+    //         });
+    //
+    //     return services;
+    //
+    //     static void ConfigureSwaggerDocument(FastEndpoints.Swagger.DocumentOptions options,
+    //                                          string documentName,
+    //                                          string title,
+    //                                          string? version = null,
+    //                                          Action<NSwag.Generation.AspNetCore.AspNetCoreOpenApiDocumentGeneratorSettings>? configure = null)
+    //     {
+    //         options.DocumentSettings = s =>
+    //                                    {
+    //                                        s.DocumentName = documentName;
+    //                                        s.Title = title;
+    //
+    //                                        if (version is not null)
+    //                                            s.Version = version;
+    //
+    //                                        s.SchemaSettings.SchemaType = NJsonSchema.SchemaType.OpenApi3;
+    //                                        configure?.Invoke(s);
+    //                                    };
+    //     }
+    // }
 }

--- a/TestHarness/Web/DocumentRegistration.cs
+++ b/TestHarness/Web/DocumentRegistration.cs
@@ -4,8 +4,7 @@ static class DocumentRegistration
 {
     public static IServiceCollection AddOpenApiDocuments(this IServiceCollection services)
     {
-        Func<EndpointDefinition, bool> excludeReviewAndReleaseVersioning = ep => ep.EndpointTags?.Contains("release_versioning") is not true &&
-                                                                                 ep.EndpointTags?.Contains("swagger_review") is not true;
+        Func<EndpointDefinition, bool> excludeReleaseVersioning = ep => ep.EndpointTags?.Contains("release_versioning") is not true;
         Func<EndpointDefinition, bool> includeReleaseVersioning = ep => ep.EndpointTags?.Contains("release_versioning") is true;
         Func<EndpointDefinition, bool> includeSwaggerReview = ep => ep.EndpointTags?.Contains("swagger_review") is true;
 
@@ -13,7 +12,7 @@ static class DocumentRegistration
             services,
             o =>
             {
-                o.EndpointFilter = excludeReviewAndReleaseVersioning;
+                o.EndpointFilter = excludeReleaseVersioning;
                 o.DocumentName = "Initial Release";
                 o.Title = "Web API";
                 o.Version = "v0.0";
@@ -24,7 +23,7 @@ static class DocumentRegistration
             services,
             o =>
             {
-                o.EndpointFilter = excludeReviewAndReleaseVersioning;
+                o.EndpointFilter = excludeReleaseVersioning;
                 o.DocumentName = "Release 1.0";
                 o.Title = "Web API";
                 o.Version = "v1.0";
@@ -43,7 +42,7 @@ static class DocumentRegistration
             services,
             o =>
             {
-                o.EndpointFilter = excludeReviewAndReleaseVersioning;
+                o.EndpointFilter = excludeReleaseVersioning;
                 o.DocumentName = "Release 2.0";
                 o.Title = "FastEndpoints Sandbox";
                 o.Version = "v2.0";
@@ -55,7 +54,7 @@ static class DocumentRegistration
             services,
             o => //only ver3 & only FastEndpoints
             {
-                o.EndpointFilter = excludeReviewAndReleaseVersioning;
+                o.EndpointFilter = excludeReleaseVersioning;
                 o.DocumentName = "Release 3.0";
                 o.Title = "FastEndpoints Sandbox ver3 only";
                 o.Version = "v3.0";

--- a/TestHarness/Web/Program.cs
+++ b/TestHarness/Web/Program.cs
@@ -1,5 +1,5 @@
 using System.Globalization;
-using FastEndpoints.Swagger;
+using Scalar.AspNetCore;
 using TestCases.ClientStreamingTest;
 using TestCases.CommandBusTest;
 using TestCases.CommandHandlerTest;
@@ -17,6 +17,8 @@ using TestCases.X402;
 using Web;
 using Web.PipelineBehaviors.PreProcessors;
 using Web.Services;
+
+//using FastEndpoints.Swagger;
 
 var bld = WebApplication.CreateBuilder(args);
 bld.AddHandlerServer();
@@ -37,8 +39,9 @@ bld.Services
    .RegisterServicesFromWeb()
    .AddAntiforgery();
 
-//bld.Services.AddOpenApiDocuments();
-bld.Services.AddSwaggerDocuments();
+bld.Services.AddOpenApiDocuments();
+
+//bld.Services.AddSwaggerDocuments();
 
 if (bld.Environment.EnvironmentName == "Testing")
     bld.Services.AddSingleton<IX402FacilitatorClient, FakeFacilitatorClient>();
@@ -117,15 +120,15 @@ app.UseRequestLocalization(
 
 if (!app.Environment.IsProduction())
 {
-    app.UseSwaggerGen();
+    //app.UseSwaggerGen();
 
-    // app.MapOpenApi();
-    // app.MapScalarApiReference(
-    //     o =>
-    //     {
-    //         o.AddDocuments("Initial Release", "Release 1.0", "Release 2.0", "Release 3.0");
-    //         o.OperationTitleSource = OperationTitleSource.Path;
-    //     });
+    app.MapOpenApi();
+    app.MapScalarApiReference(
+        o =>
+        {
+            o.AddDocuments("Initial Release", "Release 1.0", "Release 2.0", "Release 3.0");
+            o.OperationTitleSource = OperationTitleSource.Path;
+        });
 }
 app.Services.RegisterGenericCommand(typeof(GenericCommand<>), typeof(GenericCommandHandler<>));
 app.Services.RegisterGenericCommand(typeof(GenericNoResultCommand<>), typeof(GenericNoResultCommandHandler<>));

--- a/TestHarness/Web/Program.cs
+++ b/TestHarness/Web/Program.cs
@@ -1,7 +1,5 @@
 using System.Globalization;
-using FastEndpoints.OpenApi;
-using Microsoft.OpenApi;
-using Scalar.AspNetCore;
+using FastEndpoints.Swagger;
 using TestCases.ClientStreamingTest;
 using TestCases.CommandBusTest;
 using TestCases.CommandHandlerTest;
@@ -20,10 +18,6 @@ using Web;
 using Web.PipelineBehaviors.PreProcessors;
 using Web.Services;
 
-Func<EndpointDefinition, bool> excludeReleaseVersioning = ep => ep.EndpointTags?.Contains("release_versioning") is not true;
-Func<EndpointDefinition, bool> includeReleaseVersioning = ep => ep.EndpointTags?.Contains("release_versioning") is true;
-Func<EndpointDefinition, bool> includeSwaggerReview = ep => ep.EndpointTags?.Contains("swagger_review") is true;
-
 var bld = WebApplication.CreateBuilder(args);
 bld.AddHandlerServer();
 bld.Services
@@ -41,117 +35,10 @@ bld.Services
    .AddSingleton(new SingltonSVC(0))
    .AddJobQueues<Job, JobStorage>()
    .RegisterServicesFromWeb()
-   .AddAntiforgery()
-   .OpenApiDocument(
-       o =>
-       {
-           o.EndpointFilter = excludeReleaseVersioning;
-           o.DocumentName = "Initial Release";
-           o.Title = "Web API";
-           o.Version = "v0.0";
-           o.TagCase = TagCase.TitleCase;
-           o.TagStripSymbols = true;
-       })
-   .OpenApiDocument(
-       o =>
-       {
-           o.EndpointFilter = excludeReleaseVersioning;
-           o.DocumentName = "Release 1.0";
-           o.Title = "Web API";
-           o.Version = "v1.0";
-           o.AddAuth(
-               "ApiKey",
-               new()
-               {
-                   Name = "api_key",
-                   In = ParameterLocation.Header,
-                   Type = SecuritySchemeType.ApiKey
-               });
-           o.MaxEndpointVersion = 1;
-           o.TagStripSymbols = true;
-       })
-   .OpenApiDocument(
-       o =>
-       {
-           o.EndpointFilter = excludeReleaseVersioning;
-           o.DocumentName = "Release 2.0";
-           o.Title = "FastEndpoints Sandbox";
-           o.Version = "v2.0";
-           o.MaxEndpointVersion = 2;
-           o.ShowDeprecatedOps = true;
-           o.TagStripSymbols = true;
-       })
-   .OpenApiDocument(
-       o => //only ver3 & only FastEndpoints
-       {
-           o.EndpointFilter = excludeReleaseVersioning;
-           o.DocumentName = "Release 3.0";
-           o.Title = "FastEndpoints Sandbox ver3 only";
-           o.Version = "v3.0";
-           o.MinEndpointVersion = 3;
-           o.MaxEndpointVersion = 3;
-           o.ExcludeNonFastEndpoints = true;
-       })
+   .AddAntiforgery();
 
-   //used for release versioning tests
-   .OpenApiDocument(
-       o =>
-       {
-           o.ExcludeNonFastEndpoints = true;
-           o.EndpointFilter = includeReleaseVersioning;
-           o.Title = "Web API";
-           o.DocumentName = "ReleaseVersioning - v0";
-           o.ReleaseVersion = 0;
-           o.ShowDeprecatedOps = true;
-       })
-   .OpenApiDocument(
-       o =>
-       {
-           o.ExcludeNonFastEndpoints = true;
-           o.EndpointFilter = includeReleaseVersioning;
-           o.Title = "Web API";
-           o.DocumentName = "ReleaseVersioning - v1";
-           o.ReleaseVersion = 1;
-           o.ShowDeprecatedOps = true;
-       })
-   .OpenApiDocument(
-       o =>
-       {
-           o.ExcludeNonFastEndpoints = true;
-           o.EndpointFilter = includeReleaseVersioning;
-           o.Title = "Web API";
-           o.DocumentName = "ReleaseVersioning - v2";
-           o.ReleaseVersion = 2;
-           o.ShowDeprecatedOps = true;
-       })
-   .OpenApiDocument(
-       o =>
-       {
-           o.ExcludeNonFastEndpoints = true;
-           o.EndpointFilter = includeReleaseVersioning;
-           o.Title = "Web API";
-           o.DocumentName = "ReleaseVersioning - v3";
-           o.ReleaseVersion = 3;
-           o.ShowDeprecatedOps = true;
-       })
-   .OpenApiDocument(
-       o =>
-       {
-           o.ExcludeNonFastEndpoints = true;
-           o.EndpointFilter = includeSwaggerReview;
-           o.Title = "Web API";
-           o.DocumentName = "Swagger Review";
-           o.TagStripSymbols = true;
-       })
-   .OpenApiDocument(
-       o =>
-       {
-           o.ExcludeNonFastEndpoints = true;
-           o.EndpointFilter = includeSwaggerReview;
-           o.Title = "Web API";
-           o.DocumentName = "Swagger Review Empty Schema";
-           o.TagStripSymbols = true;
-       });
+//bld.Services.AddOpenApiDocuments();
+bld.Services.AddSwaggerDocuments();
 
 if (bld.Environment.EnvironmentName == "Testing")
     bld.Services.AddSingleton<IX402FacilitatorClient, FakeFacilitatorClient>();
@@ -230,15 +117,16 @@ app.UseRequestLocalization(
 
 if (!app.Environment.IsProduction())
 {
-    app.MapOpenApi();
-    app.MapScalarApiReference(
-        o =>
-        {
-            o.AddDocuments("Initial Release", "Release 1.0", "Release 2.0", "Release 3.0");
-            o.OperationTitleSource = OperationTitleSource.Path;
-        });
-}
+    app.UseSwaggerGen();
 
+    // app.MapOpenApi();
+    // app.MapScalarApiReference(
+    //     o =>
+    //     {
+    //         o.AddDocuments("Initial Release", "Release 1.0", "Release 2.0", "Release 3.0");
+    //         o.OperationTitleSource = OperationTitleSource.Path;
+    //     });
+}
 app.Services.RegisterGenericCommand(typeof(GenericCommand<>), typeof(GenericCommandHandler<>));
 app.Services.RegisterGenericCommand(typeof(GenericNoResultCommand<>), typeof(GenericNoResultCommandHandler<>));
 app.Services.RegisterGenericCommand<JobTestGenericCommand<SomeEvent>, JobTestGenericCommandHandler<SomeEvent>>();

--- a/TestHarness/Web/Web.csproj
+++ b/TestHarness/Web/Web.csproj
@@ -15,7 +15,8 @@
         <ProjectReference Include="..\..\Src\Library\FastEndpoints.csproj"/>
         <ProjectReference Include="..\..\Src\Messaging\Messaging.Remote\FastEndpoints.Messaging.Remote.csproj"/>
         <ProjectReference Include="..\..\Src\Security\FastEndpoints.Security.csproj"/>
-        <ProjectReference Include="..\..\Src\OpenApi\FastEndpoints.OpenApi.csproj"/>
+        <!-- <ProjectReference Include="..\..\Src\OpenApi\FastEndpoints.OpenApi.csproj"/> -->
+        <ProjectReference Include="..\..\Src\Swagger\FastEndpoints.Swagger.csproj"/>
     </ItemGroup>
 
     <!--<PropertyGroup>

--- a/TestHarness/Web/Web.csproj
+++ b/TestHarness/Web/Web.csproj
@@ -15,8 +15,8 @@
         <ProjectReference Include="..\..\Src\Library\FastEndpoints.csproj"/>
         <ProjectReference Include="..\..\Src\Messaging\Messaging.Remote\FastEndpoints.Messaging.Remote.csproj"/>
         <ProjectReference Include="..\..\Src\Security\FastEndpoints.Security.csproj"/>
-        <!-- <ProjectReference Include="..\..\Src\OpenApi\FastEndpoints.OpenApi.csproj"/> -->
-        <ProjectReference Include="..\..\Src\Swagger\FastEndpoints.Swagger.csproj"/>
+        <ProjectReference Include="..\..\Src\OpenApi\FastEndpoints.OpenApi.csproj"/>
+        <!-- <ProjectReference Include="..\..\Src\Swagger\FastEndpoints.Swagger.csproj"/> -->
     </ItemGroup>
 
     <!--<PropertyGroup>

--- a/TestHarness/Web/[Features]/TestCases/Swagger/Review/Endpoints.cs
+++ b/TestHarness/Web/[Features]/TestCases/Swagger/Review/Endpoints.cs
@@ -1125,3 +1125,70 @@ sealed class MissingSchemaEnumEndpoint : EndpointWithoutRequest
     public override Task HandleAsync(CancellationToken ct)
         => Send.OkAsync(ct);
 }
+
+// Regression test for cross-document child-validator cache: the same nested validator type must
+// produce schema constraints in every document that contains an endpoint referencing it,
+// not just in the first document generated during the process lifetime.
+
+sealed class MultiDocSharedOrderLine
+{
+    public required string Sku { get; init; }
+    public required int Qty { get; init; }
+}
+
+sealed class MultiDocSharedOrderLineValidator : AbstractValidator<MultiDocSharedOrderLine>
+{
+    public MultiDocSharedOrderLineValidator()
+    {
+        RuleFor(x => x.Sku).NotEmpty();
+        RuleFor(x => x.Qty).GreaterThan(0);
+    }
+}
+
+sealed class MultiDocOrderRequestA
+{
+    public List<MultiDocSharedOrderLine> Lines { get; init; } = [];
+}
+
+sealed class MultiDocOrderRequestAValidator : Validator<MultiDocOrderRequestA>
+{
+    public MultiDocOrderRequestAValidator()
+        => RuleForEach(x => x.Lines).SetValidator(new MultiDocSharedOrderLineValidator());
+}
+
+sealed class MultiDocOrderEndpointA : Endpoint<MultiDocOrderRequestA>
+{
+    public override void Configure()
+    {
+        Post("/swagger-review/multi-doc-order-a");
+        Tags("swagger_review");
+        AllowAnonymous();
+    }
+
+    public override Task HandleAsync(MultiDocOrderRequestA r, CancellationToken ct)
+        => Send.OkAsync(ct);
+}
+
+sealed class MultiDocOrderRequestB
+{
+    public List<MultiDocSharedOrderLine> Lines { get; init; } = [];
+}
+
+sealed class MultiDocOrderRequestBValidator : Validator<MultiDocOrderRequestB>
+{
+    public MultiDocOrderRequestBValidator()
+        => RuleForEach(x => x.Lines).SetValidator(new MultiDocSharedOrderLineValidator());
+}
+
+sealed class MultiDocOrderEndpointB : Endpoint<MultiDocOrderRequestB>
+{
+    public override void Configure()
+    {
+        Post("/swagger-review/multi-doc-order-b");
+        Tags("swagger_review");
+        AllowAnonymous();
+    }
+
+    public override Task HandleAsync(MultiDocOrderRequestB r, CancellationToken ct)
+        => Send.OkAsync(ct);
+}

--- a/TestHarness/Web/[Features]/TestCases/Swagger/Review/Endpoints.cs
+++ b/TestHarness/Web/[Features]/TestCases/Swagger/Review/Endpoints.cs
@@ -1,7 +1,8 @@
+using FastEndpoints.OpenApi;
 using FluentValidation;
-using FastEndpoints.Swagger;
+using Microsoft.OpenApi;
 
-//using Microsoft.OpenApi;
+//using FastEndpoints.Swagger;
 
 namespace TestCases.Swagger.Review;
 
@@ -299,32 +300,32 @@ sealed class DuplicateQueryNamingPolicyRequest
     public string FirstName { get; set; } = string.Empty;
 }
 
-// sealed class DuplicateQueryNamingPolicyEndpoint : Endpoint<DuplicateQueryNamingPolicyRequest, string>
-// {
-//     public override void Configure()
-//     {
-//         Get("/swagger-review/duplicate-query-naming-policy");
-//         Tags("swagger_review");
-//         AllowAnonymous();
-//         Description(
-//             b => b.WithMetadata(
-//                 new OpenApiOperation
-//                 {
-//                     Parameters =
-//                     [
-//                         new()
-//                         {
-//                             Name = "firstName",
-//                             In = ParameterLocation.Query,
-//                             Schema = new OpenApiSchema { Type = JsonSchemaType.String }
-//                         }
-//                     ]
-//                 }));
-//     }
-//
-//     public override Task HandleAsync(DuplicateQueryNamingPolicyRequest req, CancellationToken ct)
-//         => Send.OkAsync(req.FirstName, ct);
-// }
+sealed class DuplicateQueryNamingPolicyEndpoint : Endpoint<DuplicateQueryNamingPolicyRequest, string>
+{
+    public override void Configure()
+    {
+        Get("/swagger-review/duplicate-query-naming-policy");
+        Tags("swagger_review");
+        AllowAnonymous();
+        Description(
+            b => b.WithMetadata(
+                new OpenApiOperation
+                {
+                    Parameters =
+                    [
+                        new OpenApiParameter
+                        {
+                            Name = "firstName",
+                            In = ParameterLocation.Query,
+                            Schema = new OpenApiSchema { Type = JsonSchemaType.String }
+                        }
+                    ]
+                }));
+    }
+
+    public override Task HandleAsync(DuplicateQueryNamingPolicyRequest req, CancellationToken ct)
+        => Send.OkAsync(req.FirstName, ct);
+}
 
 sealed class BindFromQueryGetReviewRequest
 {
@@ -1205,7 +1206,10 @@ sealed class DualChildAddress
 
 sealed class DualChildAddressValidator : Validator<DualChildAddress>
 {
-    public DualChildAddressValidator() => RuleFor(x => x.Zip).NotEmpty();
+    public DualChildAddressValidator()
+    {
+        RuleFor(x => x.Zip).NotEmpty();
+    }
 }
 
 sealed class DualChildAddressRequest

--- a/TestHarness/Web/[Features]/TestCases/Swagger/Review/Endpoints.cs
+++ b/TestHarness/Web/[Features]/TestCases/Swagger/Review/Endpoints.cs
@@ -1197,3 +1197,41 @@ sealed class MultiDocOrderEndpointB : Endpoint<MultiDocOrderRequestB>
     public override Task HandleAsync(MultiDocOrderRequestB r, CancellationToken ct)
         => Send.OkAsync(ct);
 }
+
+sealed class DualChildAddress
+{
+    public string Zip { get; init; } = string.Empty;
+}
+
+sealed class DualChildAddressValidator : Validator<DualChildAddress>
+{
+    public DualChildAddressValidator() => RuleFor(x => x.Zip).NotEmpty();
+}
+
+sealed class DualChildAddressRequest
+{
+    public DualChildAddress BillingAddress { get; init; } = new();
+    public DualChildAddress ShippingAddress { get; init; } = new();
+}
+
+sealed class DualChildAddressRequestValidator : Validator<DualChildAddressRequest>
+{
+    public DualChildAddressRequestValidator()
+    {
+        RuleFor(x => x.BillingAddress).SetValidator(new DualChildAddressValidator());
+        RuleFor(x => x.ShippingAddress).SetValidator(new DualChildAddressValidator());
+    }
+}
+
+sealed class DualChildAddressEndpoint : Endpoint<DualChildAddressRequest>
+{
+    public override void Configure()
+    {
+        Post("/swagger-review/dual-child-address");
+        Tags("swagger_review");
+        AllowAnonymous();
+    }
+
+    public override Task HandleAsync(DualChildAddressRequest r, CancellationToken ct)
+        => Send.OkAsync(ct);
+}

--- a/TestHarness/Web/[Features]/TestCases/Swagger/Review/Endpoints.cs
+++ b/TestHarness/Web/[Features]/TestCases/Swagger/Review/Endpoints.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
-using FastEndpoints.OpenApi;
-using Microsoft.OpenApi;
+using FastEndpoints.Swagger;
+
+//using Microsoft.OpenApi;
 
 namespace TestCases.Swagger.Review;
 
@@ -298,32 +299,32 @@ sealed class DuplicateQueryNamingPolicyRequest
     public string FirstName { get; set; } = string.Empty;
 }
 
-sealed class DuplicateQueryNamingPolicyEndpoint : Endpoint<DuplicateQueryNamingPolicyRequest, string>
-{
-    public override void Configure()
-    {
-        Get("/swagger-review/duplicate-query-naming-policy");
-        Tags("swagger_review");
-        AllowAnonymous();
-        Description(
-            b => b.WithMetadata(
-                new OpenApiOperation
-                {
-                    Parameters =
-                    [
-                        new OpenApiParameter
-                        {
-                            Name = "firstName",
-                            In = ParameterLocation.Query,
-                            Schema = new OpenApiSchema { Type = JsonSchemaType.String }
-                        }
-                    ]
-                }));
-    }
-
-    public override Task HandleAsync(DuplicateQueryNamingPolicyRequest req, CancellationToken ct)
-        => Send.OkAsync(req.FirstName, ct);
-}
+// sealed class DuplicateQueryNamingPolicyEndpoint : Endpoint<DuplicateQueryNamingPolicyRequest, string>
+// {
+//     public override void Configure()
+//     {
+//         Get("/swagger-review/duplicate-query-naming-policy");
+//         Tags("swagger_review");
+//         AllowAnonymous();
+//         Description(
+//             b => b.WithMetadata(
+//                 new OpenApiOperation
+//                 {
+//                     Parameters =
+//                     [
+//                         new()
+//                         {
+//                             Name = "firstName",
+//                             In = ParameterLocation.Query,
+//                             Schema = new OpenApiSchema { Type = JsonSchemaType.String }
+//                         }
+//                     ]
+//                 }));
+//     }
+//
+//     public override Task HandleAsync(DuplicateQueryNamingPolicyRequest req, CancellationToken ct)
+//         => Send.OkAsync(req.FirstName, ct);
+// }
 
 sealed class BindFromQueryGetReviewRequest
 {
@@ -841,7 +842,7 @@ sealed class ExplicitResponseExampleReviewEndpoint : EndpointWithoutRequest<Resp
         Summary(
             s =>
             {
-                s.Response(200, example: new ResponseExampleMetadataReviewResponse { Message = "from response metadata" });
+                s.Response(example: new ResponseExampleMetadataReviewResponse { Message = "from response metadata" });
                 s.ResponseExamples[200] = new ResponseExampleMetadataReviewResponse { Message = "from explicit response examples" };
             });
     }
@@ -1153,7 +1154,9 @@ sealed class MultiDocOrderRequestA
 sealed class MultiDocOrderRequestAValidator : Validator<MultiDocOrderRequestA>
 {
     public MultiDocOrderRequestAValidator()
-        => RuleForEach(x => x.Lines).SetValidator(new MultiDocSharedOrderLineValidator());
+    {
+        RuleForEach(x => x.Lines).SetValidator(new MultiDocSharedOrderLineValidator());
+    }
 }
 
 sealed class MultiDocOrderEndpointA : Endpoint<MultiDocOrderRequestA>
@@ -1177,7 +1180,9 @@ sealed class MultiDocOrderRequestB
 sealed class MultiDocOrderRequestBValidator : Validator<MultiDocOrderRequestB>
 {
     public MultiDocOrderRequestBValidator()
-        => RuleForEach(x => x.Lines).SetValidator(new MultiDocSharedOrderLineValidator());
+    {
+        RuleForEach(x => x.Lines).SetValidator(new MultiDocSharedOrderLineValidator());
+    }
 }
 
 sealed class MultiDocOrderEndpointB : Endpoint<MultiDocOrderRequestB>

--- a/Tests/IntegrationTests/FastEndpoints.OpenApi/release-0.json
+++ b/Tests/IntegrationTests/FastEndpoints.OpenApi/release-0.json
@@ -1917,6 +1917,39 @@
         }
       }
     },
+    "/api/swagger-review/dual-child-address": {
+      "post": {
+        "tags": [
+          "SwaggerReview"
+        ],
+        "operationId": "swagger_review_TestCasesSwaggerReviewDualChildAddressEndpoint",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesSwaggerReviewDualChildAddressRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FastEndpointsErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/swagger-review/duplicate-examples": {
       "post": {
         "tags": [
@@ -2625,6 +2658,72 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TestCasesSwaggerReviewMissingSchemaPrimitiveResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/swagger-review/multi-doc-order-a": {
+      "post": {
+        "tags": [
+          "SwaggerReview"
+        ],
+        "operationId": "swagger_review_TestCasesSwaggerReviewMultiDocOrderEndpointA",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesSwaggerReviewMultiDocOrderRequestA"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FastEndpointsErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/swagger-review/multi-doc-order-b": {
+      "post": {
+        "tags": [
+          "SwaggerReview"
+        ],
+        "operationId": "swagger_review_TestCasesSwaggerReviewMultiDocOrderEndpointB",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesSwaggerReviewMultiDocOrderRequestB"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FastEndpointsErrorResponse"
                 }
               }
             }
@@ -7764,6 +7863,12 @@
           "$ref": "#/components/schemas/TestCasesQueryObjectWithObjectsArrayBindingTestObjectInArray"
         }
       },
+      "SystemCollectionsGenericListOfTestCasesSwaggerReviewMultiDocSharedOrderLine": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/TestCasesSwaggerReviewMultiDocSharedOrderLine"
+        }
+      },
       "SystemCollectionsGenericListOfTestCasesSwaggerReviewUniqueItemsReviewChild": {
         "uniqueItems": true,
         "type": "array",
@@ -9251,6 +9356,29 @@
           }
         }
       },
+      "TestCasesSwaggerReviewDualChildAddress": {
+        "required": [
+          "zip"
+        ],
+        "type": "object",
+        "properties": {
+          "zip": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      },
+      "TestCasesSwaggerReviewDualChildAddressRequest": {
+        "type": "object",
+        "properties": {
+          "billingAddress": {
+            "$ref": "#/components/schemas/TestCasesSwaggerReviewDualChildAddress"
+          },
+          "shippingAddress": {
+            "$ref": "#/components/schemas/TestCasesSwaggerReviewDualChildAddress"
+          }
+        }
+      },
       "TestCasesSwaggerReviewDuplicateRequestExamplesRequest": {
         "type": "object",
         "properties": {
@@ -9391,6 +9519,40 @@
           },
           "effectiveOn": {
             "$ref": "#/components/schemas/SystemDateOnly"
+          }
+        }
+      },
+      "TestCasesSwaggerReviewMultiDocOrderRequestA": {
+        "type": "object",
+        "properties": {
+          "lines": {
+            "$ref": "#/components/schemas/SystemCollectionsGenericListOfTestCasesSwaggerReviewMultiDocSharedOrderLine"
+          }
+        }
+      },
+      "TestCasesSwaggerReviewMultiDocOrderRequestB": {
+        "type": "object",
+        "properties": {
+          "lines": {
+            "$ref": "#/components/schemas/SystemCollectionsGenericListOfTestCasesSwaggerReviewMultiDocSharedOrderLine"
+          }
+        }
+      },
+      "TestCasesSwaggerReviewMultiDocSharedOrderLine": {
+        "required": [
+          "sku",
+          "qty"
+        ],
+        "type": "object",
+        "properties": {
+          "sku": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "qty": {
+            "exclusiveMinimum": 0,
+            "type": "integer",
+            "format": "int32"
           }
         }
       },

--- a/Tests/IntegrationTests/FastEndpoints.OpenApi/release-1.json
+++ b/Tests/IntegrationTests/FastEndpoints.OpenApi/release-1.json
@@ -1974,6 +1974,39 @@
         }
       }
     },
+    "/api/swagger-review/dual-child-address": {
+      "post": {
+        "tags": [
+          "SwaggerReview"
+        ],
+        "operationId": "swagger_review_TestCasesSwaggerReviewDualChildAddressEndpoint",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesSwaggerReviewDualChildAddressRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FastEndpointsErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/swagger-review/duplicate-examples": {
       "post": {
         "tags": [
@@ -2682,6 +2715,72 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TestCasesSwaggerReviewMissingSchemaPrimitiveResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/swagger-review/multi-doc-order-a": {
+      "post": {
+        "tags": [
+          "SwaggerReview"
+        ],
+        "operationId": "swagger_review_TestCasesSwaggerReviewMultiDocOrderEndpointA",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesSwaggerReviewMultiDocOrderRequestA"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FastEndpointsErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/swagger-review/multi-doc-order-b": {
+      "post": {
+        "tags": [
+          "SwaggerReview"
+        ],
+        "operationId": "swagger_review_TestCasesSwaggerReviewMultiDocOrderEndpointB",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesSwaggerReviewMultiDocOrderRequestB"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FastEndpointsErrorResponse"
                 }
               }
             }
@@ -7922,6 +8021,12 @@
           "$ref": "#/components/schemas/TestCasesQueryObjectWithObjectsArrayBindingTestObjectInArray"
         }
       },
+      "SystemCollectionsGenericListOfTestCasesSwaggerReviewMultiDocSharedOrderLine": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/TestCasesSwaggerReviewMultiDocSharedOrderLine"
+        }
+      },
       "SystemCollectionsGenericListOfTestCasesSwaggerReviewUniqueItemsReviewChild": {
         "uniqueItems": true,
         "type": "array",
@@ -9409,6 +9514,29 @@
           }
         }
       },
+      "TestCasesSwaggerReviewDualChildAddress": {
+        "required": [
+          "zip"
+        ],
+        "type": "object",
+        "properties": {
+          "zip": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      },
+      "TestCasesSwaggerReviewDualChildAddressRequest": {
+        "type": "object",
+        "properties": {
+          "billingAddress": {
+            "$ref": "#/components/schemas/TestCasesSwaggerReviewDualChildAddress"
+          },
+          "shippingAddress": {
+            "$ref": "#/components/schemas/TestCasesSwaggerReviewDualChildAddress"
+          }
+        }
+      },
       "TestCasesSwaggerReviewDuplicateRequestExamplesRequest": {
         "type": "object",
         "properties": {
@@ -9549,6 +9677,40 @@
           },
           "effectiveOn": {
             "$ref": "#/components/schemas/SystemDateOnly"
+          }
+        }
+      },
+      "TestCasesSwaggerReviewMultiDocOrderRequestA": {
+        "type": "object",
+        "properties": {
+          "lines": {
+            "$ref": "#/components/schemas/SystemCollectionsGenericListOfTestCasesSwaggerReviewMultiDocSharedOrderLine"
+          }
+        }
+      },
+      "TestCasesSwaggerReviewMultiDocOrderRequestB": {
+        "type": "object",
+        "properties": {
+          "lines": {
+            "$ref": "#/components/schemas/SystemCollectionsGenericListOfTestCasesSwaggerReviewMultiDocSharedOrderLine"
+          }
+        }
+      },
+      "TestCasesSwaggerReviewMultiDocSharedOrderLine": {
+        "required": [
+          "sku",
+          "qty"
+        ],
+        "type": "object",
+        "properties": {
+          "sku": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "qty": {
+            "exclusiveMinimum": 0,
+            "type": "integer",
+            "format": "int32"
           }
         }
       },

--- a/Tests/IntegrationTests/FastEndpoints.OpenApi/release-2.json
+++ b/Tests/IntegrationTests/FastEndpoints.OpenApi/release-2.json
@@ -2168,6 +2168,39 @@
         }
       }
     },
+    "/api/swagger-review/dual-child-address": {
+      "post": {
+        "tags": [
+          "SwaggerReview"
+        ],
+        "operationId": "swagger_review_TestCasesSwaggerReviewDualChildAddressEndpoint",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesSwaggerReviewDualChildAddressRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FastEndpointsErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/swagger-review/duplicate-examples": {
       "post": {
         "tags": [
@@ -2876,6 +2909,72 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TestCasesSwaggerReviewMissingSchemaPrimitiveResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/swagger-review/multi-doc-order-a": {
+      "post": {
+        "tags": [
+          "SwaggerReview"
+        ],
+        "operationId": "swagger_review_TestCasesSwaggerReviewMultiDocOrderEndpointA",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesSwaggerReviewMultiDocOrderRequestA"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FastEndpointsErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/swagger-review/multi-doc-order-b": {
+      "post": {
+        "tags": [
+          "SwaggerReview"
+        ],
+        "operationId": "swagger_review_TestCasesSwaggerReviewMultiDocOrderEndpointB",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesSwaggerReviewMultiDocOrderRequestB"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FastEndpointsErrorResponse"
                 }
               }
             }
@@ -8045,6 +8144,12 @@
           "$ref": "#/components/schemas/TestCasesQueryObjectWithObjectsArrayBindingTestObjectInArray"
         }
       },
+      "SystemCollectionsGenericListOfTestCasesSwaggerReviewMultiDocSharedOrderLine": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/TestCasesSwaggerReviewMultiDocSharedOrderLine"
+        }
+      },
       "SystemCollectionsGenericListOfTestCasesSwaggerReviewUniqueItemsReviewChild": {
         "uniqueItems": true,
         "type": "array",
@@ -9532,6 +9637,29 @@
           }
         }
       },
+      "TestCasesSwaggerReviewDualChildAddress": {
+        "required": [
+          "zip"
+        ],
+        "type": "object",
+        "properties": {
+          "zip": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      },
+      "TestCasesSwaggerReviewDualChildAddressRequest": {
+        "type": "object",
+        "properties": {
+          "billingAddress": {
+            "$ref": "#/components/schemas/TestCasesSwaggerReviewDualChildAddress"
+          },
+          "shippingAddress": {
+            "$ref": "#/components/schemas/TestCasesSwaggerReviewDualChildAddress"
+          }
+        }
+      },
       "TestCasesSwaggerReviewDuplicateRequestExamplesRequest": {
         "type": "object",
         "properties": {
@@ -9672,6 +9800,40 @@
           },
           "effectiveOn": {
             "$ref": "#/components/schemas/SystemDateOnly"
+          }
+        }
+      },
+      "TestCasesSwaggerReviewMultiDocOrderRequestA": {
+        "type": "object",
+        "properties": {
+          "lines": {
+            "$ref": "#/components/schemas/SystemCollectionsGenericListOfTestCasesSwaggerReviewMultiDocSharedOrderLine"
+          }
+        }
+      },
+      "TestCasesSwaggerReviewMultiDocOrderRequestB": {
+        "type": "object",
+        "properties": {
+          "lines": {
+            "$ref": "#/components/schemas/SystemCollectionsGenericListOfTestCasesSwaggerReviewMultiDocSharedOrderLine"
+          }
+        }
+      },
+      "TestCasesSwaggerReviewMultiDocSharedOrderLine": {
+        "required": [
+          "sku",
+          "qty"
+        ],
+        "type": "object",
+        "properties": {
+          "sku": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "qty": {
+            "exclusiveMinimum": 0,
+            "type": "integer",
+            "format": "int32"
           }
         }
       },

--- a/Tests/IntegrationTests/FastEndpoints.Swagger/OperationProcessorEdgeCaseTests.cs
+++ b/Tests/IntegrationTests/FastEndpoints.Swagger/OperationProcessorEdgeCaseTests.cs
@@ -89,6 +89,30 @@ public class OperationProcessorEdgeCaseTests(Fixture App) : TestBase<Fixture>
     }
 
     [Fact]
+    public async Task shared_nested_validator_constraints_survive_multi_document_generation()
+    {
+        var doc1 = await App.DocGenerator.GenerateAsync("Swagger Review");
+        var doc2 = await App.DocGenerator.GenerateAsync("Swagger Review Empty Schema");
+
+        var orderLineKey = JToken.Parse(doc1.ToJson())["components"]!["schemas"]!
+                                 .Children<JProperty>()
+                                 .First(p => p.Name.EndsWith("MultiDocSharedOrderLine"))
+                                 .Name;
+
+        static JToken GetOrderLineSchema(string json, string key)
+            => JToken.Parse(json)["components"]!["schemas"]![key]!;
+
+        var schema1 = GetOrderLineSchema(doc1.ToJson(), orderLineKey);
+        var schema2 = GetOrderLineSchema(doc2.ToJson(), orderLineKey);
+
+        schema1["properties"]!["sku"]!["minLength"]!.Value<int>().ShouldBe(1);
+        schema2["properties"]!["sku"]!["minLength"]!.Value<int>().ShouldBe(1);
+
+        schema1["properties"]!["qty"]!["exclusiveMinimum"]!.Value<bool>().ShouldBeTrue();
+        schema2["properties"]!["qty"]!["exclusiveMinimum"]!.Value<bool>().ShouldBeTrue();
+    }
+
+    [Fact]
     public async Task x402_headers_are_added_to_request_and_responses()
     {
         var doc = await App.DocGenerator.GenerateAsync("Release 2.0");

--- a/Tests/IntegrationTests/FastEndpoints.Swagger/OperationProcessorEdgeCaseTests.cs
+++ b/Tests/IntegrationTests/FastEndpoints.Swagger/OperationProcessorEdgeCaseTests.cs
@@ -135,4 +135,61 @@ public class OperationProcessorEdgeCaseTests(Fixture App) : TestBase<Fixture>
                                                                                       .ShouldBe("#/components/schemas/FastEndpointsProblemDetails");
         responses["404"]!["description"]!.Value<string>().ShouldBe("Not Found");
     }
+
+    [Fact]
+    public async Task concurrent_document_generation_preserves_nested_validator_constraints()
+    {
+        var results = await Task.WhenAll(
+            App.DocGenerator.GenerateAsync("Swagger Review"),
+            App.DocGenerator.GenerateAsync("Swagger Review Empty Schema"),
+            App.DocGenerator.GenerateAsync("Release 2.0"));
+
+        foreach (var doc in results.Take(2)) // first two contain swagger_review endpoints
+        {
+            var json = doc.ToJson();
+
+            var orderLineKey = JToken.Parse(json)["components"]!["schemas"]!
+                                     .Children<JProperty>()
+                                     .First(p => p.Name.EndsWith("MultiDocSharedOrderLine"))
+                                     .Name;
+
+            var orderLineSchema = JToken.Parse(json)["components"]!["schemas"]![orderLineKey]!;
+            orderLineSchema["properties"]!["sku"]!["minLength"]!.Value<int>().ShouldBe(1);
+            orderLineSchema["properties"]!["qty"]!["exclusiveMinimum"]!.Value<bool>().ShouldBeTrue();
+
+            var addressKey = JToken.Parse(json)["components"]!["schemas"]!
+                                   .Children<JProperty>()
+                                   .First(p => p.Name.EndsWith("DualChildAddress") && !p.Name.EndsWith("DualChildAddressRequest"))
+                                   .Name;
+
+            var addressSchema = JToken.Parse(json)["components"]!["schemas"]![addressKey]!;
+            addressSchema["required"]!.Values<string>().ShouldContain("zip");
+            addressSchema["properties"]!["zip"]!["minLength"]!.Value<int>().ShouldBe(1);
+        }
+    }
+
+    [Fact]
+    public async Task repeated_same_child_validator_type_applies_constraints_to_all_properties()
+    {
+        var doc = await App.DocGenerator.GenerateAsync("Swagger Review");
+
+        var addressKey = JToken.Parse(doc.ToJson())["components"]!["schemas"]!
+                               .Children<JProperty>()
+                               .First(p => p.Name.EndsWith("DualChildAddress"))
+                               .Name;
+
+        var requestKey = JToken.Parse(doc.ToJson())["components"]!["schemas"]!
+                                .Children<JProperty>()
+                                .First(p => p.Name.EndsWith("DualChildAddressRequest"))
+                                .Name;
+
+        var addressSchema = JToken.Parse(doc.ToJson())["components"]!["schemas"]![addressKey]!;
+        var requestSchema = JToken.Parse(doc.ToJson())["components"]!["schemas"]![requestKey]!;
+
+        addressSchema["required"]!.Values<string>().ShouldContain("zip");
+        addressSchema["properties"]!["zip"]!["minLength"]!.Value<int>().ShouldBe(1);
+
+        requestSchema["properties"]!["billingAddress"]!["$ref"]!.Value<string>().ShouldEndWith(addressKey);
+        requestSchema["properties"]!["shippingAddress"]!["$ref"]!.Value<string>().ShouldEndWith(addressKey);
+    }
 }

--- a/Tests/IntegrationTests/FastEndpoints.Swagger/release-0.json
+++ b/Tests/IntegrationTests/FastEndpoints.Swagger/release-0.json
@@ -1,5 +1,5 @@
 {
-  "x-generator": "NSwag v14.6.3.0 (NJsonSchema v11.5.2.0 (Newtonsoft.Json v13.0.0.0))",
+  "x-generator": "NSwag v14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))",
   "openapi": "3.0.0",
   "info": {
     "title": "Web API",
@@ -31,7 +31,23 @@
           "200": {
             "description": "all good",
             "headers": {
-              "x-some-custom-header": {}
+              "x-some-custom-header": {
+                "description": "my custom header",
+                "schema": {
+                  "title": "<>f__AnonymousType0OfString",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "prop1": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                },
+                "example": {
+                  "prop1": "prop1 val"
+                }
+              }
             },
             "content": {
               "application/json": {
@@ -73,7 +89,23 @@
           "200": {
             "description": "all good",
             "headers": {
-              "x-some-custom-header": {}
+              "x-some-custom-header": {
+                "description": "my custom header",
+                "schema": {
+                  "title": "<>f__AnonymousType0OfString",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "prop1": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                },
+                "example": {
+                  "prop1": "prop1 val"
+                }
+              }
             },
             "content": {
               "application/json": {
@@ -115,7 +147,23 @@
           "200": {
             "description": "all good",
             "headers": {
-              "x-some-custom-header": {}
+              "x-some-custom-header": {
+                "description": "my custom header",
+                "schema": {
+                  "title": "<>f__AnonymousType0OfString",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "prop1": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                },
+                "example": {
+                  "prop1": "prop1 val"
+                }
+              }
             },
             "content": {
               "application/json": {
@@ -1814,7 +1862,7 @@
               }
             },
             "example": [
-              ""
+              "574ee711-1506-4c15-85b1-e7b6ec00c367"
             ]
           },
           {
@@ -2361,7 +2409,7 @@
               }
             },
             "example": [
-              ""
+              "5e83ef75-5191-4c92-a864-752e5342cdfc"
             ]
           },
           {
@@ -3024,7 +3072,7 @@
               }
             },
             "example": [
-              ""
+              "31bcb76c-f383-465c-9ccc-7e1196ae79f2"
             ]
           },
           {
@@ -3370,6 +3418,68 @@
         ]
       }
     },
+    "/api/api/test-cases/circular-fromform-binding-test": {
+      "post": {
+        "tags": [
+          "Api"
+        ],
+        "operationId": "TestCasesNestedFromFormBindingTestCircularEndpoint",
+        "requestBody": {
+          "x-name": "data",
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestCircularFormData"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestCircularResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/api/test-cases/nested-fromform-binding-test": {
+      "post": {
+        "tags": [
+          "Api"
+        ],
+        "operationId": "TestCasesNestedFromFormBindingTestEndpoint",
+        "requestBody": {
+          "x-name": "data",
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestRequest_FormData"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/test-cases/on-before-on-after-validate": {
       "post": {
         "tags": [
@@ -3673,6 +3783,47 @@
         }
       }
     },
+    "/api/test-cases/circular-query-object-binding-test": {
+      "get": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesQueryObjectBindingTestCircularEndpoint",
+        "parameters": [
+          {
+            "name": "data",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TestCasesQueryObjectBindingTestCircularQueryData"
+                }
+              ]
+            },
+            "example": {
+              "name": "name",
+              "child": {
+                "name": "name",
+                "child": null
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestCasesQueryObjectBindingTestCircularResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/test-cases/query-object-binding-test": {
       "get": {
         "tags": [
@@ -3750,26 +3901,28 @@
               ]
             },
             "example": {
-              "id": "id",
+              "id": "87d1d694-117e-4752-90c0-cc7263bfadfa",
               "name": "name",
               "age": 0,
               "child": {
-                "id": "id",
+                "id": "409ecca1-6535-4cdb-8ec4-6872ed744736",
                 "name": "name",
                 "age": 0,
+                "birthDate": "2026-05-29",
+                "wakeUpTime": "wakeUpTime",
                 "strings": [
                   ""
                 ],
                 "favoriteDays": [
-                  0
+                  "Sunday"
                 ],
                 "isHidden": false
               },
               "numbers": [
                 0
               ],
-              "favoriteDay": 0,
-              "byteEnum": 0,
+              "favoriteDay": "Sunday",
+              "byteEnum": "Check",
               "isHidden": false
             }
           }
@@ -3817,7 +3970,7 @@
                     "int": 0,
                     "long": 0,
                     "double": 0.0,
-                    "enum": 0
+                    "enum": "Sunday"
                   }
                 ]
               },
@@ -3828,7 +3981,7 @@
                   "int": 0,
                   "long": 0,
                   "double": 0.0,
-                  "enum": 0
+                  "enum": "Sunday"
                 }
               ]
             }
@@ -4074,11 +4227,11 @@
               ]
             },
             "example": {
-              "id": "id",
+              "id": "2ac385c3-d241-4942-9b17-f34af8f84b05",
               "name": "name",
               "age": 0,
               "child": {
-                "id": "id",
+                "id": "366e6c79-f984-4920-8a09-119127aedbeb",
                 "name": "name",
                 "age": 0,
                 "strings": [
@@ -4358,6 +4511,54 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TestCasesSTJInfiniteRecursionTestResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tests/generic-stream-command": {
+      "get": {
+        "tags": [
+          "Tests"
+        ],
+        "operationId": "TestCasesStreamCommandBusTestGenericStreamCmdEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "guid"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tests/stream-command": {
+      "get": {
+        "tags": [
+          "Tests"
+        ],
+        "operationId": "TestCasesStreamCommandBusTestStreamCmdEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
                 }
               }
             }
@@ -5238,6 +5439,89 @@
             "x-position": 1
           }
         ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/non-fe-auth": {
+      "get": {
+        "tags": [
+          "non-fe-auth"
+        ],
+        "operationId": "GetNonFeAuth",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JWTBearerAuth": []
+          }
+        ]
+      }
+    },
+    "/non-fe-auth-anon": {
+      "get": {
+        "tags": [
+          "non-fe-auth"
+        ],
+        "operationId": "GetNonFeAuthAnon",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/filtered-shared-path": {
+      "get": {
+        "tags": [
+          "exclude"
+        ],
+        "operationId": "GetFilteredSharedPath",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "shared-path"
+        ],
+        "operationId": "PostFilteredSharedPath",
         "responses": {
           "200": {
             "description": "",
@@ -6336,6 +6620,192 @@
         "type": "object",
         "additionalProperties": false
       },
+      "TestCasesNestedFromFormBindingTestCircularResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "childName": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestCircularRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestCircularFormData"
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestCircularFormData": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "child": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestCircularFormData"
+              }
+            ]
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "customName": {
+            "type": "string"
+          },
+          "fileName": {
+            "type": "string"
+          },
+          "documentFileNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "detailsTitle": {
+            "type": "string"
+          },
+          "detailsImageFileName": {
+            "type": "string"
+          },
+          "galleryFileNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "firstItemDescription": {
+            "type": "string"
+          },
+          "firstItemAttachmentFileName": {
+            "type": "string"
+          },
+          "numbersSum": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestRequest_FormData"
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestRequest_FormData": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "customName",
+          "file",
+          "documents",
+          "details",
+          "items",
+          "numbers"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "customName": {
+            "type": "string"
+          },
+          "file": {
+            "type": "string",
+            "format": "binary"
+          },
+          "documents": {
+            "type": "array",
+            "items": {}
+          },
+          "details": {
+            "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestRequest_Details"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestRequest_Item"
+            }
+          },
+          "numbers": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestRequest_Details": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "title",
+          "image",
+          "gallery"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string",
+            "format": "binary"
+          },
+          "gallery": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestRequest_Item": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "description",
+          "attachment"
+        ],
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "attachment": {
+            "type": "string",
+            "format": "binary"
+          }
+        }
+      },
       "TestCasesOnBeforeAfterValidationTestResponse": {
         "type": "object",
         "additionalProperties": false,
@@ -6360,7 +6830,7 @@
         }
       },
       "FastEndpointsHttp": {
-        "type": "integer",
+        "type": "string",
         "description": "enum for specifying a http verb",
         "x-enumNames": [
           "GET",
@@ -6374,15 +6844,15 @@
           "TRACE"
         ],
         "enum": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9
+          "GET",
+          "POST",
+          "PUT",
+          "PATCH",
+          "DELETE",
+          "HEAD",
+          "OPTIONS",
+          "CONNECT",
+          "TRACE"
         ]
       },
       "TestCasesPlainTextRequestTestResponse": {
@@ -6469,6 +6939,42 @@
         "type": "object",
         "additionalProperties": false
       },
+      "TestCasesQueryObjectBindingTestCircularResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "childName": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "TestCasesQueryObjectBindingTestCircularRequest": {
+        "type": "object",
+        "additionalProperties": false
+      },
+      "TestCasesQueryObjectBindingTestCircularQueryData": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "child": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TestCasesQueryObjectBindingTestCircularQueryData"
+              }
+            ]
+          }
+        }
+      },
       "TestCasesQueryObjectBindingTestResponse": {
         "type": "object",
         "additionalProperties": false,
@@ -6503,7 +7009,7 @@
         }
       },
       "SystemDayOfWeek": {
-        "type": "integer",
+        "type": "string",
         "description": "",
         "x-enumNames": [
           "Sunday",
@@ -6515,13 +7021,13 @@
           "Saturday"
         ],
         "enum": [
-          0,
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
+          "Sunday",
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday"
         ]
       },
       "TestCasesQueryObjectBindingTestPerson": {
@@ -6575,6 +7081,16 @@
             "type": "integer",
             "format": "int32"
           },
+          "birthDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "wakeUpTime": {
+            "type": "string",
+            "format": "time",
+            "nullable": true
+          },
           "strings": {
             "type": "array",
             "items": {
@@ -6593,7 +7109,7 @@
         }
       },
       "TestCasesQueryObjectBindingTestByteEnum": {
-        "type": "integer",
+        "type": "string",
         "description": "",
         "x-enumNames": [
           "Check",
@@ -6601,9 +7117,9 @@
           "AnotherCheck"
         ],
         "enum": [
-          0,
-          1,
-          2
+          "Check",
+          "Test",
+          "AnotherCheck"
         ]
       },
       "TestCasesQueryObjectBindingTestRequest": {
@@ -6921,11 +7437,12 @@
             "nullable": true
           },
           "stringOverride": {
-            "type": "string"
+            "type": "integer",
+            "format": "int64"
           },
           "stringOverrideNullable": {
-            "type": "string",
-            "nullable": true
+            "type": "integer",
+            "format": "int64"
           },
           "fromBody": {
             "type": "string",
@@ -7075,7 +7592,7 @@
       },
       "FastEndpointsProblemDetails": {
         "type": "object",
-        "description": "RFC7807 compatible problem details/ error response class. this can be used by configuring startup like so:\napp.UseFastEndpoints(c => c.Errors.UseProblemDetails())",
+        "description": "RFC9457 compatible problem details/ error response class. this can be used by configuring startup like so:\napp.UseFastEndpoints(c => c.Errors.UseProblemDetails())",
         "additionalProperties": false,
         "properties": {
           "type": {

--- a/Tests/IntegrationTests/FastEndpoints.Swagger/release-1.json
+++ b/Tests/IntegrationTests/FastEndpoints.Swagger/release-1.json
@@ -1,5 +1,5 @@
 {
-  "x-generator": "NSwag v14.6.3.0 (NJsonSchema v11.5.2.0 (Newtonsoft.Json v13.0.0.0))",
+  "x-generator": "NSwag v14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))",
   "openapi": "3.0.0",
   "info": {
     "title": "Web API",
@@ -31,7 +31,23 @@
           "200": {
             "description": "all good",
             "headers": {
-              "x-some-custom-header": {}
+              "x-some-custom-header": {
+                "description": "my custom header",
+                "schema": {
+                  "title": "<>f__AnonymousType0OfString",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "prop1": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                },
+                "example": {
+                  "prop1": "prop1 val"
+                }
+              }
             },
             "content": {
               "application/json": {
@@ -73,7 +89,23 @@
           "200": {
             "description": "all good",
             "headers": {
-              "x-some-custom-header": {}
+              "x-some-custom-header": {
+                "description": "my custom header",
+                "schema": {
+                  "title": "<>f__AnonymousType0OfString",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "prop1": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                },
+                "example": {
+                  "prop1": "prop1 val"
+                }
+              }
             },
             "content": {
               "application/json": {
@@ -115,7 +147,23 @@
           "200": {
             "description": "all good",
             "headers": {
-              "x-some-custom-header": {}
+              "x-some-custom-header": {
+                "description": "my custom header",
+                "schema": {
+                  "title": "<>f__AnonymousType0OfString",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "prop1": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                },
+                "example": {
+                  "prop1": "prop1 val"
+                }
+              }
             },
             "content": {
               "application/json": {
@@ -1874,7 +1922,7 @@
               }
             },
             "example": [
-              ""
+              "ca21737c-a20d-4400-9e33-588665bc5d78"
             ]
           },
           {
@@ -2429,7 +2477,7 @@
               }
             },
             "example": [
-              ""
+              "91e6c5cd-1883-4391-b629-31cdb470f82f"
             ]
           },
           {
@@ -3095,7 +3143,7 @@
               }
             },
             "example": [
-              ""
+              "3dc3e0cb-7a39-4c38-adf9-72aac0220c6b"
             ]
           },
           {
@@ -3456,6 +3504,68 @@
         ]
       }
     },
+    "/api/api/test-cases/circular-fromform-binding-test": {
+      "post": {
+        "tags": [
+          "Api"
+        ],
+        "operationId": "TestCasesNestedFromFormBindingTestCircularEndpoint",
+        "requestBody": {
+          "x-name": "data",
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestCircularFormData"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestCircularResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/api/test-cases/nested-fromform-binding-test": {
+      "post": {
+        "tags": [
+          "Api"
+        ],
+        "operationId": "TestCasesNestedFromFormBindingTestEndpoint",
+        "requestBody": {
+          "x-name": "data",
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestRequest_FormData"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/test-cases/on-before-on-after-validate": {
       "post": {
         "tags": [
@@ -3765,6 +3875,47 @@
         }
       }
     },
+    "/api/test-cases/circular-query-object-binding-test": {
+      "get": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesQueryObjectBindingTestCircularEndpoint",
+        "parameters": [
+          {
+            "name": "data",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TestCasesQueryObjectBindingTestCircularQueryData"
+                }
+              ]
+            },
+            "example": {
+              "name": "name",
+              "child": {
+                "name": "name",
+                "child": null
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestCasesQueryObjectBindingTestCircularResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/test-cases/query-object-binding-test": {
       "get": {
         "tags": [
@@ -3842,26 +3993,28 @@
               ]
             },
             "example": {
-              "id": "id",
+              "id": "73f9c357-9939-4e57-9ac5-c98ff98ce346",
               "name": "name",
               "age": 0,
               "child": {
-                "id": "id",
+                "id": "16b6e623-47d4-4644-aa32-e50b45c6a354",
                 "name": "name",
                 "age": 0,
+                "birthDate": "2026-05-29",
+                "wakeUpTime": "wakeUpTime",
                 "strings": [
                   ""
                 ],
                 "favoriteDays": [
-                  0
+                  "Sunday"
                 ],
                 "isHidden": false
               },
               "numbers": [
                 0
               ],
-              "favoriteDay": 0,
-              "byteEnum": 0,
+              "favoriteDay": "Sunday",
+              "byteEnum": "Check",
               "isHidden": false
             }
           }
@@ -3909,7 +4062,7 @@
                     "int": 0,
                     "long": 0,
                     "double": 0.0,
-                    "enum": 0
+                    "enum": "Sunday"
                   }
                 ]
               },
@@ -3920,7 +4073,7 @@
                   "int": 0,
                   "long": 0,
                   "double": 0.0,
-                  "enum": 0
+                  "enum": "Sunday"
                 }
               ]
             }
@@ -4166,11 +4319,11 @@
               ]
             },
             "example": {
-              "id": "id",
+              "id": "a47cd036-24ed-4c5f-aa34-0aa0a42c7dd0",
               "name": "name",
               "age": 0,
               "child": {
-                "id": "id",
+                "id": "cff7a8e7-c158-4af9-b2e3-ca1ca2e96e59",
                 "name": "name",
                 "age": 0,
                 "strings": [
@@ -4462,6 +4615,54 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TestCasesSTJInfiniteRecursionTestResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tests/generic-stream-command": {
+      "get": {
+        "tags": [
+          "Tests"
+        ],
+        "operationId": "TestCasesStreamCommandBusTestGenericStreamCmdEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "guid"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tests/stream-command": {
+      "get": {
+        "tags": [
+          "Tests"
+        ],
+        "operationId": "TestCasesStreamCommandBusTestStreamCmdEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
                 }
               }
             }
@@ -5363,6 +5564,92 @@
             "x-position": 1
           }
         ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/non-fe-auth": {
+      "get": {
+        "tags": [
+          "non-fe-auth"
+        ],
+        "operationId": "GetNonFeAuth",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JWTBearerAuth": []
+          },
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/non-fe-auth-anon": {
+      "get": {
+        "tags": [
+          "non-fe-auth"
+        ],
+        "operationId": "GetNonFeAuthAnon",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/filtered-shared-path": {
+      "get": {
+        "tags": [
+          "exclude"
+        ],
+        "operationId": "GetFilteredSharedPath",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "shared-path"
+        ],
+        "operationId": "PostFilteredSharedPath",
         "responses": {
           "200": {
             "description": "",
@@ -6461,6 +6748,192 @@
         "type": "object",
         "additionalProperties": false
       },
+      "TestCasesNestedFromFormBindingTestCircularResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "childName": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestCircularRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestCircularFormData"
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestCircularFormData": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "child": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestCircularFormData"
+              }
+            ]
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "customName": {
+            "type": "string"
+          },
+          "fileName": {
+            "type": "string"
+          },
+          "documentFileNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "detailsTitle": {
+            "type": "string"
+          },
+          "detailsImageFileName": {
+            "type": "string"
+          },
+          "galleryFileNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "firstItemDescription": {
+            "type": "string"
+          },
+          "firstItemAttachmentFileName": {
+            "type": "string"
+          },
+          "numbersSum": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestRequest_FormData"
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestRequest_FormData": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "customName",
+          "file",
+          "documents",
+          "details",
+          "items",
+          "numbers"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "customName": {
+            "type": "string"
+          },
+          "file": {
+            "type": "string",
+            "format": "binary"
+          },
+          "documents": {
+            "type": "array",
+            "items": {}
+          },
+          "details": {
+            "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestRequest_Details"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestRequest_Item"
+            }
+          },
+          "numbers": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestRequest_Details": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "title",
+          "image",
+          "gallery"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string",
+            "format": "binary"
+          },
+          "gallery": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestRequest_Item": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "description",
+          "attachment"
+        ],
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "attachment": {
+            "type": "string",
+            "format": "binary"
+          }
+        }
+      },
       "TestCasesOnBeforeAfterValidationTestResponse": {
         "type": "object",
         "additionalProperties": false,
@@ -6485,7 +6958,7 @@
         }
       },
       "FastEndpointsHttp": {
-        "type": "integer",
+        "type": "string",
         "description": "enum for specifying a http verb",
         "x-enumNames": [
           "GET",
@@ -6499,15 +6972,15 @@
           "TRACE"
         ],
         "enum": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9
+          "GET",
+          "POST",
+          "PUT",
+          "PATCH",
+          "DELETE",
+          "HEAD",
+          "OPTIONS",
+          "CONNECT",
+          "TRACE"
         ]
       },
       "TestCasesPlainTextRequestTestResponse": {
@@ -6594,6 +7067,42 @@
         "type": "object",
         "additionalProperties": false
       },
+      "TestCasesQueryObjectBindingTestCircularResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "childName": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "TestCasesQueryObjectBindingTestCircularRequest": {
+        "type": "object",
+        "additionalProperties": false
+      },
+      "TestCasesQueryObjectBindingTestCircularQueryData": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "child": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TestCasesQueryObjectBindingTestCircularQueryData"
+              }
+            ]
+          }
+        }
+      },
       "TestCasesQueryObjectBindingTestResponse": {
         "type": "object",
         "additionalProperties": false,
@@ -6628,7 +7137,7 @@
         }
       },
       "SystemDayOfWeek": {
-        "type": "integer",
+        "type": "string",
         "description": "",
         "x-enumNames": [
           "Sunday",
@@ -6640,13 +7149,13 @@
           "Saturday"
         ],
         "enum": [
-          0,
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
+          "Sunday",
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday"
         ]
       },
       "TestCasesQueryObjectBindingTestPerson": {
@@ -6700,6 +7209,16 @@
             "type": "integer",
             "format": "int32"
           },
+          "birthDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "wakeUpTime": {
+            "type": "string",
+            "format": "time",
+            "nullable": true
+          },
           "strings": {
             "type": "array",
             "items": {
@@ -6718,7 +7237,7 @@
         }
       },
       "TestCasesQueryObjectBindingTestByteEnum": {
-        "type": "integer",
+        "type": "string",
         "description": "",
         "x-enumNames": [
           "Check",
@@ -6726,9 +7245,9 @@
           "AnotherCheck"
         ],
         "enum": [
-          0,
-          1,
-          2
+          "Check",
+          "Test",
+          "AnotherCheck"
         ]
       },
       "TestCasesQueryObjectBindingTestRequest": {
@@ -7046,11 +7565,12 @@
             "nullable": true
           },
           "stringOverride": {
-            "type": "string"
+            "type": "integer",
+            "format": "int64"
           },
           "stringOverrideNullable": {
-            "type": "string",
-            "nullable": true
+            "type": "integer",
+            "format": "int64"
           },
           "fromBody": {
             "type": "string",
@@ -7200,7 +7720,7 @@
       },
       "FastEndpointsProblemDetails": {
         "type": "object",
-        "description": "RFC7807 compatible problem details/ error response class. this can be used by configuring startup like so:\napp.UseFastEndpoints(c => c.Errors.UseProblemDetails())",
+        "description": "RFC9457 compatible problem details/ error response class. this can be used by configuring startup like so:\napp.UseFastEndpoints(c => c.Errors.UseProblemDetails())",
         "additionalProperties": false,
         "properties": {
           "type": {

--- a/Tests/IntegrationTests/FastEndpoints.Swagger/release-2.json
+++ b/Tests/IntegrationTests/FastEndpoints.Swagger/release-2.json
@@ -1,5 +1,5 @@
 {
-  "x-generator": "NSwag v14.6.3.0 (NJsonSchema v11.5.2.0 (Newtonsoft.Json v13.0.0.0))",
+  "x-generator": "NSwag v14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))",
   "openapi": "3.0.0",
   "info": {
     "title": "FastEndpoints Sandbox",
@@ -31,7 +31,23 @@
           "200": {
             "description": "all good",
             "headers": {
-              "x-some-custom-header": {}
+              "x-some-custom-header": {
+                "description": "my custom header",
+                "schema": {
+                  "title": "<>f__AnonymousType0OfString",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "prop1": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                },
+                "example": {
+                  "prop1": "prop1 val"
+                }
+              }
             },
             "content": {
               "application/json": {
@@ -74,7 +90,23 @@
           "200": {
             "description": "all good",
             "headers": {
-              "x-some-custom-header": {}
+              "x-some-custom-header": {
+                "description": "my custom header",
+                "schema": {
+                  "title": "<>f__AnonymousType0OfString",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "prop1": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                },
+                "example": {
+                  "prop1": "prop1 val"
+                }
+              }
             },
             "content": {
               "application/json": {
@@ -117,7 +149,23 @@
           "200": {
             "description": "all good",
             "headers": {
-              "x-some-custom-header": {}
+              "x-some-custom-header": {
+                "description": "my custom header",
+                "schema": {
+                  "title": "<>f__AnonymousType0OfString",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "prop1": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                },
+                "example": {
+                  "prop1": "prop1 val"
+                }
+              }
             },
             "content": {
               "application/json": {
@@ -162,7 +210,23 @@
           "200": {
             "description": "all good",
             "headers": {
-              "x-some-custom-header": {}
+              "x-some-custom-header": {
+                "description": "my custom header",
+                "schema": {
+                  "title": "<>f__AnonymousType0OfString",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "prop1": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                },
+                "example": {
+                  "prop1": "prop1 val"
+                }
+              }
             },
             "content": {
               "application/json": {
@@ -205,7 +269,23 @@
           "200": {
             "description": "all good",
             "headers": {
-              "x-some-custom-header": {}
+              "x-some-custom-header": {
+                "description": "my custom header",
+                "schema": {
+                  "title": "<>f__AnonymousType0OfString",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "prop1": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                },
+                "example": {
+                  "prop1": "prop1 val"
+                }
+              }
             },
             "content": {
               "application/json": {
@@ -248,7 +328,23 @@
           "200": {
             "description": "all good",
             "headers": {
-              "x-some-custom-header": {}
+              "x-some-custom-header": {
+                "description": "my custom header",
+                "schema": {
+                  "title": "<>f__AnonymousType0OfString",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "prop1": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                },
+                "example": {
+                  "prop1": "prop1 val"
+                }
+              }
             },
             "content": {
               "application/json": {
@@ -2023,7 +2119,7 @@
               }
             },
             "example": [
-              ""
+              "a7a65a80-6dc0-48f5-a85f-0989003b4e02"
             ]
           },
           {
@@ -2570,7 +2666,7 @@
               }
             },
             "example": [
-              ""
+              "01b87115-a5fa-48cb-9670-2c5537dd4d6f"
             ]
           },
           {
@@ -3233,7 +3329,7 @@
               }
             },
             "example": [
-              ""
+              "c58747de-f2eb-4e80-b4f2-d93198e84b9a"
             ]
           },
           {
@@ -3579,6 +3675,68 @@
         ]
       }
     },
+    "/api/api/test-cases/circular-fromform-binding-test": {
+      "post": {
+        "tags": [
+          "Api"
+        ],
+        "operationId": "TestCasesNestedFromFormBindingTestCircularEndpoint",
+        "requestBody": {
+          "x-name": "data",
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestCircularFormData"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestCircularResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/api/test-cases/nested-fromform-binding-test": {
+      "post": {
+        "tags": [
+          "Api"
+        ],
+        "operationId": "TestCasesNestedFromFormBindingTestEndpoint",
+        "requestBody": {
+          "x-name": "data",
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestRequest_FormData"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/test-cases/on-before-on-after-validate": {
       "post": {
         "tags": [
@@ -3882,6 +4040,47 @@
         }
       }
     },
+    "/api/test-cases/circular-query-object-binding-test": {
+      "get": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesQueryObjectBindingTestCircularEndpoint",
+        "parameters": [
+          {
+            "name": "data",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TestCasesQueryObjectBindingTestCircularQueryData"
+                }
+              ]
+            },
+            "example": {
+              "name": "name",
+              "child": {
+                "name": "name",
+                "child": null
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestCasesQueryObjectBindingTestCircularResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/test-cases/query-object-binding-test": {
       "get": {
         "tags": [
@@ -3959,26 +4158,28 @@
               ]
             },
             "example": {
-              "id": "id",
+              "id": "9512d3aa-3748-4306-925c-e4beb103441e",
               "name": "name",
               "age": 0,
               "child": {
-                "id": "id",
+                "id": "6f50e195-8ff7-4789-af18-1b464ec0b441",
                 "name": "name",
                 "age": 0,
+                "birthDate": "2026-05-29",
+                "wakeUpTime": "wakeUpTime",
                 "strings": [
                   ""
                 ],
                 "favoriteDays": [
-                  0
+                  "Sunday"
                 ],
                 "isHidden": false
               },
               "numbers": [
                 0
               ],
-              "favoriteDay": 0,
-              "byteEnum": 0,
+              "favoriteDay": "Sunday",
+              "byteEnum": "Check",
               "isHidden": false
             }
           }
@@ -4026,7 +4227,7 @@
                     "int": 0,
                     "long": 0,
                     "double": 0.0,
-                    "enum": 0
+                    "enum": "Sunday"
                   }
                 ]
               },
@@ -4037,7 +4238,7 @@
                   "int": 0,
                   "long": 0,
                   "double": 0.0,
-                  "enum": 0
+                  "enum": "Sunday"
                 }
               ]
             }
@@ -4283,11 +4484,11 @@
               ]
             },
             "example": {
-              "id": "id",
+              "id": "b5fb9b5f-fd82-4b5f-9562-cc083bfaa882",
               "name": "name",
               "age": 0,
               "child": {
-                "id": "id",
+                "id": "2a0cb047-0956-4012-b9d1-31fa02183c69",
                 "name": "name",
                 "age": 0,
                 "strings": [
@@ -4567,6 +4768,54 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TestCasesSTJInfiniteRecursionTestResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tests/generic-stream-command": {
+      "get": {
+        "tags": [
+          "Tests"
+        ],
+        "operationId": "TestCasesStreamCommandBusTestGenericStreamCmdEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "guid"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tests/stream-command": {
+      "get": {
+        "tags": [
+          "Tests"
+        ],
+        "operationId": "TestCasesStreamCommandBusTestStreamCmdEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
                 }
               }
             }
@@ -5447,6 +5696,89 @@
             "x-position": 1
           }
         ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/non-fe-auth": {
+      "get": {
+        "tags": [
+          "non-fe-auth"
+        ],
+        "operationId": "GetNonFeAuth",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "JWTBearerAuth": []
+          }
+        ]
+      }
+    },
+    "/non-fe-auth-anon": {
+      "get": {
+        "tags": [
+          "non-fe-auth"
+        ],
+        "operationId": "GetNonFeAuthAnon",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/filtered-shared-path": {
+      "get": {
+        "tags": [
+          "exclude"
+        ],
+        "operationId": "GetFilteredSharedPath",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "shared-path"
+        ],
+        "operationId": "PostFilteredSharedPath",
         "responses": {
           "200": {
             "description": "",
@@ -6545,6 +6877,192 @@
         "type": "object",
         "additionalProperties": false
       },
+      "TestCasesNestedFromFormBindingTestCircularResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "childName": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestCircularRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestCircularFormData"
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestCircularFormData": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "child": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestCircularFormData"
+              }
+            ]
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "customName": {
+            "type": "string"
+          },
+          "fileName": {
+            "type": "string"
+          },
+          "documentFileNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "detailsTitle": {
+            "type": "string"
+          },
+          "detailsImageFileName": {
+            "type": "string"
+          },
+          "galleryFileNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "firstItemDescription": {
+            "type": "string"
+          },
+          "firstItemAttachmentFileName": {
+            "type": "string"
+          },
+          "numbersSum": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestRequest_FormData"
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestRequest_FormData": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "customName",
+          "file",
+          "documents",
+          "details",
+          "items",
+          "numbers"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "customName": {
+            "type": "string"
+          },
+          "file": {
+            "type": "string",
+            "format": "binary"
+          },
+          "documents": {
+            "type": "array",
+            "items": {}
+          },
+          "details": {
+            "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestRequest_Details"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TestCasesNestedFromFormBindingTestRequest_Item"
+            }
+          },
+          "numbers": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestRequest_Details": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "title",
+          "image",
+          "gallery"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string",
+            "format": "binary"
+          },
+          "gallery": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        }
+      },
+      "TestCasesNestedFromFormBindingTestRequest_Item": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "description",
+          "attachment"
+        ],
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "attachment": {
+            "type": "string",
+            "format": "binary"
+          }
+        }
+      },
       "TestCasesOnBeforeAfterValidationTestResponse": {
         "type": "object",
         "additionalProperties": false,
@@ -6569,7 +7087,7 @@
         }
       },
       "FastEndpointsHttp": {
-        "type": "integer",
+        "type": "string",
         "description": "enum for specifying a http verb",
         "x-enumNames": [
           "GET",
@@ -6583,15 +7101,15 @@
           "TRACE"
         ],
         "enum": [
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9
+          "GET",
+          "POST",
+          "PUT",
+          "PATCH",
+          "DELETE",
+          "HEAD",
+          "OPTIONS",
+          "CONNECT",
+          "TRACE"
         ]
       },
       "TestCasesPlainTextRequestTestResponse": {
@@ -6678,6 +7196,42 @@
         "type": "object",
         "additionalProperties": false
       },
+      "TestCasesQueryObjectBindingTestCircularResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "childName": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "TestCasesQueryObjectBindingTestCircularRequest": {
+        "type": "object",
+        "additionalProperties": false
+      },
+      "TestCasesQueryObjectBindingTestCircularQueryData": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "child": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TestCasesQueryObjectBindingTestCircularQueryData"
+              }
+            ]
+          }
+        }
+      },
       "TestCasesQueryObjectBindingTestResponse": {
         "type": "object",
         "additionalProperties": false,
@@ -6712,7 +7266,7 @@
         }
       },
       "SystemDayOfWeek": {
-        "type": "integer",
+        "type": "string",
         "description": "",
         "x-enumNames": [
           "Sunday",
@@ -6724,13 +7278,13 @@
           "Saturday"
         ],
         "enum": [
-          0,
-          1,
-          2,
-          3,
-          4,
-          5,
-          6
+          "Sunday",
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday"
         ]
       },
       "TestCasesQueryObjectBindingTestPerson": {
@@ -6784,6 +7338,16 @@
             "type": "integer",
             "format": "int32"
           },
+          "birthDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "wakeUpTime": {
+            "type": "string",
+            "format": "time",
+            "nullable": true
+          },
           "strings": {
             "type": "array",
             "items": {
@@ -6802,7 +7366,7 @@
         }
       },
       "TestCasesQueryObjectBindingTestByteEnum": {
-        "type": "integer",
+        "type": "string",
         "description": "",
         "x-enumNames": [
           "Check",
@@ -6810,9 +7374,9 @@
           "AnotherCheck"
         ],
         "enum": [
-          0,
-          1,
-          2
+          "Check",
+          "Test",
+          "AnotherCheck"
         ]
       },
       "TestCasesQueryObjectBindingTestRequest": {
@@ -7130,11 +7694,12 @@
             "nullable": true
           },
           "stringOverride": {
-            "type": "string"
+            "type": "integer",
+            "format": "int64"
           },
           "stringOverrideNullable": {
-            "type": "string",
-            "nullable": true
+            "type": "integer",
+            "format": "int64"
           },
           "fromBody": {
             "type": "string",
@@ -7284,7 +7849,7 @@
       },
       "FastEndpointsProblemDetails": {
         "type": "object",
-        "description": "RFC7807 compatible problem details/ error response class. this can be used by configuring startup like so:\napp.UseFastEndpoints(c => c.Errors.UseProblemDetails())",
+        "description": "RFC9457 compatible problem details/ error response class. this can be used by configuring startup like so:\napp.UseFastEndpoints(c => c.Errors.UseProblemDetails())",
         "additionalProperties": false,
         "properties": {
           "type": {

--- a/Tests/IntegrationTests/FastEndpoints.Swagger/release-versioning-v0.json
+++ b/Tests/IntegrationTests/FastEndpoints.Swagger/release-versioning-v0.json
@@ -1,5 +1,5 @@
 {
-  "x-generator": "NSwag v14.6.3.0 (NJsonSchema v11.5.2.0 (Newtonsoft.Json v13.0.0.0))",
+  "x-generator": "NSwag v14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))",
   "openapi": "3.0.0",
   "info": {
     "title": "Web API",

--- a/Tests/IntegrationTests/FastEndpoints.Swagger/release-versioning-v1.json
+++ b/Tests/IntegrationTests/FastEndpoints.Swagger/release-versioning-v1.json
@@ -1,5 +1,5 @@
 {
-  "x-generator": "NSwag v14.6.3.0 (NJsonSchema v11.5.2.0 (Newtonsoft.Json v13.0.0.0))",
+  "x-generator": "NSwag v14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))",
   "openapi": "3.0.0",
   "info": {
     "title": "Web API",

--- a/Tests/IntegrationTests/FastEndpoints.Swagger/release-versioning-v2.json
+++ b/Tests/IntegrationTests/FastEndpoints.Swagger/release-versioning-v2.json
@@ -1,5 +1,5 @@
 {
-  "x-generator": "NSwag v14.6.3.0 (NJsonSchema v11.5.2.0 (Newtonsoft.Json v13.0.0.0))",
+  "x-generator": "NSwag v14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))",
   "openapi": "3.0.0",
   "info": {
     "title": "Web API",

--- a/Tests/IntegrationTests/FastEndpoints.Swagger/release-versioning-v3.json
+++ b/Tests/IntegrationTests/FastEndpoints.Swagger/release-versioning-v3.json
@@ -1,5 +1,5 @@
 {
-  "x-generator": "NSwag v14.6.3.0 (NJsonSchema v11.5.2.0 (Newtonsoft.Json v13.0.0.0))",
+  "x-generator": "NSwag v14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))",
   "openapi": "3.0.0",
   "info": {
     "title": "Web API",


### PR DESCRIPTION
# Fix for #1112 and #1109 _childAdaptorValidators -System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access and nested SetValidator constraints dropped when generating multiple versioned documents in same process

## Fix: ValidationSchemaProcessor concurrent and cross-document state corruption

### Background

`ValidationSchemaProcessor` is registered as a **singleton** via `CreateSingleton`
(which uses `GetOrAdd` on an internal concurrent cache), so every `SwaggerDocument`
in the application shares the same processor instance. This exposed two distinct bugs
in the `_childAdaptorValidators` field — one concurrency issue and one document-lifetime
issue — both fixed in this PR.

---

### Bug 1 — Concurrent dictionary corruption (race condition)

**Symptom:** Hitting the swagger endpoint with simultaneous requests threw
`InvalidOperationException` with a corrupted `Dictionary` internal state.

**Root cause:** `_childAdaptorValidators` was declared as a plain
`Dictionary<string, IValidator>`. Multiple threads calling `Process()` concurrently
could both find a key absent and write to the dictionary simultaneously, corrupting
its internal state.

**Initial fix (commit dd18fe51):** Changed the field to
`ConcurrentDictionary<string, IValidator>` so concurrent reads and writes are safe.

---

### Bug 2 — Cross-document constraint loss (state leakage)

**Symptom:** When two `SwaggerDocument` registrations share a DTO whose validator
uses `RuleForEach(...).SetValidator(new ChildValidator())` (or
`RuleFor(...).SetValidator(...)`), only the **first** document generated in a given
process lifetime has the nested validator's constraints (`required`, `minLength`,
`minimum`, etc.) on the shared schema component. The second document's copy of that
schema is emitted with all constraints stripped. The effect is symmetric — whichever
document is requested first wins; the other loses.

**Root cause:** The `_childAdaptorValidators` cache (even as `ConcurrentDictionary`)
accumulated validator-type entries across all document passes for the lifetime of the
process. On the second document's pass, `TryGetValue` succeeded for types already seen
in the first pass, causing the code to `continue` and skip `ApplyValidator` entirely —
leaving the second document's schemas without any nested constraints.

**Reproduction:**

```csharp
// Both validators use the same OrderLineValidator
public class CreateOrderV1Validator : Validator<CreateOrderV1Request>
{
    public CreateOrderV1Validator()
        => RuleForEach(x => x.Lines).SetValidator(new OrderLineValidator());
}
public class CreateOrderV2Validator : Validator<CreateOrderV2Request>
{
    public CreateOrderV2Validator()
        => RuleForEach(x => x.Lines).SetValidator(new OrderLineValidator());
}
```
Fetch v1 first, then v2:

v1/swagger.json → OrderLine has required, minLength, minimum ✓
v2/swagger.json → OrderLine has no constraints ✗
Combined fix
Both bugs share the same root cause: _childAdaptorValidators as a long-lived
instance field. The complete solution is to remove the field entirely and replace
it with a fresh Dictionary<string, IValidator> created at the start of each
Process() invocation, then threaded through the private call chain:


Process()  ← creates dictionary here; discarded on return
  └─ ApplyValidator(…, dict)
       ├─ ApplyRulesToSchema(…, dict)
       │    └─ TryApplyValidation(…, dict)
       │         └─ ApplyValidationRule(…, dict)
       │              └─ ApplyValidator (recursive, same dict)
       └─ ApplyRulesFromIncludedValidators(…, dict)
This supersedes the ConcurrentDictionary workaround:

Concurrency — a call-local Dictionary is never shared between threads, so there is no concurrent write to protect against.
Cross-document leakage — the dict is discarded when Process() returns, so each document pass starts clean and applies all child-validator constraints to its own fresh schema objects.
Recursion guard — still works correctly: within one Process() call the dict accumulates seen validator types as before, preventing infinite loops from self-referential validators.
No logic changes — only the dictionary's lifetime narrows from process-scoped to
per-Process()-call.

Test
Added MultiDocSharedOrderLine + MultiDocSharedOrderLineValidator
(using RuleForEach + SetValidator) along with two swagger-review endpoints
(MultiDocOrderEndpointA, MultiDocOrderEndpointB) that both reference the same
child validator. The regression test
shared_nested_validator_constraints_survive_multi_document_generation generates
"Swagger Review" then "Swagger Review Empty Schema" and asserts that
sku.minLength and qty.exclusiveMinimum are present in both documents.

Note: The Int.Swagger integration test project is (and was already) failing before these changes because of IOpenApiDocumentGenerator not being registered. Solving this is probably not worth it since the Swagger package is about to be phased out.
