### PR TITLE
Added cached compiled property getter in (recursive) DTO validation

### DIFF
--- a/Src/Attributes/Contracts/ReflectionCache.cs
+++ b/Src/Attributes/Contracts/ReflectionCache.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Reflection;
 using Microsoft.Extensions.Primitives;
 
@@ -42,6 +42,11 @@ public sealed class TypeDefinition
 /// </summary>
 public sealed class PropertyDefinition
 {
+    /// <summary>
+    /// func used for getting the value of a property from a class
+    /// </summary>
+    public Func<object, object?>? Getter { get; set; }
+
     /// <summary>
     /// action used for setting the value of a property on a class
     /// </summary>

--- a/Src/Core/ServiceResolver/ServiceResolver.cs
+++ b/Src/Core/ServiceResolver/ServiceResolver.cs
@@ -36,19 +36,21 @@ sealed class ServiceResolver(IServiceProvider provider, IHttpContextAccessor? ct
 
     public object CreateInstance(Type type, IServiceProvider? serviceProvider = null)
     {
-        var factory = _factoryCache.GetOrAdd(type, FactoryInitializer);
-
-        //WARNING: DO NOT DO THIS!!! it results in a perf degradation. no idea why.
-        // var factory = _factoryCache.GetOrAdd(type, ActivatorUtilities.CreateFactory(type, Type.EmptyTypes));
+        var factory = _factoryCache.GetOrAdd(type, ValueFactory);
 
         return factory(serviceProvider ?? ctxAccessor?.HttpContext?.RequestServices ?? provider, null);
 
-        static ObjectFactory FactoryInitializer(Type t)
+        static ObjectFactory ValueFactory(Type t)
             => ActivatorUtilities.CreateFactory(t, Type.EmptyTypes);
     }
 
     public object CreateSingleton(Type type)
-        => _singletonCache.GetOrAdd(type, ActivatorUtilities.GetServiceOrCreateInstance(ctxAccessor?.HttpContext?.RequestServices ?? provider, type));
+    {
+        return _singletonCache.GetOrAdd(type, ValueFactory, (ctxAccessor, provider));
+
+        static object ValueFactory(Type t, (IHttpContextAccessor? ctxAccessor, IServiceProvider provider) args)
+            => ActivatorUtilities.GetServiceOrCreateInstance(args.ctxAccessor?.HttpContext?.RequestServices ?? args.provider, t);
+    }
 
     public IServiceScope CreateScope()
         => isUnitTestMode

--- a/Src/Generator/ReflectionGenerator.cs
+++ b/Src/Generator/ReflectionGenerator.cs
@@ -145,6 +145,8 @@ public class ReflectionGenerator : IIncrementalGenerator
 
                 foreach (var prop in tInfo.Properties)
                 {
+                    var getter = $"Getter = dto => {BuildPropCast(tInfo)}.{prop.PropName}";
+
                     b.w(
                         $"""
 
@@ -152,8 +154,8 @@ public class ReflectionGenerator : IIncrementalGenerator
                          """);
                     b.w(
                         prop.IsInitOnly
-                            ? $" new(){BuildInitServiceKey(prop)}"
-                            : $" new() {{ Setter = (dto, val) => {BuildPropCast(tInfo)}.{prop.PropName} = ({prop.PropertyType})val!{BuildServiceKey(prop)} }}");
+                            ? $" new() {{ {getter}{BuildServiceKey(prop)} }}"
+                            : $" new() {{ {getter}, Setter = (dto, val) => {BuildPropCast(tInfo)}.{prop.PropName} = ({prop.PropertyType})val!{BuildServiceKey(prop)} }}");
                     b.w("),");
                 }
 
@@ -212,9 +214,6 @@ public class ReflectionGenerator : IIncrementalGenerator
 
         static string BuildServiceKey(TypeInfo.Prop p)
             => p.ServiceKey is null ? string.Empty : $", ServiceKey = {SymbolDisplay.FormatLiteral(p.ServiceKey, quote: true)}";
-
-        static string BuildInitServiceKey(TypeInfo.Prop p)
-            => p.ServiceKey is null ? string.Empty : $" {{ ServiceKey = {SymbolDisplay.FormatLiteral(p.ServiceKey, quote: true)} }}";
 
         static string BuildTryParseArgs(bool? isIParsable)
             => isIParsable is true

--- a/Src/Library/Binder/BinderExtensions.cs
+++ b/Src/Library/Binder/BinderExtensions.cs
@@ -61,6 +61,27 @@ static class BinderExtensions
             }
         }
 
