### PR TITLE
Fix: configure serializer options once per process to prevent concurrent JsonSerializerOptions read-only race

### DIFF
--- a/Src/Library/Endpoint/Idempotency/IdempotencyOptions.cs
+++ b/Src/Library/Endpoint/Idempotency/IdempotencyOptions.cs
@@ -1,12 +1,5 @@
 using Microsoft.Net.Http.Headers;
 
-#if NET9_0_OR_GREATER
-using Lock = System.Threading.Lock;
-
-#else
-    using Lock = object;
-#endif
-
 namespace FastEndpoints;
 
 /// <summary>

--- a/Src/Library/Main/MainExtensions.cs
+++ b/Src/Library/Main/MainExtensions.cs
@@ -66,13 +66,12 @@ public static class MainExtensions
         return app;
     }
 
-    static readonly object _serializerConfigLock = new();
+    static readonly Lock _serializerConfigLock = new();
     static volatile bool _serializerConfigured;
 
     public static IEndpointRouteBuilder MapFastEndpoints(this IEndpointRouteBuilder app, Action<Cfg>? configAction = null)
     {
         ServiceResolver.Instance = app.ServiceProvider.GetRequiredService<IServiceResolver>();
-
         ConfigureSerializerOnce(app, configAction);
         Cfg.BndOpts.AddTypedHeaderValueParsers();
 
@@ -212,14 +211,8 @@ public static class MainExtensions
         return app;
     }
 
