### PR TITLE
Set `Microsoft.OpenApi.Kiota.Builder` to `PrivateAssets` `All`

### DIFF
--- a/Src/ClientGen.Kiota/FastEndpoints.ClientGen.Kiota.csproj
+++ b/Src/ClientGen.Kiota/FastEndpoints.ClientGen.Kiota.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="NSwag.Generation.AspNetCore"/>
-        <PackageReference Include="Microsoft.OpenApi.Kiota.Builder"/>
+        <PackageReference Include="Microsoft.OpenApi.Kiota.Builder" PrivateAssets="All"/>
         <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
     </ItemGroup>
 

--- a/Src/OpenApi.Kiota/FastEndpoints.OpenApi.Kiota.csproj
+++ b/Src/OpenApi.Kiota/FastEndpoints.OpenApi.Kiota.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
-        <PackageReference Include="Microsoft.OpenApi.Kiota.Builder"/>
+        <PackageReference Include="Microsoft.OpenApi.Kiota.Builder" PrivateAssets="All"/>
         <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
     </ItemGroup>
 


### PR DESCRIPTION
Since `Microsoft.OpenApi.Kiota.Builder` has a dependency on `Microsoft.VisualStudio.Threading.Analyzers` meaning that whenever we use it we end up pulling in a quite an opinionated analyzer to our project.

Even though its an analyzer this setting `PrivateAssets` to `Analyzers` dosent seem to work and it still ends up being applied to dependent projects.