### PR TITLE
Fix concurrent WAF host builds by serializing the host creation in Ap…

### DIFF
--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -189,6 +189,12 @@ app.UseJobQueues(o => o.Warmup());
 
 ## Fixes 🪲
 
+<details><summary>'AppFixture' concurrent WebApplicationFactory host build issue</summary>
+
+`AppFixture` now builds the cached `WebApplicationFactory` host while the shared initializer is still serialized. This prevents parallel first-use test fixtures from each triggering their own lazy host build through `CreateClient()`, avoiding races during FastEndpoints startup configuration.
+
+</details>
+
 <details><summary>'ValidationSchemaProcessor' concurrency issue when generating multiple Swagger documents</summary>
 
 The `_childAdaptorValidators` instance field on the singleton `ValidationSchemaProcessor` was a plain non-thread-safe `Dictionary<string, IValidator>`. Concurrent Swagger document generation (e.g. multiple documents being built in parallel at startup) could cause race conditions on that shared dictionary. The field is now a local variable scoped to each `Process` call, eliminating shared mutable state entirely.

--- a/Src/Testing/AppFixture.Waf.cs
+++ b/Src/Testing/AppFixture.Waf.cs
@@ -195,10 +195,7 @@ public abstract partial class AppFixture<TProgram> : BaseFixture, IAsyncLifetime
                     ConfigureApp(b);
                 });
 
-            // Build the single host HERE, while still inside the AsyncLazy, so it is serialized across all fixture
-            // instances. Without this, each instance's `_wafInstance.CreateClient()` triggers the lazy host build, and
-            // those builds are not serialized across parallel first callers — N test classes build the host
-            // concurrently, racing on shared System.Text.Json config in MapFastEndpoints.
+            // build the single host inside the cached initializer to serialize parallel first callers.
             _ = waf.Services;
 
             return waf;

--- a/Src/Testing/AppFixture.Waf.cs
+++ b/Src/Testing/AppFixture.Waf.cs
@@ -199,7 +199,7 @@ public abstract partial class AppFixture<TProgram> : BaseFixture, IAsyncLifetime
             // instances. Without this, each instance's `_wafInstance.CreateClient()` triggers the lazy host build, and
             // those builds are not serialized across parallel first callers — N test classes build the host
             // concurrently, racing on shared System.Text.Json config in MapFastEndpoints.
-            _ = waf.Server;
+            _ = waf.Services;
 
             return waf;
         }

--- a/Src/Testing/AppFixture.Waf.cs
+++ b/Src/Testing/AppFixture.Waf.cs
@@ -187,13 +187,21 @@ public abstract partial class AppFixture<TProgram> : BaseFixture, IAsyncLifetime
         {
             await PreSetupAsync();
 
-            return new WafWrapper(ConfigureAppHost).WithWebHostBuilder(
+            var waf = new WafWrapper(ConfigureAppHost).WithWebHostBuilder(
                 b =>
                 {
                     b.UseEnvironment("Testing");
                     b.ConfigureTestServices(ConfigureServices);
                     ConfigureApp(b);
                 });
+
+            // Build the single host HERE, while still inside the AsyncLazy, so it is serialized across all fixture
+            // instances. Without this, each instance's `_wafInstance.CreateClient()` triggers the lazy host build, and
+            // those builds are not serialized across parallel first callers — N test classes build the host
+            // concurrently, racing on shared System.Text.Json config in MapFastEndpoints.
+            _ = waf.Server;
+
+            return waf;
         }
     }
 


### PR DESCRIPTION
Fixes #1120 

`AppFixture<TProgram>.InitializeAsync()` (in `AppFixture.Waf.cs`) does, for **every** fixture instance:

```csharp
_wafInstance = (WebApplicationFactory<TProgram>)await WafCache.GetOrAdd(tDerivedFixture), _ => new(WafInitializer));
Client = _wafInstance.CreateClient();   // <-- triggers the host BUILD, per instance
await SetupAsync();

async Task<object> WafInitializer()
{
    await PreSetupAsync();

    return new WafWrapper(ConfigureAppHost).WithWebHostBuilder(
        b =>
        {
            b.UseEnvironment("Testing");
            b.ConfigureTestServices(ConfigureServices);
            ConfigureApp(b);
        });
}
```

- `WafCache` + `AsyncLazy` correctly serialize creation of the **`WafWrapper` object** — that part is fine.
- But `WithWebHostBuilder(...)` does **not** build the host. The host is built lazily on first access.
- Every test class's fixture instance then calls `_wafInstance.CreateClient()` on the **same shared**
  `WafWrapper`. The deferred host build is **not serialized across these concurrent first callers**, so *N*
  parallel classes run `CreateHost` → `Program.Main` → `UseFastEndpoints` → `MapFastEndpoints` **at the same
  time**, racing on a shared `System.Text.Json` `ConfigurationList`.

So the cache prevents multiple `WafWrapper` objects, but not multiple concurrent host **builds**.

The fix:
```csharp
async Task<object> WafInitializer()
{
    await PreSetupAsync();

    var waf = new WafWrapper(ConfigureAppHost).WithWebHostBuilder(
        b =>
        {
            b.UseEnvironment("Testing");
            b.ConfigureTestServices(ConfigureServices);
            ConfigureApp(b);
        });

    // Build the single host HERE, while still inside the AsyncLazy, so it is serialized across all fixture
    // instances. Without this, each instance's `_wafInstance.CreateClient()` triggers the lazy host build, and
    // those builds are not serialized across parallel first callers — N test classes build the host
    // concurrently, racing on shared System.Text.Json config in MapFastEndpoints.
    _ = waf.Server;

    return waf;
}
```