-    /// <summary>
-    ///     Configures the process-wide serializer options (<see cref="SerializerOptions.Options" />) exactly once.
-    /// </summary>
     static void ConfigureSerializerOnce(IEndpointRouteBuilder app, Action<Cfg>? configAction)
     {
-        if (_serializerConfigured)
-            return;
-
         lock (_serializerConfigLock)
         {
             if (_serializerConfigured)

--- a/Src/Library/Main/MainExtensions.cs
+++ b/Src/Library/Main/MainExtensions.cs
@@ -66,16 +66,14 @@ public static class MainExtensions
         return app;
     }
 
+    static readonly object _serializerConfigLock = new();
+    static volatile bool _serializerConfigured;
+
     public static IEndpointRouteBuilder MapFastEndpoints(this IEndpointRouteBuilder app, Action<Cfg>? configAction = null)
     {
         ServiceResolver.Instance = app.ServiceProvider.GetRequiredService<IServiceResolver>();
 
-        var serializerOptions = app.ServiceProvider.GetService<IOptions<JsonOptions>>()?.Value.SerializerOptions;
-
-        if (serializerOptions is not null)
-            Cfg.SerOpts.Options = new(serializerOptions);
-
-        Cfg.SerOpts.Options.ConfigureSerializer(app.ServiceProvider.GetRequiredService<Cfg>(), configAction);
+        ConfigureSerializerOnce(app, configAction);
         Cfg.BndOpts.AddTypedHeaderValueParsers();
 
         if (Cfg.ValOpts.UsePropertyNamingPolicy && Cfg.SerOpts.Options.PropertyNamingPolicy is not null)
@@ -212,6 +210,30 @@ public static class MainExtensions
            .ExcludeFromDescription();
 
         return app;
+    }
+
+    /// <summary>
+    ///     Configures the process-wide serializer options (<see cref="SerializerOptions.Options" />) exactly once.
+    /// </summary>
+    static void ConfigureSerializerOnce(IEndpointRouteBuilder app, Action<Cfg>? configAction)
+    {
+        if (_serializerConfigured)
+            return;
+
+        lock (_serializerConfigLock)
+        {
+            if (_serializerConfigured)
+                return;
+
+            var serializerOptions = app.ServiceProvider.GetService<IOptions<JsonOptions>>()?.Value.SerializerOptions;
+
+            if (serializerOptions is not null)
+                Cfg.SerOpts.Options = new(serializerOptions);
+
+            Cfg.SerOpts.Options.ConfigureSerializer(app.ServiceProvider.GetRequiredService<Cfg>(), configAction);
+
+            _serializerConfigured = true;
+        }
     }
 
     internal static string BuildRoute(this StringBuilder builder, int epVersion, string route, string? prefixOverride)

--- a/Src/Library/Metadata.cs
+++ b/Src/Library/Metadata.cs
@@ -1,3 +1,9 @@
+#if NET9_0_OR_GREATER
+    global using Lock = System.Threading.Lock;
+#else
+    global using Lock = object;
+#endif
+
 using System.Runtime.CompilerServices;
 
 [assembly:InternalsVisibleTo("FastEndpoints.AspVersioning, PublicKey=002400000480000094000000060200000024000052534131000400000100010051c42d27b58576d0e7a31a419b1a07b3cfefcece51c94ebb3ac9309423361041fd6521dae4ea609d6d6bc1d23402413b13bb1a10e3f05ca0740f41a524a418a1e596b0eeb14facde12bbc1c07e0e5a5f1220a12821dfeb1ba070c8eae1f857508faa6ad00cfa7da3f57252e210be8900dd53b180ef319d4adab21f266ccf06a1")]

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -106,6 +106,14 @@ This fixes nested `[FromQuery]` request DTO properties such as `DateOnly?` and `
 
 ## Improvements 🚀
 
+<details><summary>Serializer options are now configured once per process during startup</summary>
+
+FastEndpoints now performs its process-wide serializer configuration under a one-time startup lock. This prevents parallel host creation in the same process, such as `WebApplicationFactory` based integration tests, from re-pointing and mutating the shared `JsonSerializerOptions` instance while another host is already serializing requests or responses.
+
+This keeps the existing process-global configuration model: the first FastEndpoints startup configures the shared serializer options and later hosts in the same process reuse that configuration instead of reconfiguring it.
+
+</details>
+
 <details><summary>Access control permission lookup data is now source generated</summary>
 
 The `Allow` source generator now emits the permission name/code lookup initialization directly, avoiding runtime reflection when access control permissions are first used.

--- a/Tests/IntegrationTests/FastEndpoints/BindingTests/MalformedMultipartTests.cs
+++ b/Tests/IntegrationTests/FastEndpoints/BindingTests/MalformedMultipartTests.cs
@@ -29,14 +29,12 @@ public class MalformedMultipartTests : IAsyncLifetime
         var bld = WebApplication.CreateBuilder();
         bld.WebHost.ConfigureKestrel(o => o.Listen(IPAddress.Loopback, 0));
         bld.Services.AddFastEndpoints(o => o.Filter = t => t == typeof(Ep));
+        Config.EpOpts.RoutePrefix = null;
+        Config.EpOpts.Filter = null;
+        Config.EpOpts.Configurator = null;
+
         var app = bld.Build();
-        app.UseFastEndpoints(
-            c =>
-            {
-                c.Endpoints.RoutePrefix = null;
-                c.Endpoints.Filter = null;
-                c.Endpoints.Configurator = null;
-            });
+        app.UseFastEndpoints();
         _app = app;
     }
 

--- a/Tests/IntegrationTests/FastEndpoints/BindingTests/MaxRequestBodyLimitTests.cs
+++ b/Tests/IntegrationTests/FastEndpoints/BindingTests/MaxRequestBodyLimitTests.cs
@@ -30,15 +30,13 @@ public class MaxRequestBodyLimitTests : IAsyncLifetime
         var bld = WebApplication.CreateBuilder();
         bld.WebHost.ConfigureKestrel(o => o.ListenLocalhost(1024));
         bld.Services.AddFastEndpoints(o => o.Filter = t => t == typeof(Endpoint));
+        Config.EpOpts.RoutePrefix = null;
+        Config.EpOpts.Filter = null;
+        Config.EpOpts.Configurator = ep => ep.MaxRequestBodySize(100);
+        Config.BndOpts.FormExceptionTransformer = ex => new("formErrors", ex.Message);
+
         var app = bld.Build();
-        app.UseFastEndpoints(
-            c =>
-            {
-                c.Endpoints.RoutePrefix = null;
-                c.Endpoints.Filter = null;
-                c.Endpoints.Configurator = ep => ep.MaxRequestBodySize(100);
-                c.Binding.FormExceptionTransformer = ex => new("formErrors", ex.Message);
-            });
+        app.UseFastEndpoints();
         _app = app;
     }
 

--- a/Tests/IntegrationTests/FastEndpoints/MiscTests/SerializerConfigurationTests.cs
+++ b/Tests/IntegrationTests/FastEndpoints/MiscTests/SerializerConfigurationTests.cs
@@ -1,0 +1,178 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Misc;
+
+public class SerializerConfigurationTests
+{
+    const int RequestCount = 8;
+
+    static ManualResetEventSlim _releaseResponses = new(false);
+    static int _configureCalls;
+    static int _requestsEntered;
+    static int _responsesSent;
+
+    [Fact]
+    public async Task Serializer_Configuration_Is_Process_Wide_And_Race_Free_When_Hosts_Start_In_Parallel()
+    {
+        var previousSerializerConfigured = SerializerConfigured;
+        var previousSerializerOptions = Config.SerOpts.Options;
+        var previousServiceResolver = ServiceResolver.InstanceNotSet ? null : ServiceResolver.Instance;
+        var previousRoutePrefix = Config.EpOpts.RoutePrefix;
+        var previousEndpointFilter = Config.EpOpts.Filter;
+        var previousEndpointConfigurator = Config.EpOpts.Configurator;
+
+        WebApplication? appA = null;
+        WebApplication? appB = null;
+
+        ResetTestState();
+        Config.SerOpts.Options = new();
+        Config.EpOpts.RoutePrefix = null;
+        Config.EpOpts.Filter = null;
+        Config.EpOpts.Configurator = null;
+        SerializerConfigured = false;
+
+        try
+        {
+            appA = BuildApp();
+            appA.UseFastEndpoints(ConfigureSerializer);
+            await appA.StartAsync(TestContext.Current.CancellationToken);
+
+            // ReSharper disable once ShortLivedHttpClient
+            using var client = new HttpClient();
+            client.BaseAddress = new($"{appA.Urls.First()}/");
+
+            var responseTasks = Enumerable.Range(0, RequestCount)
+                                          .Select(_ => client.GetAsync("serializer-race-test", TestContext.Current.CancellationToken))
+                                          .ToArray();
+
+            SpinWait.SpinUntil(
+                        () => Volatile.Read(ref _requestsEntered) == RequestCount,
+                        TimeSpan.FromSeconds(10))
+                    .ShouldBeTrue("all requests should enter the first host before the second host starts");
+
+            appB = BuildApp();
+            appB.UseFastEndpoints(ConfigureSerializer);
+            await appB.StartAsync(TestContext.Current.CancellationToken);
+
+            // If the second host reused the process-wide serializer configuration, its config action never ran.
+            // Release the first host responses here. Before the one-time startup gate, the second config action
+            // released these responses while it was still mutating the freshly-published JsonSerializerOptions,
+            // which let the first host freeze that instance and made the second mutation throw.
+            _releaseResponses.Set();
+
+            var responses = await Task.WhenAll(responseTasks);
+
+            foreach (var response in responses)
+            {
+                response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+                var body = await response.Content.ReadFromJsonAsync<SerializerRaceResponse>(TestContext.Current.CancellationToken);
+                body?.Message.ShouldBe("ok");
+            }
+
+            Volatile.Read(ref _configureCalls).ShouldBe(1, "FastEndpoints serializer/global config is process-wide and should run once per process");
+        }
+        finally
+        {
+            _releaseResponses.Set();
+
+            if (appB is not null)
+                await appB.DisposeAsync();
+
+            if (appA is not null)
+                await appA.DisposeAsync();
+
+            Config.SerOpts.Options = previousSerializerOptions;
+            Config.EpOpts.RoutePrefix = previousRoutePrefix;
+            Config.EpOpts.Filter = previousEndpointFilter;
+            Config.EpOpts.Configurator = previousEndpointConfigurator;
+            SerializerConfigured = previousSerializerConfigured;
+            SetServiceResolver(previousServiceResolver);
+            ResetTestState();
+        }
+    }
+
+    static WebApplication BuildApp()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.ConfigureKestrel(o => o.Listen(IPAddress.Loopback, 0));
+        builder.Services.AddFastEndpoints(o => o.SourceGeneratorDiscoveredTypes.Add(typeof(SerializerRaceEndpoint)));
+
+        return builder.Build();
+    }
+
+    static void ConfigureSerializer(Config config)
+    {
+        var call = Interlocked.Increment(ref _configureCalls);
+
+        if (call == 2)
+        {
+            SpinWait.SpinUntil(
+                        () => Volatile.Read(ref _requestsEntered) == RequestCount,
+                        TimeSpan.FromSeconds(10))
+                    .ShouldBeTrue("all first-host requests should be waiting before releasing responses from the second config action");
+
+            _releaseResponses.Set();
+
+            SpinWait.SpinUntil(
+                        () => Volatile.Read(ref _responsesSent) == RequestCount,
+                        TimeSpan.FromSeconds(10))
+                    .ShouldBeTrue("first-host responses should serialize with the second host's published serializer options");
+        }
+
+        config.Serializer.Options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+    }
+
+    static bool SerializerConfigured
+    {
+        get => (bool)SerializerConfiguredField.GetValue(null)!;
+        set => SerializerConfiguredField.SetValue(null, value);
+    }
+
+    static FieldInfo SerializerConfiguredField { get; } =
+        typeof(MainExtensions).GetField("_serializerConfigured", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    static FieldInfo ServiceResolverInstanceField { get; } =
+        typeof(ServiceResolver).GetField("_instance", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    static void SetServiceResolver(IServiceResolver? resolver)
+        => ServiceResolverInstanceField.SetValue(null, resolver);
+
+    static void ResetTestState()
+    {
+        _releaseResponses.Dispose();
+        _releaseResponses = new(false);
+        _configureCalls = 0;
+        _requestsEntered = 0;
+        _responsesSent = 0;
+    }
+
+    sealed class SerializerRaceEndpoint : EndpointWithoutRequest<SerializerRaceResponse>
+    {
+        public override void Configure()
+        {
+            Get("serializer-race-test");
+            AllowAnonymous();
+        }
+
+        public override async Task HandleAsync(CancellationToken ct)
+        {
+            Interlocked.Increment(ref _requestsEntered);
+            _releaseResponses.Wait(ct);
+
+            await Send.OkAsync(new() { Message = "ok" }, ct);
+            Interlocked.Increment(ref _responsesSent);
+        }
+    }
+
+    sealed class SerializerRaceResponse
+    {
+        public string Message { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
## Background

`FastEndpoints.Config` stores serializer settings in a **process-global static**. `Config.Serializer.Options` (`Cfg.SerOpts.Options`) is a single `System.Text.Json.JsonSerializerOptions` instance shared by every host in the process:

```csharp
// Src/Library/Config/Config.cs
internal static readonly SerializerOptions SerOpts = new();

// Src/Library/Config/SerializerOptions.cs
public JsonSerializerOptions Options { get; internal set; } = new();
```

This is fine for the normal "one app per process" scenario. It becomes a problem when **multiple hosts are created in the same process** — the typical setup for `WebApplicationFactory`-based integration tests, **especially when the test framework runs test classes in parallel** (e.g. TUnit, which is parallel-by-default, or xUnit without disabling parallelization). Each host's startup calls `MapFastEndpoints`, which **re-points and mutates that shared static**.

## Symptom

Running such integration tests in parallel intermittently fails at host startup with:

```
System.InvalidOperationException: This JsonSerializerOptions instance is read-only or has already been used in serialization or deserialization.
   at System.Text.Json.ThrowHelper.ThrowInvalidOperationException_SerializerOptionsReadOnly(JsonSerializerContext context)
   at System.Text.Json.JsonSerializerOptions.set_DefaultIgnoreCondition(JsonIgnoreCondition value)
   at <the user's UseFastEndpoints config action>          // e.g. cfg.Serializer.Options.DefaultIgnoreCondition = ...
   at FastEndpoints.MainExtensions.MapFastEndpoints(IEndpointRouteBuilder app, Action`1 configAction)
   at FastEndpoints.MainExtensions.UseFastEndpoints(IApplicationBuilder app, Action`1 configAction)
   at Program.<Main>$(String[] args)
   ...
   at Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory`1.CreateHost(IHostBuilder builder)
   at Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory`1.StartServer()
```

It is **sporadic** and **timing-dependent** — it shows up more often on CI, on Linux, and on higher core counts (more parallelism), and frequently passes locally. The throwing statement varies: it can be any mutation of the options (e.g. `set_DefaultIgnoreCondition`, `set_PropertyNamingPolicy`, `Converters.Add(...)`), or one of FastEndpoints' own internal mutations (see below).

## Root cause

`MapFastEndpoints` configures the shared static in place:

```csharp
// Src/Library/Main/MainExtensions.cs (before)
var serializerOptions = app.ServiceProvider.GetService<IOptions<JsonOptions>>()?.Value.SerializerOptions;

if (serializerOptions is not null)
    Cfg.SerOpts.Options = new(serializerOptions);                       // (1) publish a fresh instance to the shared static

Cfg.SerOpts.Options.ConfigureSerializer(                                // (2) then mutate it in place
    app.ServiceProvider.GetRequiredService<Cfg>(), configAction);
```

…and `ConfigureSerializer` mutates it further, including invoking the user's config action:

```csharp
// Src/Library/Config/ConfigExtensions.cs
opts.TypeInfoResolver = opts.TypeInfoResolver?.WithAddedModifier(...);                 // mutate
configAction?.Invoke(cfg);                                                            // mutate (cfg.Serializer.Options.X = ...)
opts.TypeInfoResolverChain.Insert(0, new FastEndpointsSerializerContext(new(opts)));  // mutate
```

A `JsonSerializerOptions` becomes **read-only on its first (de)serialization** (FastEndpoints' `RequestDeserializer` / `ResponseSerializer` call `ReadFromJsonAsync` / `WriteAsJsonAsync` with `SerOpts.Options`). With two hosts (A and B) starting in the same process, this interleaving occurs:

```
Host B startup:  Cfg.SerOpts.Options = newB            // (1) re-point the shared static
Host A serving:  reads Cfg.SerOpts.Options (== newB)   // serializes a request/response
                 -> first use freezes newB             // newB is now read-only
Host B startup:  newB.set_DefaultIgnoreCondition(...)  // (2) mutate -> THROWS (read-only)
```

Because the shared static is re-pointed by B and then read by A's request pipeline, **A freezes the very instance B is still configuring**.

Importantly, this cannot be worked around from the application side:

- Even a **no-op** config action still throws, because FastEndpoints itself mutates the shared instance (`TypeInfoResolver` / `TypeInfoResolverChain.Insert`) during every host's startup.
- A **user-level lock** around `UseFastEndpoints` does not help either — the freeze happens during request **serving**, which is not (and cannot be) held under that lock.

## Fix

Configure the process-global serializer options **exactly once**, under a lock (double-checked):

```csharp
static readonly object _serializerConfigLock = new();
static volatile bool _serializerConfigured;

static void ConfigureSerializerOnce(IEndpointRouteBuilder app, Action<Cfg>? configAction)
{
    if (_serializerConfigured)
        return;

    lock (_serializerConfigLock)
    {
        if (_serializerConfigured)
            return;

        var serializerOptions = app.ServiceProvider.GetService<IOptions<JsonOptions>>()?.Value.SerializerOptions;

        if (serializerOptions is not null)
            Cfg.SerOpts.Options = new(serializerOptions);

        Cfg.SerOpts.Options.ConfigureSerializer(app.ServiceProvider.GetRequiredService<Cfg>(), configAction);

        _serializerConfigured = true;
    }
}
```

`MapFastEndpoints` now calls `ConfigureSerializerOnce(app, configAction)` in place of the inline configuration block.

### Why this is correct and race-free

- The single configuration provably runs **before any host can serve**: every host must pass through `MapFastEndpoints` (and therefore this gate) before its request pipeline is live. The first host to take the lock configures the options while **no other host has finished startup**, so no request pipeline can be serializing/freezing the instance at that moment.
- Every subsequent host **skips** the re-point/reconfigure and reuses the already-configured instance. Once the first (de)serialization freezes it, it is never mutated again — so the read-only mutation can no longer occur.

### Non-breaking / parallelism preserved

- **No behavior change** for the normal single-host-per-process case: there is exactly one `MapFastEndpoints` call, so the options are configured once, exactly as before.
- Hosts still **start up and serve fully in parallel** — only the one-time options setup is synchronized (an uncontended `volatile` read on the fast path after the first call). It does **not** force tests to run sequentially.
- This keeps the existing "global configuration per process" model; it just makes that one-time setup deterministic and thread-safe.

This eliminated a long-standing sporadic CI failure in a parallel `WebApplicationFactory` (TUnit) integration-test suite, while keeping the tests running in parallel.
