### PR TITLE
Fixed HEAD endpoints emitting request DTO as requestBody instead of query parameters

### DIFF
--- a/Src/OpenApi/Operations/OperationTransformer.Requests.cs
+++ b/Src/OpenApi/Operations/OperationTransformer.Requests.cs
@@ -52,7 +52,7 @@ sealed partial class RequestOperationTransformer(DocumentOptions docOpts, Shared
 
         if (requestDtoType != Types.EmptyRequest)
         {
-            var isGetRequest = context.Description.HttpMethod == "GET";
+            var isBodylessRequest = context.Description.HttpMethod is "GET" or "HEAD";
             var requestDtoIsList = requestDtoType.IsCollection();
             var requestDtoProps = requestDtoIsList
                                       ? null
@@ -63,11 +63,11 @@ sealed partial class RequestOperationTransformer(DocumentOptions docOpts, Shared
             if (requestDtoProps is not null)
             {
                 RemoveHiddenProperties(operation, requestDtoProps, state, operationKey);
-                AddBoundParameters(operation, requestDtoProps, routeParameterLookup, isGetRequest, state, operationKey);
+                AddBoundParameters(operation, requestDtoProps, routeParameterLookup, isBodylessRequest, state, operationKey);
             }
 
-            // remove request body if GET request (unless explicitly enabled) or if empty
-            if ((isGetRequest && !docOpts.EnableGetRequestsWithBody) || operation.IsRequestBodyEmpty(sharedCtx))
+            // remove request body if bodyless method (GET or HEAD request, unless explicitly enabled) or if empty
+            if ((isBodylessRequest && !docOpts.EnableGetRequestsWithBody) || operation.IsRequestBodyEmpty(sharedCtx))
             {
                 if (!requestDtoIsList)
                     operation.RequestBody = null;
@@ -286,7 +286,7 @@ sealed partial class RequestOperationTransformer(DocumentOptions docOpts, Shared
     void AddBoundParameters(OpenApiOperation operation,
                             List<PropertyInfo> requestDtoProps,
                             Dictionary<string, RouteParameterInfo> routeParameters,
-                            bool isGetRequest,
+                            bool isBodylessRequest,
                             RequestTransformState state,
                             string operationKey)
     {
@@ -300,7 +300,7 @@ sealed partial class RequestOperationTransformer(DocumentOptions docOpts, Shared
 
             var queryParamName = _parameterNameResolver.GetQueryName(p);
 
-            if (ShouldAddQueryParam(p, metadata, operation, queryParamName, isGetRequest && !docOpts.EnableGetRequestsWithBody))
+            if (ShouldAddQueryParam(p, metadata, operation, queryParamName, isBodylessRequest && !docOpts.EnableGetRequestsWithBody))
             {
                 operation.RemovePropFromRequestBody(p, sharedCtx, operationKey, docOpts, NamingPolicy, state.PropsRemovedFromBody);
 
@@ -390,7 +390,7 @@ sealed partial class RequestOperationTransformer(DocumentOptions docOpts, Shared
                                     PropertyMetadata metadata,
                                     OpenApiOperation operation,
                                     string queryParamName,
-                                    bool isGetRequest)
+                                    bool isBodylessRequest)
     {
         if (metadata.FromHeader is not null || metadata.FromCookie is not null)
             return false;
@@ -407,6 +407,6 @@ sealed partial class RequestOperationTransformer(DocumentOptions docOpts, Shared
         if (operation.Parameters?.Any(p => string.Equals(p.Name, queryParamName, StringComparison.OrdinalIgnoreCase)) == true)
             return false;
 
-        return isGetRequest || prop.IsDefined(Types.QueryParamAttribute);
+        return isBodylessRequest || prop.IsDefined(Types.QueryParamAttribute);
     }
 }

--- a/Src/OpenApi/Operations/OperationTransformer.Requests.cs
+++ b/Src/OpenApi/Operations/OperationTransformer.Requests.cs
@@ -53,6 +53,8 @@ sealed partial class RequestOperationTransformer(DocumentOptions docOpts, Shared
         if (requestDtoType != Types.EmptyRequest)
         {
             var isBodylessRequest = context.Description.HttpMethod is "GET" or "HEAD";
+            var useQueryParamsForBodylessRequest = context.Description.HttpMethod is "HEAD" ||
+                                                   (context.Description.HttpMethod is "GET" && !docOpts.EnableGetRequestsWithBody);
             var requestDtoIsList = requestDtoType.IsCollection();
             var requestDtoProps = requestDtoIsList
                                       ? null
@@ -63,11 +65,11 @@ sealed partial class RequestOperationTransformer(DocumentOptions docOpts, Shared
             if (requestDtoProps is not null)
             {
                 RemoveHiddenProperties(operation, requestDtoProps, state, operationKey);
-                AddBoundParameters(operation, requestDtoProps, routeParameterLookup, isBodylessRequest, state, operationKey);
+                AddBoundParameters(operation, requestDtoProps, routeParameterLookup, useQueryParamsForBodylessRequest, state, operationKey);
             }
 
-            // remove request body if bodyless method (GET or HEAD request, unless explicitly enabled) or if empty
-            if ((isBodylessRequest && !docOpts.EnableGetRequestsWithBody) || operation.IsRequestBodyEmpty(sharedCtx))
+            // remove request body if GET (unless explicitly enabled), HEAD, or empty
+            if (useQueryParamsForBodylessRequest || operation.IsRequestBodyEmpty(sharedCtx))
             {
                 if (!requestDtoIsList)
                     operation.RequestBody = null;
@@ -286,7 +288,7 @@ sealed partial class RequestOperationTransformer(DocumentOptions docOpts, Shared
     void AddBoundParameters(OpenApiOperation operation,
                             List<PropertyInfo> requestDtoProps,
                             Dictionary<string, RouteParameterInfo> routeParameters,
-                            bool isBodylessRequest,
+                            bool useQueryParamsForBodylessRequest,
                             RequestTransformState state,
                             string operationKey)
     {
@@ -300,7 +302,7 @@ sealed partial class RequestOperationTransformer(DocumentOptions docOpts, Shared
 
             var queryParamName = _parameterNameResolver.GetQueryName(p);
 
-            if (ShouldAddQueryParam(p, metadata, operation, queryParamName, isBodylessRequest && !docOpts.EnableGetRequestsWithBody))
+            if (ShouldAddQueryParam(p, metadata, operation, queryParamName, useQueryParamsForBodylessRequest))
             {
                 operation.RemovePropFromRequestBody(p, sharedCtx, operationKey, docOpts, NamingPolicy, state.PropsRemovedFromBody);
 

--- a/Src/Swagger/OperationProcessor.cs
+++ b/Src/Swagger/OperationProcessor.cs
@@ -157,6 +157,8 @@ sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationPro
         state.RequestDtoType = state.ApiDescription.ParameterDescriptions.FirstOrDefault()?.Type;
         state.RequestDtoIsList = state.RequestDtoType?.GetInterfaces().Contains(Types.IEnumerable) is true;
         state.IsBodylessRequest = state.ApiDescription.HttpMethod is "GET" or "HEAD";
+        state.UseQueryParamsForBodylessRequest = state.ApiDescription.HttpMethod is "HEAD" ||
+                                                 (state.ApiDescription.HttpMethod is "GET" && !docOpts.EnableGetRequestsWithBody);
         state.RequestDtoProps =
             state.RequestDtoIsList
                 ? null
@@ -266,8 +268,8 @@ sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationPro
                                    p => ShouldAddQueryParam(
                                        p,
                                        requestParams,
-                                       state.IsBodylessRequest && !docOpts.EnableGetRequestsWithBody,
-                                       docOpts)) //user wants body in GET or HEAD requests
+                                       state.UseQueryParamsForBodylessRequest,
+                                       docOpts))
                                .Select(
                                    p =>
                                    {
@@ -396,9 +398,9 @@ sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationPro
     void FinalizeRequestBody(ProcessingState state)
     {
         //only applies when the request dto is not a list.
-        //remove request body for GET or HEAD methods unless explicitly enabled, or when no properties remain.
+        //remove request body for GET (unless explicitly enabled), HEAD, or when no properties remain.
         if (!state.RequestDtoIsList &&
-            ((state.IsBodylessRequest && !docOpts.EnableGetRequestsWithBody) || state.RequestContent?.HasNoProperties() is true))
+            (state.UseQueryParamsForBodylessRequest || state.RequestContent?.HasNoProperties() is true))
         {
             state.Operation.RequestBody = null;
 
@@ -1044,6 +1046,7 @@ sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationPro
         public Type? RequestDtoType { get; set; }
         public bool RequestDtoIsList { get; set; }
         public bool IsBodylessRequest { get; set; }
+        public bool UseQueryParamsForBodylessRequest { get; set; }
         public List<PropertyInfo>? RequestDtoProps { get; set; }
         public Dictionary<string, ParamDescription> RequestParamDescriptions { get; set; } = new(StringComparer.OrdinalIgnoreCase);
         public ParamCreationContext ParamCtx { get; set; }

--- a/Src/Swagger/OperationProcessor.cs
+++ b/Src/Swagger/OperationProcessor.cs
@@ -156,7 +156,7 @@ sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationPro
 
         state.RequestDtoType = state.ApiDescription.ParameterDescriptions.FirstOrDefault()?.Type;
         state.RequestDtoIsList = state.RequestDtoType?.GetInterfaces().Contains(Types.IEnumerable) is true;
-        state.IsGetRequest = state.ApiDescription.HttpMethod == "GET";
+        state.IsBodylessRequest = state.ApiDescription.HttpMethod is "GET" or "HEAD";
         state.RequestDtoProps =
             state.RequestDtoIsList
                 ? null
@@ -266,8 +266,8 @@ sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationPro
                                    p => ShouldAddQueryParam(
                                        p,
                                        requestParams,
-                                       state.IsGetRequest && !docOpts.EnableGetRequestsWithBody,
-                                       docOpts)) //user wants body in GET requests
+                                       state.IsBodylessRequest && !docOpts.EnableGetRequestsWithBody,
+                                       docOpts)) //user wants body in GET or HEAD requests
                                .Select(
                                    p =>
                                    {
@@ -395,21 +395,17 @@ sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationPro
 
     void FinalizeRequestBody(ProcessingState state)
     {
-        //remove request body if this is a GET request (swagger ui/fetch client doesn't support GET with body).
-        //note: user can decide to allow GET requests with body via EnableGetRequestsWithBody setting.
-        //or if there are no properties left on the request dto after above operations.
-        //only if the request dto is not a list.
-        if ((state.IsGetRequest && !docOpts.EnableGetRequestsWithBody) || state.RequestContent?.HasNoProperties() is true)
+        //only applies when the request dto is not a list.
+        //remove request body for GET or HEAD methods unless explicitly enabled, or when no properties remain.
+        if (!state.RequestDtoIsList &&
+            ((state.IsBodylessRequest && !docOpts.EnableGetRequestsWithBody) || state.RequestContent?.HasNoProperties() is true))
         {
-            if (!state.RequestDtoIsList)
-            {
-                state.Operation.RequestBody = null;
+            state.Operation.RequestBody = null;
 
-                for (var i = state.Operation.Parameters.Count - 1; i >= 0; i--)
-                {
-                    if (state.Operation.Parameters[i].Kind == OpenApiParameterKind.Body)
-                        state.Operation.Parameters.RemoveAt(i);
-                }
+            for (var i = state.Operation.Parameters.Count - 1; i >= 0; i--)
+            {
+                if (state.Operation.Parameters[i].Kind == OpenApiParameterKind.Body)
+                    state.Operation.Parameters.RemoveAt(i);
             }
         }
 
@@ -443,7 +439,7 @@ sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationPro
                    : null;
     }
 
-    static bool ShouldAddQueryParam(PropertyInfo prop, List<OpenApiParameter> reqParams, bool isGetRequest, DocumentOptions docOpts)
+    static bool ShouldAddQueryParam(PropertyInfo prop, List<OpenApiParameter> reqParams, bool isBodylessRequest, DocumentOptions docOpts)
     {
         var paramName = prop.Name.ApplyPropNamingPolicy(docOpts);
 
@@ -466,8 +462,8 @@ sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationPro
 
         return
 
-            //it's a GET request and request params already has it. so don't add
-            (isGetRequest && !reqParams.Any(rp => rp.Name.Equals(paramName, StringComparison.OrdinalIgnoreCase))) ||
+            //it's a GET or HEAD request and request params already has it. so don't add
+            (isBodylessRequest && !reqParams.Any(rp => rp.Name.Equals(paramName, StringComparison.OrdinalIgnoreCase))) ||
 
             //this prop is marked with [QueryParam], so add. applies to all verbs.
             prop.IsDefined(Types.QueryParamAttribute);
@@ -1047,7 +1043,7 @@ sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationPro
 
         public Type? RequestDtoType { get; set; }
         public bool RequestDtoIsList { get; set; }
-        public bool IsGetRequest { get; set; }
+        public bool IsBodylessRequest { get; set; }
         public List<PropertyInfo>? RequestDtoProps { get; set; }
         public Dictionary<string, ParamDescription> RequestParamDescriptions { get; set; } = new(StringComparer.OrdinalIgnoreCase);
         public ParamCreationContext ParamCtx { get; set; }

--- a/TestHarness/Web/[Features]/TestCases/Swagger/Review/Endpoints.cs
+++ b/TestHarness/Web/[Features]/TestCases/Swagger/Review/Endpoints.cs
@@ -1239,3 +1239,35 @@ sealed class DualChildAddressEndpoint : Endpoint<DualChildAddressRequest>
     public override Task HandleAsync(DualChildAddressRequest r, CancellationToken ct)
         => Send.OkAsync(ct);
 }
+
+sealed class BodylessReviewRequest
+{
+    public string? Name { get; set; }
+    public int? Page { get; set; }
+}
+
+sealed class GetBodylessReviewEndpoint : Endpoint<BodylessReviewRequest>
+{
+    public override void Configure()
+    {
+        Get("/swagger-review/bodyless-query-params");
+        Tags("swagger_review");
+        AllowAnonymous();
+    }
+
+    public override Task HandleAsync(BodylessReviewRequest r, CancellationToken ct)
+        => Send.OkAsync(ct);
+}
+
+sealed class HeadBodylessReviewEndpoint : Endpoint<BodylessReviewRequest>
+{
+    public override void Configure()
+    {
+        Head("/swagger-review/bodyless-query-params");
+        Tags("swagger_review");
+        AllowAnonymous();
+    }
+
+    public override Task HandleAsync(BodylessReviewRequest r, CancellationToken ct)
+        => Send.OkAsync(ct);
+}

--- a/Tests/IntegrationTests/FastEndpoints.OpenApi/OperationTransformerEdgeCaseTests.cs
+++ b/Tests/IntegrationTests/FastEndpoints.OpenApi/OperationTransformerEdgeCaseTests.cs
@@ -832,4 +832,32 @@ public class OperationTransformerEdgeCaseTests(Fixture App) : TestBase<Fixture>
 
         return suffixIndex < 0 ? refId : refId[..suffixIndex];
     }
+
+    [Fact]
+    public async Task get_request_has_no_request_body_and_uses_query_parameters()
+    {
+        var json = await App.GetDocumentJsonAsync("Swagger Review");
+        var op = JToken.Parse(json)["paths"]!["/api/swagger-review/bodyless-query-params"]!["get"]!;
+
+        op.ShouldNotBeNull();
+        op["requestBody"].ShouldBeNull();
+
+        var parameters = op["parameters"]!.ToArray();
+        parameters.ShouldContain(p => p["name"]!.Value<string>() == "name" && p["in"]!.Value<string>() == "query");
+        parameters.ShouldContain(p => p["name"]!.Value<string>() == "page" && p["in"]!.Value<string>() == "query");
+    }
+
+    [Fact]
+    public async Task head_request_has_no_request_body_and_uses_query_parameters()
+    {
+        var json = await App.GetDocumentJsonAsync("Swagger Review");
+        var op = JToken.Parse(json)["paths"]!["/api/swagger-review/bodyless-query-params"]!["head"]!;
+
+        op.ShouldNotBeNull();
+        op["requestBody"].ShouldBeNull();
+
+        var parameters = op["parameters"]!.ToArray();
+        parameters.ShouldContain(p => p["name"]!.Value<string>() == "name" && p["in"]!.Value<string>() == "query");
+        parameters.ShouldContain(p => p["name"]!.Value<string>() == "page" && p["in"]!.Value<string>() == "query");
+    }
 }

--- a/Tests/IntegrationTests/FastEndpoints.OpenApi/release-0.json
+++ b/Tests/IntegrationTests/FastEndpoints.OpenApi/release-0.json
@@ -7580,7 +7580,7 @@
             }
           }
         },
-        "description": "RFC9457 compatible problem details/ error response class. this can be used by configuring startup like so:\r\n```app.UseFastEndpoints(c =&gt; c.Errors.UseProblemDetails())```"
+        "description": "RFC9457 compatible problem details/ error response class. this can be used by configuring startup like so:\n```app.UseFastEndpoints(c =&gt; c.Errors.UseProblemDetails())```"
       },
       "FastEndpointsSecurityTokenRequest": {
         "type": "object",

--- a/Tests/IntegrationTests/FastEndpoints.OpenApi/release-0.json
+++ b/Tests/IntegrationTests/FastEndpoints.OpenApi/release-0.json
@@ -1694,6 +1694,76 @@
         }
       }
     },
+    "/api/swagger-review/bodyless-query-params": {
+      "get": {
+        "tags": [
+          "SwaggerReview"
+        ],
+        "operationId": "swagger_review_TestCasesSwaggerReviewGetBodylessReviewEndpoint",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": [
+                "null",
+                "integer"
+              ],
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      },
+      "head": {
+        "tags": [
+          "SwaggerReview"
+        ],
+        "operationId": "swagger_review_TestCasesSwaggerReviewHeadBodylessReviewEndpoint",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": [
+                "null",
+                "integer"
+              ],
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    },
     "/api/swagger-review/catch-all/{slug}": {
       "get": {
         "tags": [
@@ -7510,7 +7580,7 @@
             }
           }
         },
-        "description": "RFC9457 compatible problem details/ error response class. this can be used by configuring startup like so:\n```app.UseFastEndpoints(c =&gt; c.Errors.UseProblemDetails())```"
+        "description": "RFC9457 compatible problem details/ error response class. this can be used by configuring startup like so:\r\n```app.UseFastEndpoints(c =&gt; c.Errors.UseProblemDetails())```"
       },
       "FastEndpointsSecurityTokenRequest": {
         "type": "object",

--- a/Tests/IntegrationTests/FastEndpoints.OpenApi/release-1.json
+++ b/Tests/IntegrationTests/FastEndpoints.OpenApi/release-1.json
@@ -1751,6 +1751,76 @@
         }
       }
     },
+    "/api/swagger-review/bodyless-query-params": {
+      "get": {
+        "tags": [
+          "SwaggerReview"
+        ],
+        "operationId": "swagger_review_TestCasesSwaggerReviewGetBodylessReviewEndpoint",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": [
+                "null",
+                "integer"
+              ],
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      },
+      "head": {
+        "tags": [
+          "SwaggerReview"
+        ],
+        "operationId": "swagger_review_TestCasesSwaggerReviewHeadBodylessReviewEndpoint",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": [
+                "null",
+                "integer"
+              ],
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    },
     "/api/swagger-review/catch-all/{slug}": {
       "get": {
         "tags": [
@@ -7668,7 +7738,7 @@
             }
           }
         },
-        "description": "RFC9457 compatible problem details/ error response class. this can be used by configuring startup like so:\n```app.UseFastEndpoints(c =&gt; c.Errors.UseProblemDetails())```"
+        "description": "RFC9457 compatible problem details/ error response class. this can be used by configuring startup like so:\r\n```app.UseFastEndpoints(c =&gt; c.Errors.UseProblemDetails())```"
       },
       "FastEndpointsSecurityTokenRequest": {
         "type": "object",

--- a/Tests/IntegrationTests/FastEndpoints.OpenApi/release-1.json
+++ b/Tests/IntegrationTests/FastEndpoints.OpenApi/release-1.json
@@ -7738,7 +7738,7 @@
             }
           }
         },
