### PR TITLE
Add WriteOnlyWhenDifferent to SwaggerInitFile target

### DIFF
--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
 
-        <Version>8.2.0-beta.43</Version>
+        <Version>8.2.0-beta.45</Version>
 
         <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>

--- a/Src/OpenApi/FastEndpoints.OpenApi.targets
+++ b/Src/OpenApi/FastEndpoints.OpenApi.targets
@@ -22,7 +22,7 @@ internal static class OpenApiExportPathInitializer
 }
             </_OpenApiInitFileContent>
         </PropertyGroup>
-        <WriteLinesToFile File="$(_OpenApiInitFile)" Lines="$(_OpenApiInitFileContent)" Overwrite="true"/>
+        <WriteLinesToFile File="$(_OpenApiInitFile)" Lines="$(_OpenApiInitFileContent)" Overwrite="true" WriteOnlyWhenDifferent="true"/>
         <ItemGroup>
             <Compile Include="$(_OpenApiInitFile)"/>
         </ItemGroup>

--- a/Src/Swagger/FastEndpoints.Swagger.targets
+++ b/Src/Swagger/FastEndpoints.Swagger.targets
@@ -22,7 +22,7 @@ internal static class SwaggerExportPathInitializer
 }
             </_SwaggerInitFileContent>
         </PropertyGroup>
-        <WriteLinesToFile File="$(_SwaggerInitFile)" Lines="$(_SwaggerInitFileContent)" Overwrite="true"/>
+        <WriteLinesToFile File="$(_SwaggerInitFile)" Lines="$(_SwaggerInitFileContent)" Overwrite="true" WriteOnlyWhenDifferent="true"/>
         <ItemGroup>
             <Compile Include="$(_SwaggerInitFile)"/>
         </ItemGroup>


### PR DESCRIPTION
This PR contains a single change, it stops every build from updating the timestamp on the the SwaggerInitFile. The content of the file is not changing, it's hardcoded in the target, there is no point in always rewriting it. 
The timestamp update flagged the project that referenced the nuget as changed, causing unnecessary rebuilds on my solution. 

Sorry if something is missing, I've just found this minor inconvenience and wanted to upstream the fix, I've not found any contributing guidelines.