### PR TITLE
Fix ObjectDisposedException from ServiceResolver root-provider fallback during requests

### DIFF
--- a/Src/Core/ServiceResolver/ServiceResolver.cs
+++ b/Src/Core/ServiceResolver/ServiceResolver.cs
@@ -64,17 +64,27 @@ sealed class ServiceResolver(IServiceProvider provider, IHttpContextAccessor? ct
         => ctxAccessor?.HttpContext?.RequestServices.GetRequiredService(typeOfService) ??
            provider.GetRequiredService(typeOfService);
 
+    //when a request scope is active, resolve solely from it instead of falling back to the captured root 'provider'.
+    //the request scope is a child of the root, so it already sees every registered service; the '?? provider' fallback
+    //would only ever return null for an unregistered service anyway. but 'provider' is a process-wide captured root, and
+    //in multi-host setups (e.g. several WebApplicationFactory instances in one test run) the static ServiceResolver.Instance
+    //can outlive the host that set it - querying that disposed root throws ObjectDisposedException. only fall back to the
+    //root when there is no active request scope (background command/event execution or unit-test setup).
+
     public TService? TryResolve<TService>() where TService : class
-        => ctxAccessor?.HttpContext?.RequestServices.GetService<TService>() ??
-           provider.GetService<TService>();
+        => ctxAccessor?.HttpContext?.RequestServices is { } rs
+               ? rs.GetService<TService>()
+               : provider.GetService<TService>();
 
     public object? TryResolve(Type typeOfService)
-        => ctxAccessor?.HttpContext?.RequestServices.GetService(typeOfService) ??
-           provider.GetService(typeOfService);
+        => ctxAccessor?.HttpContext?.RequestServices is { } rs
+               ? rs.GetService(typeOfService)
+               : provider.GetService(typeOfService);
 
     public TService? TryResolve<TService>(string keyName) where TService : class
-        => ctxAccessor?.HttpContext?.RequestServices.GetKeyedService<TService>(keyName) ??
-           provider.GetKeyedService<TService>(keyName);
+        => ctxAccessor?.HttpContext?.RequestServices is { } rs
+               ? rs.GetKeyedService<TService>(keyName)
+               : provider.GetKeyedService<TService>(keyName);
 
     public object? TryResolve(Type typeOfService, string keyName)
     {

--- a/Tests/UnitTests/FastEndpoints/ServiceResolverTests.cs
+++ b/Tests/UnitTests/FastEndpoints/ServiceResolverTests.cs
@@ -309,6 +309,64 @@ public class ServiceResolverTests
     }
 
     [Fact]
+    public void TryResolve_Generic_WithActiveRequestScope_DoesNotFallBackToDisposedRootProvider()
+    {
+        // simulates a torn-down host whose resolver still lingers in the static ServiceResolver.Instance:
+        // the captured root provider is disposed, yet a request scope is active.
+        var rootProvider = new ServiceCollection().BuildServiceProvider();
+        rootProvider.Dispose();
+
+        var requestServices = new ServiceCollection().BuildServiceProvider();
+        var httpContext = new DefaultHttpContext { RequestServices = requestServices };
+        var ctxAccessor = A.Fake<IHttpContextAccessor>();
+        A.CallTo(() => ctxAccessor.HttpContext).Returns(httpContext);
+
+        var resolver = new ServiceResolver(rootProvider, ctxAccessor);
+
+        // resolving an unregistered service must come back null from the request scope,
+        // not throw ObjectDisposedException by falling back to the disposed root provider.
+        var resolve = () => resolver.TryResolve<ITestService>();
+
+        resolve.ShouldNotThrow().ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryResolve_NonGeneric_WithActiveRequestScope_DoesNotFallBackToDisposedRootProvider()
+    {
+        var rootProvider = new ServiceCollection().BuildServiceProvider();
+        rootProvider.Dispose();
+
+        var requestServices = new ServiceCollection().BuildServiceProvider();
+        var httpContext = new DefaultHttpContext { RequestServices = requestServices };
+        var ctxAccessor = A.Fake<IHttpContextAccessor>();
+        A.CallTo(() => ctxAccessor.HttpContext).Returns(httpContext);
+
+        var resolver = new ServiceResolver(rootProvider, ctxAccessor);
+
+        var resolve = () => resolver.TryResolve(typeof(ITestService));
+
+        resolve.ShouldNotThrow().ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryResolve_GenericWithKeyName_WithActiveRequestScope_DoesNotFallBackToDisposedRootProvider()
+    {
+        var rootProvider = new ServiceCollection().BuildServiceProvider();
+        rootProvider.Dispose();
+
+        var requestServices = new ServiceCollection().BuildServiceProvider();
+        var httpContext = new DefaultHttpContext { RequestServices = requestServices };
+        var ctxAccessor = A.Fake<IHttpContextAccessor>();
+        A.CallTo(() => ctxAccessor.HttpContext).Returns(httpContext);
+
+        var resolver = new ServiceResolver(rootProvider, ctxAccessor);
+
+        var resolve = () => resolver.TryResolve<ITestService>("myKey");
+
+        resolve.ShouldNotThrow().ShouldBeNull();
+    }
+
+    [Fact]
     public void TryResolve_GenericWithKeyName_ReturnsKeyedServiceWhenRegistered()
     {
         var services = new ServiceCollection();

--- a/Tests/UnitTests/FastEndpoints/ServiceResolverTests.cs
+++ b/Tests/UnitTests/FastEndpoints/ServiceResolverTests.cs
@@ -367,6 +367,24 @@ public class ServiceResolverTests
     }
 
     [Fact]
+    public void TryResolve_NonGenericWithKeyName_WithActiveRequestScope_DoesNotFallBackToDisposedRootProvider()
+    {
+        var rootProvider = new ServiceCollection().BuildServiceProvider();
+        rootProvider.Dispose();
+
+        var requestServices = new ServiceCollection().BuildServiceProvider();
+        var httpContext = new DefaultHttpContext { RequestServices = requestServices };
+        var ctxAccessor = A.Fake<IHttpContextAccessor>();
+        A.CallTo(() => ctxAccessor.HttpContext).Returns(httpContext);
+
+        var resolver = new ServiceResolver(rootProvider, ctxAccessor);
+
+        var resolve = () => resolver.TryResolve(typeof(ITestService), "myKey");
+
+        resolve.ShouldNotThrow().ShouldBeNull();
+    }
+
+    [Fact]
     public void TryResolve_GenericWithKeyName_ReturnsKeyedServiceWhenRegistered()
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
## Problem

In multi-host test processes (several `WebApplicationFactory` instances in one test run), command execution can throw:

```
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'IServiceProvider'.
   at ...ServiceProviderEngineScope.GetService(Type serviceType)
   at FastEndpoints.ServiceResolver.TryResolve(Type typeOfService)
   at FastEndpoints.CommandExtensions.PrepareExecution[TResult](...)
   at FastEndpoints.CommandExtensions.ExecuteAsync[TResult](ICommand`1 command, CancellationToken ct)
```

It surfaced after upgrading to `8.2.0-beta.*` and is intermittent (depends on another test host being torn down during a test's lifetime).

## Root cause

Since #1017 (command/event bus extraction), bootstrap moved from `Cfg.ServiceResolver` to the process-global static `ServiceResolver.Instance`, and the command bus now resolves through that static. On every `MapFastEndpoints()` call:

- `ServiceResolver.Instance` is overwritten with the current host's resolver (capturing that host's **root** `IServiceProvider`), and
- `CommandExtensions.TestCommandHandlerMarker` is set unconditionally.

So `CommandExtensions.PrepareExecution` always runs `resolver.TryResolve(TestCommandHandlerMarker)`, and `ServiceResolver.TryResolve` falls back to the captured root `provider` when the request scope doesn't contain the type:

```csharp
public object? TryResolve(Type typeOfService)
    => ctxAccessor?.HttpContext?.RequestServices.GetService(typeOfService) ??
       provider.GetService(typeOfService);
```

With multiple hosts in one process, `Instance` points at whichever host bootstrapped last. Once that host is disposed, `Instance` still references it, and the marker type (not registered in the live request scope) makes `TryResolve` fall back to the **disposed** root provider → `ObjectDisposedException`.

## Fix

When a request scope is active, resolve solely from `HttpContext.RequestServices` instead of falling back to the captured root `provider`. The request scope is a child of the root, so it already resolves every registered service; the `?? provider` fallback only ever returned `null` for unregistered services anyway. The root is still used when there is no active request scope (background command/event execution, unit-test setup).

Applied to `TryResolve<T>()`, `TryResolve(Type)`, and `TryResolve<T>(string keyName)` — the variants whose fallback runs after `GetService` returns null. The required `Resolve(...)` overloads are unaffected: their `?.` chain only reaches `provider` when there is no `HttpContext`.

## Tests

Added `ServiceResolver` regression tests (generic / non-generic / keyed `TryResolve`) that resolve an unregistered service with an active request scope while the captured root provider is disposed — they throw `ObjectDisposedException` without the fix and pass with it. All existing `ServiceResolver` tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