-        "description": "RFC9457 compatible problem details/ error response class. this can be used by configuring startup like so:\r\n```app.UseFastEndpoints(c =&gt; c.Errors.UseProblemDetails())```"
+        "description": "RFC9457 compatible problem details/ error response class. this can be used by configuring startup like so:\n```app.UseFastEndpoints(c =&gt; c.Errors.UseProblemDetails())```"
       },
       "FastEndpointsSecurityTokenRequest": {
         "type": "object",

--- a/Tests/IntegrationTests/FastEndpoints.OpenApi/release-2.json
+++ b/Tests/IntegrationTests/FastEndpoints.OpenApi/release-2.json
@@ -7861,7 +7861,7 @@
             }
           }
         },
-        "description": "RFC9457 compatible problem details/ error response class. this can be used by configuring startup like so:\r\n```app.UseFastEndpoints(c =&gt; c.Errors.UseProblemDetails())```"
+        "description": "RFC9457 compatible problem details/ error response class. this can be used by configuring startup like so:\n```app.UseFastEndpoints(c =&gt; c.Errors.UseProblemDetails())```"
       },
       "FastEndpointsSecurityTokenRequest": {
         "type": "object",

--- a/Tests/IntegrationTests/FastEndpoints.OpenApi/release-2.json
+++ b/Tests/IntegrationTests/FastEndpoints.OpenApi/release-2.json
@@ -1945,6 +1945,76 @@
         }
       }
     },