+        internal Func<object, object?> GetterForProp(PropertyInfo prop)
+        {
+            if (!Cfg.BndOpts.ReflectionCache.TryGetValue(type, out var classDef))
+                throw new InvalidOperationException($"Reflection data not found for: [{type.FullName}]");
+
+            if (classDef.Properties is null)
+                throw new InvalidOperationException($"Reflection data not found for properties of: [{type.FullName}]");
+
+            return classDef.Properties.GetOrAdd(prop, static _ => new PropertyDefinition())
+                           .Getter ??= CompileGetter(type, prop);
+
+            static Func<object, object?> CompileGetter(Type tParent, PropertyInfo p)
+            {
+                //(object parent) => (object?)((TParent)parent).property;
+                var parent = Expression.Parameter(Types.Object);
+                var body = Expression.Convert(Expression.Property(Expression.Convert(parent, tParent), p.Name), Types.Object);
+
+                return Expression.Lambda<Func<object, object?>>(body, parent).Compile();
+            }
+        }
+
         internal Action<object, object?> SetterForProp(PropertyInfo prop)
         {
             if (!Cfg.BndOpts.ReflectionCache.TryGetValue(type, out var classDef))
@@ -69,7 +90,7 @@ static class BinderExtensions
             if (classDef.Properties is null)
                 throw new InvalidOperationException($"Reflection data not found for properties of: [{type.FullName}]");
 
-            return classDef.Properties.GetOrAdd(prop, new PropertyDefinition())
+            return classDef.Properties.GetOrAdd(prop, static _ => new PropertyDefinition())
                            .Setter ??= CompileSetter(type, prop);
 
             static Action<object, object?> CompileSetter(Type tParent, PropertyInfo p)

--- a/Src/Library/Binder/BinderExtensions.cs
+++ b/Src/Library/Binder/BinderExtensions.cs
@@ -33,7 +33,7 @@ static class BinderExtensions
             if (type == Types.EmptyRequest)
                 return _emptyRequestInitializer;
 
-            return Cfg.BndOpts.ReflectionCache.GetOrAdd(type, new TypeDefinition())
+            return Cfg.BndOpts.ReflectionCache.GetOrAdd(type, static _ => new())
                       .ObjectFactory ??= CompileFactory(type);
 
             static Func<object> CompileFactory(Type t)
@@ -69,7 +69,7 @@ static class BinderExtensions
             if (classDef.Properties is null)
                 throw new InvalidOperationException($"Reflection data not found for properties of: [{type.FullName}]");
 
-            return classDef.Properties.GetOrAdd(prop, static _ => new PropertyDefinition())
+            return classDef.Properties.GetOrAdd(prop, static _ => new())
                            .Getter ??= CompileGetter(type, prop);
 
             static Func<object, object?> CompileGetter(Type tParent, PropertyInfo p)
@@ -90,7 +90,7 @@ static class BinderExtensions
             if (classDef.Properties is null)
                 throw new InvalidOperationException($"Reflection data not found for properties of: [{type.FullName}]");
 
-            return classDef.Properties.GetOrAdd(prop, static _ => new PropertyDefinition())
+            return classDef.Properties.GetOrAdd(prop, static _ => new())
                            .Setter ??= CompileSetter(type, prop);
 
             static Action<object, object?> CompileSetter(Type tParent, PropertyInfo p)
@@ -110,7 +110,7 @@ static class BinderExtensions
             //user may have already registered a parser func for a given type via config at startup.
             //or reflection source generator may have already populated the cache.
             //if it's not there, compile the func at runtime.
-            return Cfg.BndOpts.ReflectionCache.GetOrAdd(type.GetUnderlyingType(), new TypeDefinition()).ValueParser
+            return Cfg.BndOpts.ReflectionCache.GetOrAdd(type.GetUnderlyingType(), static _ => new()).ValueParser
                        ??= GetOrCompileParser(type);
 
             static Func<StringValues, ParseResult> GetOrCompileParser(Type type)
@@ -188,7 +188,7 @@ static class BinderExtensions
 
         internal ICollection<PropertyInfo> BindableProps()
         {
-            return (Cfg.BndOpts.ReflectionCache.GetOrAdd(type, new TypeDefinition())
+            return (Cfg.BndOpts.ReflectionCache.GetOrAdd(type, static _ => new())
                        .Properties ??= new(GetProperties(type))).Keys;
 
             static IEnumerable<KeyValuePair<PropertyInfo, PropertyDefinition>> GetProperties(Type t)

--- a/Src/Library/Binder/RequestBinder.cs
+++ b/Src/Library/Binder/RequestBinder.cs
@@ -64,7 +64,7 @@ public class RequestBinder<TRequest> : IRequestBinder<TRequest> where TRequest :
                 if (!matcher(prop))
                     continue;
 
-                Cfg.BndOpts.ReflectionCache.GetOrAdd(prop.PropertyType, new TypeDefinition()).ValueParser =
+                Cfg.BndOpts.ReflectionCache.GetOrAdd(prop.PropertyType, static _ => new TypeDefinition()).ValueParser =
                     input => parser(input, prop.PropertyType);
 
                 break;

--- a/Src/Library/Config/BindingOptions.cs
+++ b/Src/Library/Config/BindingOptions.cs
@@ -139,7 +139,7 @@ public sealed class BindingOptions
     ///  </code>
     /// </param>
     public void ValueParserFor<T>(Func<StringValues, ParseResult> parser)
-        => Cfg.BndOpts.ReflectionCache.GetOrAdd(typeof(T).GetUnderlyingType(), new TypeDefinition()).ValueParser = parser;
+        => Cfg.BndOpts.ReflectionCache.GetOrAdd(typeof(T).GetUnderlyingType(), static _ => new TypeDefinition()).ValueParser = parser;
 
     /// <summary>
     /// add a custom value parser function for any given type which the default model binder will use to parse values when model binding request dto
@@ -171,7 +171,7 @@ public sealed class BindingOptions
     ///  </code>
     /// </param>
     public void ValueParserFor(Type type, Func<StringValues, ParseResult> parser)
-        => Cfg.BndOpts.ReflectionCache.GetOrAdd(type.GetUnderlyingType(), new TypeDefinition()).ValueParser = parser;
+        => Cfg.BndOpts.ReflectionCache.GetOrAdd(type.GetUnderlyingType(), static _ => new TypeDefinition()).ValueParser = parser;
 
     /// <summary>
     /// override value parsers for request dto properties that match a predicate.

--- a/Src/Library/Endpoint/Endpoint.Validation.cs
+++ b/Src/Library/Endpoint/Endpoint.Validation.cs
@@ -56,7 +56,7 @@ public abstract partial class Endpoint<TRequest, TResponse> : IValidationErrors<
 
                 foreach (var property in tObject.BindableProps())
                 {
-                    var propertyValue = property.GetValue(obj); // todo: use a cached compiled expression
+                    var propertyValue = tObject.GetterForProp(property)(obj);
 
                     if (propertyValue is null)
                         continue;

--- a/Src/Library/Extensions/ReflectionExtensions.cs
+++ b/Src/Library/Extensions/ReflectionExtensions.cs
@@ -91,7 +91,7 @@ static class ReflectionExtensions
 
         internal bool IsValidatable()
         {
-            var typeDef = Cfg.BndOpts.ReflectionCache.GetOrAdd(source, new TypeDefinition());
+            var typeDef = Cfg.BndOpts.ReflectionCache.GetOrAdd(source, static _ => new TypeDefinition());
 
             if (typeDef.IsValidatable is null) // was never initialized
             {

--- a/Src/Library/Main/MainExtensions.cs
+++ b/Src/Library/Main/MainExtensions.cs
@@ -371,11 +371,18 @@ public static class MainExtensions
         if (!def.ReqDtoType.IsValueType) // native aot cannot instantiate value type generic binders
             _ = sp.GetService(Types.IRequestBinderOf1.MakeGenericType(def.ReqDtoType));
 
+        if (def.ReqDtoType.IsValidatable())
+        {
+            // NOTE: this only pre-compiles getters for the top-level request DTO
+            // nested child objects encountered during recursive validation still get their getters compiled lazily on first use.
+            foreach (var prop in def.ReqDtoType.BindableProps())
+                _ = def.ReqDtoType.GetterForProp(prop);
+        }
+
         _ = def.ExecuteAsyncReturnsIResult;
         _ = def.GetMapper();
         _ = def.GetValidator();
         _ = def.ReqDtoFromBodyPropName;
-        _ = def.ReqDtoType.IsValidatable();
         _ = def.ReqDtoType.ObjectFactory();
         _ = def.ToHeaderProps;
     }

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -160,7 +160,7 @@ The generator records the keyed-service key for endpoint property injection, all
 
 <details><summary>Opt-in startup warmup for endpoints, validators, mappers, and event buses</summary>
 
-Call `Warmup()` from `UseFastEndpoints(...)` to eagerly initialize validators, mappers, request binders, and compiled property setter delegates so the first real requests do not pay the cold-start cost.
+Call `Warmup()` from `UseFastEndpoints(...)` to eagerly initialize validators, mappers, request binders, and compiled property setter/getter delegates so the first real requests do not pay the cold-start cost.
 
 Warmup can be scoped to a subset of endpoints with the optional filter argument:
 

--- a/Src/Messaging/Messaging.Remote.Core/Client/Events/Storage/InMemoryEventSubscriberStorage.cs
+++ b/Src/Messaging/Messaging.Remote.Core/Client/Events/Storage/InMemoryEventSubscriberStorage.cs
@@ -11,7 +11,7 @@ sealed class InMemoryEventSubscriberStorage : IEventSubscriberStorageProvider<In
 
     public ValueTask StoreEventAsync(InMemoryEventStorageRecord e, CancellationToken _)
     {
-        var q = _subscribers.GetOrAdd(GetQueueKey(e.SubscriberID, e.EventType), QueueInitializer());
+        var q = _subscribers.GetOrAdd(GetQueueKey(e.SubscriberID, e.EventType), QueueInitializer);
 
         if (q.Count >= InMemoryEventQueue.MaxLimit)
             throw new OverflowException("In-memory event receive queue limit reached!");
@@ -23,7 +23,7 @@ sealed class InMemoryEventSubscriberStorage : IEventSubscriberStorageProvider<In
 
     public ValueTask<IEnumerable<InMemoryEventStorageRecord>> GetNextBatchAsync(PendingRecordSearchParams<InMemoryEventStorageRecord> p)
     {
-        var q = _subscribers.GetOrAdd(GetQueueKey(p.SubscriberID, p.EventType), QueueInitializer());
+        var q = _subscribers.GetOrAdd(GetQueueKey(p.SubscriberID, p.EventType), QueueInitializer);
         q.TryDequeue(out var e);
 
         return new(e is null ? [] : [e]);
@@ -35,7 +35,7 @@ sealed class InMemoryEventSubscriberStorage : IEventSubscriberStorageProvider<In
     public ValueTask PurgeStaleRecordsAsync(StaleRecordSearchParams<InMemoryEventStorageRecord> parameters)
         => throw new NotImplementedException();
 
-    static ConcurrentQueue<InMemoryEventStorageRecord> QueueInitializer()
+    static ConcurrentQueue<InMemoryEventStorageRecord> QueueInitializer(string _)
         => new();
 
     static string GetQueueKey(string subscriberId, string eventType)

--- a/Src/Messaging/Messaging.Remote/Server/Events/Storage/InMemoryEventHubStorage.cs
+++ b/Src/Messaging/Messaging.Remote/Server/Events/Storage/InMemoryEventHubStorage.cs
@@ -18,7 +18,7 @@ public sealed class InMemoryEventHubStorage : IEventHubStorageProvider<InMemoryE
 
         foreach (var r in records)
         {
-            var q = _subscribers.GetOrAdd(GetQueueKey(r.SubscriberID, r.EventType), new InMemEventQueue());
+            var q = _subscribers.GetOrAdd(GetQueueKey(r.SubscriberID, r.EventType), static _ => new InMemEventQueue());
 
             if (!q.IsStale)
                 q.Records.Enqueue(r);
@@ -34,7 +34,7 @@ public sealed class InMemoryEventHubStorage : IEventHubStorageProvider<InMemoryE
 
     public ValueTask<IEnumerable<InMemoryEventStorageRecord>> GetNextBatchAsync(PendingRecordSearchParams<InMemoryEventStorageRecord> p)
     {
-        var q = _subscribers.GetOrAdd(GetQueueKey(p.SubscriberID, p.EventType), new InMemEventQueue());
+        var q = _subscribers.GetOrAdd(GetQueueKey(p.SubscriberID, p.EventType), static _ => new InMemEventQueue());
 
         q.Records.TryDequeue(out var e);
         q.LastDequeAt = DateTime.UtcNow;

--- a/Tests/UnitTests/FastEndpoints/ReflectionGeneratorTests.cs
+++ b/Tests/UnitTests/FastEndpoints/ReflectionGeneratorTests.cs
@@ -10,6 +10,74 @@ namespace Generator;
 public class ReflectionGeneratorTests
 {
     [Fact]
+    public void request_dto_property_emits_getter_delegate()
+    {
+        const string source =
+            """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using FastEndpoints;
+
+            namespace TestApp;
+
+            public class MyRequest
+            {
+                public string Name { get; set; } = string.Empty;
+            }
+
+            public class MyEndpoint : Endpoint<MyRequest, string>
+            {
+                public override void Configure() { }
+
+                public override Task HandleAsync(MyRequest req, CancellationToken ct) => Task.CompletedTask;
+            }
+            """;
+
+        var generated = RunGenerator(source, out var diagnostics, out var outputCompilation);
+
+        diagnostics.ShouldBeEmpty();
+        outputCompilation.GetDiagnostics()
+                         .Where(d => d.Severity == DiagnosticSeverity.Error)
+                         .ShouldBeEmpty();
+        generated.ShouldContain("Getter = dto => ((t0)dto).Name");
+        generated.ShouldContain("Setter = (dto, val) => ((t0)dto).Name = (string)val!");
+    }
+
+    [Fact]
+    public void init_only_request_dto_property_emits_getter_without_setter()
+    {
+        const string source =
+            """
+            using System.Threading;
+            using System.Threading.Tasks;
+            using FastEndpoints;
+
+            namespace TestApp;
+
+            public class MyRequest
+            {
+                public string Name { get; init; } = string.Empty;
+            }
+
+            public class MyEndpoint : Endpoint<MyRequest, string>
+            {
+                public override void Configure() { }
+
+                public override Task HandleAsync(MyRequest req, CancellationToken ct) => Task.CompletedTask;
+            }
+            """;
+
+        var generated = RunGenerator(source, out var diagnostics, out var outputCompilation);
+
+        diagnostics.ShouldBeEmpty();
+        outputCompilation.GetDiagnostics()
+                         .Where(d => d.Severity == DiagnosticSeverity.Error)
+                         .ShouldBeEmpty();
+        generated.ShouldContain("Getter = dto => ((t0)dto).Name");
+        generated.ShouldNotContain("Setter =");
+    }
+
+    [Fact]
     public void endpoint_without_request_keyed_service_property_is_emitted()
     {
         const string source =


### PR DESCRIPTION
## Summary

- Adds a compiled expression-based `GetterForProp` to the reflection cache, mirroring the existing `SetterForProp` pattern
- Replaces the slow `PropertyInfo.GetValue` call in (recursive) DTO validation with the cached compiled getter
- Pre-compiles getters for top-level request DTO properties during endpoint warmup to avoid first-request JIT overhead

## Notes

Nested child objects encountered during recursive validation still get their getters compiled lazily on first use.
Pre-compiling them at warmup would require a recursive property-type traversal, which may not be worth the added complexity.