+    "/api/swagger-review/bodyless-query-params": {
+      "get": {
+        "tags": [
+          "SwaggerReview"
+        ],
+        "operationId": "swagger_review_TestCasesSwaggerReviewGetBodylessReviewEndpoint",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": [
+                "null",
+                "integer"
+              ],
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      },
+      "head": {
+        "tags": [
+          "SwaggerReview"
+        ],
+        "operationId": "swagger_review_TestCasesSwaggerReviewHeadBodylessReviewEndpoint",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "schema": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": [
+                "null",
+                "integer"
+              ],
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    },
     "/api/swagger-review/catch-all/{slug}": {
       "get": {
         "tags": [
@@ -7791,7 +7861,7 @@
             }
           }
         },
-        "description": "RFC9457 compatible problem details/ error response class. this can be used by configuring startup like so:\n```app.UseFastEndpoints(c =&gt; c.Errors.UseProblemDetails())```"
+        "description": "RFC9457 compatible problem details/ error response class. this can be used by configuring startup like so:\r\n```app.UseFastEndpoints(c =&gt; c.Errors.UseProblemDetails())```"
       },
       "FastEndpointsSecurityTokenRequest": {
         "type": "object",


### PR DESCRIPTION
## Problem

HEAD endpoints emitted their request DTO as a required `requestBody` instead of query parameters. The equivalent GET endpoint with the same DTO was handled correctly — so the earlier GET fix never covered HEAD.

HEAD (like GET) binds from the query string at runtime, so the generated document contradicted actual binding behaviour. Client generators (NSwag, etc.) turned it into a required body parameter, producing wrong/uncompilable client code.

## Changes

- Widened the `isGetRequest` check to `isBodylessRequest` (`is "GET" or "HEAD"`) in both the modern OpenAPI transformer and the legacy Swagger/NSwag processor — this makes HEAD emit query parameters and suppresses the request body, identical to GET behaviour
- Renamed the local variable, method parameter, and `ProcessingState` property to `isBodylessRequest` throughout, since the name now reflects the semantic (no body) rather than a specific verb
- Folded a redundant nested `if (!RequestDtoIsList)` in `FinalizeRequestBody` into the outer condition

## Tests

- Added paired `GetBodylessReviewEndpoint` / `HeadBodylessReviewEndpoint` sharing a DTO and route to the test harness
- Added two integration tests asserting both verbs emit query parameters and no `requestBody` — the GET test also fills a pre-existing gap (no prior test asserted `requestBody` is null for GET)
- Updated OpenAPI snapshot golden files
