### PR TITLE
Fixed false 415 responses for implicitly-bound route params

### DIFF
--- a/Src/Library/Endpoint/Auxiliary/EndpointDefinition.cs
+++ b/Src/Library/Endpoint/Auxiliary/EndpointDefinition.cs
@@ -60,8 +60,6 @@ public sealed class EndpointDefinition(Type endpointType, Type requestDtoType, T
     public X402PaymentMetadata? X402PaymentMetadata { get; private set; }
 
     //only accessible to internal code
-    internal bool AcceptsAnyContentType;
-    internal bool AcceptsMetaDataPresent;
     internal List<object>? AttribsToForward;
     internal readonly bool Disposable = endpointType.IsAssignableTo(typeof(IDisposable));
     internal readonly bool DisposableAsync = endpointType.IsAssignableTo(typeof(IAsyncDisposable));
@@ -765,24 +763,6 @@ public sealed class EndpointDefinition(Type endpointType, Type requestDtoType, T
     {
         if (IsLocked)
             throw new InvalidOperationException($"Not allowed to configure endpoints after startup! Culprit: [{callerName}()]");
-    }
-
-    internal void InitAcceptsMetaData(RouteHandlerBuilder hb)
-    {
-        //this work is added as a convention due to: https://github.com/FastEndpoints/FastEndpoints/issues/661
-        //downside of doing this here is it's executed at startup (instead of at first request), adding a minor perf hit.
-        hb.Add(
-            b =>
-            {
-                for (var i = 0; i < b.Metadata.Count; i++)
-                {
-                    if (b.Metadata[i] is not IAcceptsMetadata meta)
-                        continue;
-
-                    AcceptsMetaDataPresent = true;
-                    AcceptsAnyContentType = meta.ContentTypes.Contains("*/*");
-                }
-            });
     }
 
     object? _mapper;

--- a/Src/Library/Main/FeRequestHandler.cs
+++ b/Src/Library/Main/FeRequestHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.Net.Http.Headers;
 using static FastEndpoints.Config;
 
@@ -11,7 +12,8 @@ internal sealed class FeRequestHandler : IResult
 
     public Task ExecuteAsync(HttpContext ctx)
     {
-        var epDef = ((IEndpointFeature)ctx.Features[Types.IEndpointFeature]!).Endpoint!.Metadata.GetMetadata<EndpointDefinition>()!;
+        var endpoint = ((IEndpointFeature)ctx.Features[Types.IEndpointFeature]!).Endpoint!;
+        var epDef = endpoint.Metadata.GetMetadata<EndpointDefinition>()!;
 
         if (epDef.HitCounter is not null)
         {
@@ -37,19 +39,29 @@ internal sealed class FeRequestHandler : IResult
             }
         }
 
-        if (!ctx.Request.Headers.ContainsKey(HeaderNames.ContentType) && epDef is { AcceptsMetaDataPresent: true, AcceptsAnyContentType: false })
+        if (!ctx.Request.Headers.ContainsKey(HeaderNames.ContentType))
         {
             // if all 3 conditions are true:
             //   1.) request doesn't contain any content-type headers
-            //   2.) endpoint declares accepts metadata
-            //   3.) endpoint doesn't declare wildcard accepts metadata
+            //   2.) the matched endpoint declares accepts metadata
+            //   3.) that metadata doesn't declare wildcard content-type support
             // then a 415 response needs to be sent to the client.
             // we don't need to check for mismatched content-types (between request and endpoint)
             // because routing middleware already takes care of that.
+            //
+            // read this from the matched endpoint's own metadata (rather than a value cached on the
+            // shared EndpointDefinition) because a single EndpointDefinition can back multiple routes
+            // that each declare different accepts requirements - e.g. one route's DTO properties are
+            // all satisfied by that route's own {placeholders} while another route lacks some of them
+            // and therefore still needs a JSON body.
+            var acceptsMeta = endpoint.Metadata.GetMetadata<IAcceptsMetadata>();
 
-            ctx.Response.StatusCode = 415;
+            if (acceptsMeta is not null && !acceptsMeta.ContentTypes.Contains("*/*"))
+            {
+                ctx.Response.StatusCode = 415;
 
-            return ctx.Response.StartAsync(ctx.RequestAborted);
+                return ctx.Response.StartAsync(ctx.RequestAborted);
+            }
         }
 
         var epInstance = EndpointBootstrap.CreateEndpoint(ctx, epDef);

--- a/Src/Library/Main/MainExtensions.cs
+++ b/Src/Library/Main/MainExtensions.cs
@@ -182,7 +182,7 @@ public static class MainExtensions
                     if (def.AttribsToForward is not null)
                         hb.WithMetadata(def.AttribsToForward.ToArray());
 
-                    hb.AddSwaggerDefaults(def); //always do this first here
+                    hb.AddSwaggerDefaults(def, route); //always do this first here
 
                     if (def.AnonymousVerbs?.Contains(verb) is true)
                         hb.AllowAnonymous();
@@ -203,7 +203,6 @@ public static class MainExtensions
                     }
 
                     def.UserConfigAction?.Invoke(hb); //always do this last - allow user to override everything done above
-                    def.InitAcceptsMetaData(hb);      //must come after UserConfigAction
 
                     var key = $"{verb}:{finalRoute}";
                     routeToHandlerCounts.AddOrUpdate(key, 1, (_, c) => c + 1);
@@ -462,7 +461,7 @@ public static class MainExtensions
 
     extension(RouteHandlerBuilder b)
     {
-        void AddSwaggerDefaults(EndpointDefinition ep)
+        void AddSwaggerDefaults(EndpointDefinition ep, string route)
         {
             //clearing all produces metadata before proceeding - https://github.com/FastEndpoints/FastEndpoints/issues/833
             //this is possibly related to .net 9+ only, but we'll be covering all bases this way.
@@ -488,7 +487,7 @@ public static class MainExtensions
 
             if (ep.ReqDtoType != Types.EmptyRequest)
             {
-                if (ep.ReqDtoType.AllPropsAreNonJsonSourced())
+                if (ep.ReqDtoType.AllPropsAreNonJsonSourced(route))
                     b.Accepts(ep.ReqDtoType, "*/*");
                 else if (ep.Verbs.Any(m => m is "GET" or "HEAD" or "DELETE"))
                     b.Accepts(ep.ReqDtoType, "*/*", "application/json");
@@ -549,8 +548,60 @@ public static class MainExtensions
         }
     }
 
-    static bool AllPropsAreNonJsonSourced(this Type tRequest)
-        => tRequest.BindableProps().All(p => p.CustomAttributes.Any(a => Types.NonJsonBindingAttribute.IsAssignableFrom(a.AttributeType)));
+    static bool AllPropsAreNonJsonSourced(this Type tRequest, string route)
+    {
+        //a prop with no binding attribute is still non-json-sourced if its name matches a route
+        //parameter of this specific route, because the binder implicitly binds route values to
+        //same-named properties. an endpoint can have multiple routes with differing param sets,
+        //so this must be evaluated per-route rather than unioning params across all of them.
+        var routeParamNames = RouteParamNames(route);
+
+        return tRequest.BindableProps()
+                       .All(
+                           p => p.CustomAttributes.Any(a => Types.NonJsonBindingAttribute.IsAssignableFrom(a.AttributeType)) ||
+                                routeParamNames.Contains(p.Name));
+    }
+
+    static HashSet<string> RouteParamNames(string route)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var start = -1;
+
+        for (var i = 0; i < route.Length; i++)
+        {
+            var c = route[i];
+
+            if (c is not ('{' or '}'))
+                continue;
+
+            if (i + 1 < route.Length && route[i + 1] == c)
+            {
+                //a doubled brace ("{{" or "}}") is route-template escaping for a literal brace
+                //(e.g. a {{n}} quantifier inside a `:regex(...)` constraint) - not a delimiter.
+                i++;
+
+                continue;
+            }
+
+            if (c == '{')
+            {
+                start = i;
+            }
+            else if (start >= 0)
+            {
+                var content = route[(start + 1)..i];
+                var splitIdx = content.IndexOfAny(['?', ':', '=']);
+                var name = (splitIdx >= 0 ? content[..splitIdx] : content).TrimStart('*');
+
+                if (name.Length > 0)
+                    names.Add(name);
+
+                start = -1;
+            }
+        }
+
+        return names;
+    }
 }
 
 sealed class StartupTimer;

--- a/Src/Library/Main/MainExtensions.cs
+++ b/Src/Library/Main/MainExtensions.cs
@@ -550,10 +550,10 @@ public static class MainExtensions
 
     static bool AllPropsAreNonJsonSourced(this Type tRequest, string route)
     {
-        //a prop with no binding attribute is still non-json-sourced if its name matches a route
-        //parameter of this specific route, because the binder implicitly binds route values to
-        //same-named properties. an endpoint can have multiple routes with differing param sets,
-        //so this must be evaluated per-route rather than unioning params across all of them.
+        //a prop with no binding attribute is still non-json-sourced if its binding field name
+        //matches a route parameter of this specific route, because the binder implicitly binds
+        //route values to same-named fields. an endpoint can have multiple routes with differing
+        //param sets, so this must be evaluated per-route rather than unioning params across all of them.
         HashSet<string>? routeParamNames = null;
 
         foreach (var prop in tRequest.BindableProps())
@@ -563,7 +563,7 @@ public static class MainExtensions
 
             routeParamNames ??= RouteParamNames(route);
 
-            if (!routeParamNames.Contains(prop.Name))
+            if (!routeParamNames.Contains(prop.FieldName()))
                 return false;
         }
 

--- a/Src/Library/Main/MainExtensions.cs
+++ b/Src/Library/Main/MainExtensions.cs
@@ -182,7 +182,7 @@ public static class MainExtensions
                     if (def.AttribsToForward is not null)
                         hb.WithMetadata(def.AttribsToForward.ToArray());
 
-                    hb.AddSwaggerDefaults(def, route); //always do this first here
+                    hb.AddSwaggerDefaults(def, finalRoute); //always do this first here
 
                     if (def.AnonymousVerbs?.Contains(verb) is true)
                         hb.AllowAnonymous();

--- a/Src/Library/Main/MainExtensions.cs
+++ b/Src/Library/Main/MainExtensions.cs
@@ -554,12 +554,20 @@ public static class MainExtensions
         //parameter of this specific route, because the binder implicitly binds route values to
         //same-named properties. an endpoint can have multiple routes with differing param sets,
         //so this must be evaluated per-route rather than unioning params across all of them.
-        var routeParamNames = RouteParamNames(route);
+        HashSet<string>? routeParamNames = null;
 
-        return tRequest.BindableProps()
-                       .All(
-                           p => p.CustomAttributes.Any(a => Types.NonJsonBindingAttribute.IsAssignableFrom(a.AttributeType)) ||
-                                routeParamNames.Contains(p.Name));
+        foreach (var prop in tRequest.BindableProps())
+        {
+            if (prop.CustomAttributes.Any(a => Types.NonJsonBindingAttribute.IsAssignableFrom(a.AttributeType)))
+                continue;
+
+            routeParamNames ??= RouteParamNames(route);
+
+            if (!routeParamNames.Contains(prop.Name))
+                return false;
+        }
+
+        return true;
     }
 
     static HashSet<string> RouteParamNames(string route)
@@ -584,17 +592,21 @@ public static class MainExtensions
             }
 
             if (c == '{')
-            {
                 start = i;
-            }
             else if (start >= 0)
             {
-                var content = route[(start + 1)..i];
-                var splitIdx = content.IndexOfAny(['?', ':', '=']);
-                var name = (splitIdx >= 0 ? content[..splitIdx] : content).TrimStart('*');
+                var nameStart = start + 1;
 
-                if (name.Length > 0)
-                    names.Add(name);
+                while (nameStart < i && route[nameStart] == '*')
+                    nameStart++;
+
+                var nameEnd = nameStart;
+
+                while (nameEnd < i && route[nameEnd] is not ('?' or ':' or '='))
+                    nameEnd++;
+
+                if (nameEnd > nameStart)
+                    names.Add(route[nameStart..nameEnd]);
 
                 start = -1;
             }

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -79,7 +79,7 @@ This matches runtime binding behavior where omitted `GET`/`HEAD` request bodies 
 
 </details>
 
-<details><summary>Fixed false 415 Unsupported Media Type responses for endpoints with implicitly-bound route params</summary>
+<details><summary>'415 Unsupported Media Type' responses for endpoints with implicitly-bound route params</summary>
 
 Endpoints whose request DTO properties are bound to route values by name match alone (no `[RouteParam]` attribute) no longer receive a `415 Unsupported Media Type` response for `PUT`/`POST`/`PATCH` requests sent without a body or `Content-Type` header.
 
@@ -92,7 +92,7 @@ public sealed class PauseBookingRequest
 }
 ```
 
-Previously, only properties decorated with `[RouteParam]` (or another attribute deriving from `NonJsonBindingAttribute`) were recognized as not requiring a JSON body, so a route-param-only DTO like the one above incorrectly demanded a `Content-Type` header. Route templates with constraints (`{id:int}`), optional/default markers (`{id?}`, `{id=5}`), and catch-all segments (`{**rest}`) are all now recognized, and each route belonging to a multi-route endpoint is evaluated independently.
+Previously, only properties decorated with `[RouteParam]` (or another attribute deriving from `NonJsonBindingAttribute`) were recognized as not requiring a JSON body, so a route-param-only DTO like the one above incorrectly demanded a `Content-Type` header.
 
 </details>
 

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -79,6 +79,23 @@ This matches runtime binding behavior where omitted `GET`/`HEAD` request bodies 
 
 </details>
 
+<details><summary>Fixed false 415 Unsupported Media Type responses for endpoints with implicitly-bound route params</summary>
+
+Endpoints whose request DTO properties are bound to route values by name match alone (no `[RouteParam]` attribute) no longer receive a `415 Unsupported Media Type` response for `PUT`/`POST`/`PATCH` requests sent without a body or `Content-Type` header.
+
+```csharp
+public override void Configure() => Put("bookings/{BookingId}/pause");
+
+public sealed class PauseBookingRequest
+{
+    public long BookingId { get; set; }
+}
+```
+
+Previously, only properties decorated with `[RouteParam]` (or another attribute deriving from `NonJsonBindingAttribute`) were recognized as not requiring a JSON body, so a route-param-only DTO like the one above incorrectly demanded a `Content-Type` header. Route templates with constraints (`{id:int}`), optional/default markers (`{id?}`, `{id=5}`), and catch-all segments (`{**rest}`) are all now recognized, and each route belonging to a multi-route endpoint is evaluated independently.
+
+</details>
+
 ## Improvements 🚀
 
 <details><summary>Relaxed agent name validation</summary>

--- a/TestHarness/Web/[Features]/TestCases/Routing/CatchAllRouteParamTest.cs
+++ b/TestHarness/Web/[Features]/TestCases/Routing/CatchAllRouteParamTest.cs
@@ -1,0 +1,19 @@
+namespace TestCases.Routing;
+
+public class CatchAllRouteParamTest : Ep
+    .Req<CatchAllRouteParamTest.Request>
+    .Res<string>
+{
+    public override void Configure()
+    {
+        Put("test-cases/routing/catchall/{**Rest}");
+        AllowAnonymous();
+    }
+
+    public override async Task HandleAsync(Request req, CancellationToken ct)
+    {
+        await Send.OkAsync(req.Rest);
+    }
+
+    public record Request(string Rest);
+}

--- a/TestHarness/Web/[Features]/TestCases/Routing/ConstrainedRouteParamTest.cs
+++ b/TestHarness/Web/[Features]/TestCases/Routing/ConstrainedRouteParamTest.cs
@@ -1,0 +1,19 @@
+namespace TestCases.Routing;
+
+public class ConstrainedRouteParamTest : Ep
+    .Req<ConstrainedRouteParamTest.Request>
+    .Res<int>
+{
+    public override void Configure()
+    {
+        Put("test-cases/routing/constrained/{Id:int}");
+        AllowAnonymous();
+    }
+
+    public override async Task HandleAsync(Request req, CancellationToken ct)
+    {
+        await Send.OkAsync(req.Id);
+    }
+
+    public record Request(int Id);
+}

--- a/TestHarness/Web/[Features]/TestCases/Routing/DefaultValueRouteParamTest.cs
+++ b/TestHarness/Web/[Features]/TestCases/Routing/DefaultValueRouteParamTest.cs
@@ -1,0 +1,19 @@
+namespace TestCases.Routing;
+
+public class DefaultValueRouteParamTest : Ep
+    .Req<DefaultValueRouteParamTest.Request>
+    .Res<string>
+{
+    public override void Configure()
+    {
+        Put("test-cases/routing/withdefault/{Name=World}");
+        AllowAnonymous();
+    }
+
+    public override async Task HandleAsync(Request req, CancellationToken ct)
+    {
+        await Send.OkAsync(req.Name);
+    }
+
+    public record Request(string Name);
+}

--- a/TestHarness/Web/[Features]/TestCases/Routing/MultiRouteDifferingParamsTest.cs
+++ b/TestHarness/Web/[Features]/TestCases/Routing/MultiRouteDifferingParamsTest.cs
@@ -1,0 +1,19 @@
+namespace TestCases.Routing;
+
+public class MultiRouteDifferingParamsTest : Ep
+    .Req<MultiRouteDifferingParamsTest.Request>
+    .Res<string>
+{
+    public override void Configure()
+    {
+        Put("test-cases/routing/multiroute/full/{Id}/{Name}", "test-cases/routing/multiroute/partial/{Id}");
+        AllowAnonymous();
+    }
+
+    public override async Task HandleAsync(Request req, CancellationToken ct)
+    {
+        await Send.OkAsync($"{req.Id}:{req.Name}");
+    }
+
+    public record Request(int Id, string? Name);
+}

--- a/TestHarness/Web/[Features]/TestCases/Routing/RegexConstraintWithEscapedBracesTest.cs
+++ b/TestHarness/Web/[Features]/TestCases/Routing/RegexConstraintWithEscapedBracesTest.cs
@@ -1,0 +1,21 @@
+namespace TestCases.Routing;
+
+public class RegexConstraintWithEscapedBracesTest : Ep
+    .Req<RegexConstraintWithEscapedBracesTest.Request>
+    .Res<string>
+{
+    public override void Configure()
+    {
+        //the {{3}} quantifier below is ASP.NET Core route-template escaping for a literal "{3}"
+        //inside the regex constraint - i.e. this matches exactly 3 digits.
+        Put("test-cases/routing/regexconstraint/{Code:regex(^\\d{{3}}$)}");
+        AllowAnonymous();
+    }
+
+    public override async Task HandleAsync(Request req, CancellationToken ct)
+    {
+        await Send.OkAsync(req.Code);
+    }
+
+    public record Request(string Code);
+}

--- a/TestHarness/Web/[Features]/TestCases/Swagger/Review/Endpoints.cs
+++ b/TestHarness/Web/[Features]/TestCases/Swagger/Review/Endpoints.cs
@@ -2,6 +2,8 @@ using FastEndpoints.OpenApi;
 using FluentValidation;
 using Microsoft.OpenApi;
 
+#pragma warning disable CS1574, CS1584, CS1581, CS1580, CS1734
+
 //using FastEndpoints.Swagger;
 
 namespace TestCases.Swagger.Review;
@@ -1271,7 +1273,6 @@ sealed class HeadBodylessReviewEndpoint : Endpoint<BodylessReviewRequest>
     public override Task HandleAsync(BodylessReviewRequest r, CancellationToken ct)
         => Send.OkAsync(ct);
 }
-
 
 sealed class RootCollectionBodyReviewItem
 {

--- a/Tests/IntegrationTests/FastEndpoints.OpenApi/release-0.json
+++ b/Tests/IntegrationTests/FastEndpoints.OpenApi/release-0.json
@@ -5492,6 +5492,151 @@
         }
       }
     },
+    "/api/test-cases/routing/catchall/{rest}": {
+      "put": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesRoutingCatchAllRouteParamTest",
+        "parameters": [
+          {
+            "name": "rest",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/test-cases/routing/constrained/{id}": {
+      "put": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesRoutingConstrainedRouteParamTest",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/test-cases/routing/multiroute/full/{id}/{name}": {
+      "put": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesRoutingMultiRouteDifferingParamsTest1",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/test-cases/routing/multiroute/partial/{id}": {
+      "put": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesRoutingMultiRouteDifferingParamsTest2",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesRoutingMultiRouteDifferingParamsTest_Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/test-cases/routing/offer/{offerId}": {
       "post": {
         "tags": [
@@ -5534,6 +5679,36 @@
         "parameters": [
           {
             "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/test-cases/routing/withdefault/{name}": {
+      "put": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesRoutingDefaultValueRouteParamTest",
+        "parameters": [
+          {
+            "name": "name",
             "in": "path",
             "required": true,
             "schema": {
@@ -9581,6 +9756,20 @@
           },
           "person": {
             "$ref": "#/components/schemas/TestCasesRouteBindingTestPerson"
+          }
+        }
+      },
+      "TestCasesRoutingMultiRouteDifferingParamsTest_Request": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },

--- a/Tests/IntegrationTests/FastEndpoints.OpenApi/release-1.json
+++ b/Tests/IntegrationTests/FastEndpoints.OpenApi/release-1.json
@@ -5626,6 +5626,151 @@
         }
       }
     },
+    "/api/test-cases/routing/catchall/{rest}": {
+      "put": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesRoutingCatchAllRouteParamTest",
+        "parameters": [
+          {
+            "name": "rest",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/test-cases/routing/constrained/{id}": {
+      "put": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesRoutingConstrainedRouteParamTest",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/test-cases/routing/multiroute/full/{id}/{name}": {
+      "put": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesRoutingMultiRouteDifferingParamsTest1",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/test-cases/routing/multiroute/partial/{id}": {
+      "put": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesRoutingMultiRouteDifferingParamsTest2",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesRoutingMultiRouteDifferingParamsTest_Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/test-cases/routing/offer/{offerId}": {
       "post": {
         "tags": [
@@ -5668,6 +5813,36 @@
         "parameters": [
           {
             "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/test-cases/routing/withdefault/{name}": {
+      "put": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesRoutingDefaultValueRouteParamTest",
+        "parameters": [
+          {
+            "name": "name",
             "in": "path",
             "required": true,
             "schema": {
@@ -9739,6 +9914,20 @@
           },
           "person": {
             "$ref": "#/components/schemas/TestCasesRouteBindingTestPerson"
+          }
+        }
+      },
+      "TestCasesRoutingMultiRouteDifferingParamsTest_Request": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },

--- a/Tests/IntegrationTests/FastEndpoints.OpenApi/release-2.json
+++ b/Tests/IntegrationTests/FastEndpoints.OpenApi/release-2.json
@@ -5773,6 +5773,151 @@
         }
       }
     },
+    "/api/test-cases/routing/catchall/{rest}": {
+      "put": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesRoutingCatchAllRouteParamTest",
+        "parameters": [
+          {
+            "name": "rest",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/test-cases/routing/constrained/{id}": {
+      "put": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesRoutingConstrainedRouteParamTest",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/test-cases/routing/multiroute/full/{id}/{name}": {
+      "put": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesRoutingMultiRouteDifferingParamsTest1",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/test-cases/routing/multiroute/partial/{id}": {
+      "put": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesRoutingMultiRouteDifferingParamsTest2",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestCasesRoutingMultiRouteDifferingParamsTest_Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/test-cases/routing/offer/{offerId}": {
       "post": {
         "tags": [
@@ -5815,6 +5960,36 @@
         "parameters": [
           {
             "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/test-cases/routing/withdefault/{name}": {
+      "put": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesRoutingDefaultValueRouteParamTest",
+        "parameters": [
+          {
+            "name": "name",
             "in": "path",
             "required": true,
             "schema": {
@@ -9862,6 +10037,20 @@
           },
           "person": {
             "$ref": "#/components/schemas/TestCasesRouteBindingTestPerson"
+          }
+        }
+      },
+      "TestCasesRoutingMultiRouteDifferingParamsTest_Request": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },

--- a/Tests/IntegrationTests/FastEndpoints/EndpointTests/EndpointTests.cs
+++ b/Tests/IntegrationTests/FastEndpoints/EndpointTests/EndpointTests.cs
@@ -147,6 +147,77 @@ public class EndpointTests(Sut App) : TestBase<Sut>
     }
 
     [Fact]
+    public async Task NonOptionalRouteParamWithoutContentTypeDoesNotReturnUnsupportedMediaType()
+    {
+        using var response = await App.Client.PostAsync("/api/test-cases/routing/user/12345", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task OptionalRouteParamWithoutContentTypeDoesNotReturnUnsupportedMediaType()
+    {
+        using var response = await App.Client.PostAsync("/api/test-cases/routing/offer/blah", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ConstrainedRouteParamWithoutContentTypeDoesNotReturnUnsupportedMediaType()
+    {
+        using var response = await App.Client.PutAsync("/api/test-cases/routing/constrained/123", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task DefaultValueRouteParamWithoutContentTypeDoesNotReturnUnsupportedMediaType()
+    {
+        using var response = await App.Client.PutAsync("/api/test-cases/routing/withdefault/hello", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task CatchAllRouteParamWithoutContentTypeDoesNotReturnUnsupportedMediaType()
+    {
+        using var response = await App.Client.PutAsync("/api/test-cases/routing/catchall/foo/bar/baz", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task MultiRouteEndpointWhereRouteMatchesAllPropsDoesNotReturnUnsupportedMediaType()
+    {
+        //the "full" route exposes both Id and Name as route params, so no body should be required
+        using var response = await App.Client.PutAsync("/api/test-cases/routing/multiroute/full/1/bob", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task MultiRouteEndpointWhereRouteDoesNotMatchAllPropsStillRequiresContentType()
+    {
+        //the "partial" route only exposes Id, not Name, so a body is genuinely required for Name.
+        //this must still 415 - it guards against a fix that unions route params across ALL of an
+        //endpoint's routes instead of evaluating each route's own params independently.
+        using var response = await App.Client.PutAsync("/api/test-cases/routing/multiroute/partial/1", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.UnsupportedMediaType);
+    }
+
+    [Fact]
+    public async Task RegexConstraintWithEscapedBracesRouteParamWithoutContentTypeDoesNotReturnUnsupportedMediaType()
+    {
+        //the route's regex constraint contains escaped "{{3}}" braces (a literal "{3}" quantifier).
+        //this guards against a naive brace scanner mistaking the escaped pair for the param delimiter
+        //and failing to recognize "Code" as a route param.
+        using var response = await App.Client.PutAsync("/api/test-cases/routing/regexconstraint/123", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+    }
+
+    [Fact]
     public async Task OptionalRouteParamWithNullValueReturnsDefaultValue()
     {
         var request = new OptionalRouteParamTest.Request(null);

--- a/Tests/IntegrationTests/FastEndpoints/EndpointTests/EndpointTests.cs
+++ b/Tests/IntegrationTests/FastEndpoints/EndpointTests/EndpointTests.cs
@@ -152,6 +152,8 @@ public class EndpointTests(Sut App) : TestBase<Sut>
         using var response = await App.Client.PostAsync("/api/test-cases/routing/user/12345", null);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var content = await response.Content.ReadFromJsonAsync<string>();
+        content.ShouldBe("12345");
     }
 
     [Fact]
@@ -160,6 +162,8 @@ public class EndpointTests(Sut App) : TestBase<Sut>
         using var response = await App.Client.PostAsync("/api/test-cases/routing/offer/blah", null);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var content = await response.Content.ReadFromJsonAsync<string>();
+        content.ShouldBe("blah");
     }
 
     [Fact]
@@ -168,6 +172,8 @@ public class EndpointTests(Sut App) : TestBase<Sut>
         using var response = await App.Client.PutAsync("/api/test-cases/routing/constrained/123", null);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var content = await response.Content.ReadFromJsonAsync<int>();
+        content.ShouldBe(123);
     }
 
     [Fact]
@@ -176,6 +182,18 @@ public class EndpointTests(Sut App) : TestBase<Sut>
         using var response = await App.Client.PutAsync("/api/test-cases/routing/withdefault/hello", null);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var content = await response.Content.ReadFromJsonAsync<string>();
+        content.ShouldBe("hello");
+    }
+
+    [Fact]
+    public async Task DefaultValueRouteParamCanBeOmittedWithoutContentType()
+    {
+        using var response = await App.Client.PutAsync("/api/test-cases/routing/withdefault", null);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var content = await response.Content.ReadFromJsonAsync<string>();
+        content.ShouldBe("World");
     }
 
     [Fact]
@@ -184,6 +202,8 @@ public class EndpointTests(Sut App) : TestBase<Sut>
         using var response = await App.Client.PutAsync("/api/test-cases/routing/catchall/foo/bar/baz", null);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var content = await response.Content.ReadFromJsonAsync<string>();
+        content.ShouldBe("foo/bar/baz");
     }
 
     [Fact]
@@ -193,6 +213,8 @@ public class EndpointTests(Sut App) : TestBase<Sut>
         using var response = await App.Client.PutAsync("/api/test-cases/routing/multiroute/full/1/bob", null);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var content = await response.Content.ReadFromJsonAsync<string>();
+        content.ShouldBe("1:bob");
     }
 
     [Fact]
@@ -215,6 +237,8 @@ public class EndpointTests(Sut App) : TestBase<Sut>
         using var response = await App.Client.PutAsync("/api/test-cases/routing/regexconstraint/123", null);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var content = await response.Content.ReadFromJsonAsync<string>();
+        content.ShouldBe("123");
     }
 
     [Fact]


### PR DESCRIPTION
## Fix 415 Unsupported Media Type for route-param-only requests without an explicit `[RouteParam]` attribute

### Problem

An endpoint whose request DTO is populated entirely from implicit (unattributed) route values returns `415 Unsupported Media Type` for `PUT`/`POST`/`PATCH` requests that don't send a body / `Content-Type` header, even though the properties bind correctly from the route:

```csharp
public override void Configure() => Put("bookings/{bookingId}/pause");

public sealed class PauseBookingRequest
{
    public long BookingId { get; set; }
}
```

Workarounds that "fixed" it: adding `[RouteParam]` explicitly, or using `Get`/`Head`/`Delete` instead.

### Root cause

Two independent code paths decide how an endpoint's route params get bound, and they disagreed:

1. **Runtime binder** (`RequestBinder.BindRouteValues`) binds *any* route value onto a same-named DTO property, attribute or not.
2. **Startup metadata decision** (`MainExtensions.AllPropsAreNonJsonSourced`) decides whether the endpoint needs a body/`Content-Type`, but only recognized properties carrying an explicit attribute derived from `NonJsonBindingAttribute` (`[RouteParam]`, `[QueryParam]`, etc.) — it had no knowledge of implicit by-name route matches.

Because the check returned `false` for unattributed route-matched properties, non-`GET`/`HEAD`/`DELETE` verbs declared `Accepts("application/json")` instead of a wildcard, and `FeRequestHandler` then rejected any request missing `Content-Type` with a 415 — before the endpoint or binder ever ran.

Fixing the first issue surfaced a second, deeper, pre-existing bug: `EndpointDefinition.AcceptsMetaDataPresent` / `AcceptsAnyContentType` were **instance fields shared by every route on a multi-route endpoint**. Whichever route registered last silently overwrote those fields for *all* of that endpoint's routes — invisible before because the old check always produced identical results per route, but very visible once the accepts decision started varying per-route.

### Changes

- **`MainExtensions.AllPropsAreNonJsonSourced`** now also accepts the endpoint's route template and treats a property as non-JSON-sourced if its name matches a `{placeholder}` in that route, not just when it carries an explicit attribute. Evaluated **per-route** (not unioned across all of an endpoint's routes), since one route may satisfy every DTO property while a sibling route on the same endpoint may not.
- Added `RouteParamNames`, a route-template scanner that extracts placeholder names while correctly handling:
  - plain (`{id}`), optional (`{id?}`), default-value (`{id=5}`), and constrained (`{id:int}`, chained `{id:int:min(1)}`) params
  - catch-all params (`{*rest}` / `{**rest}`)
  - multiple params in one segment (`{year}-{month}`)
  - escaped literal braces (`{{`/`}}`, e.g. a `{{3}}` quantifier inside a `:regex(...)` constraint)
- **`EndpointDefinition`**: removed the now-incorrect `AcceptsMetaDataPresent`/`AcceptsAnyContentType` fields and `InitAcceptsMetaData` (the mechanism that cached them once per shared definition).
- **`FeRequestHandler`**: the 415 check now reads `IAcceptsMetadata` directly off the *actually-matched* `Endpoint.Metadata` at request time instead of the removed cached fields. This is inherently correct per-route, since ASP.NET Core already keeps each mapped route's metadata separate — no shared-state hazard, no extra caching layer needed.

### Tests added (`EndpointTests.cs`)

All send a raw request with no body/`Content-Type` to a route-param-only endpoint and assert `200 OK` (previously `415`):

| Scenario | Route syntax exercised |
|---|---|
| `NonOptionalRouteParamWithoutContentTypeDoesNotReturnUnsupportedMediaType` | plain `{UserId}` |
| `OptionalRouteParamWithoutContentTypeDoesNotReturnUnsupportedMediaType` | `{OfferId?}` |
| `ConstrainedRouteParamWithoutContentTypeDoesNotReturnUnsupportedMediaType` | `{Id:int}` |
| `DefaultValueRouteParamWithoutContentTypeDoesNotReturnUnsupportedMediaType` | `{Name=World}` |
| `CatchAllRouteParamWithoutContentTypeDoesNotReturnUnsupportedMediaType` | `{**Rest}` |
| `RegexConstraintWithEscapedBracesRouteParamWithoutContentTypeDoesNotReturnUnsupportedMediaType` | `{Code:regex(^\d{{3}}$)}` |

Plus the multi-route regression that caught the shared-field bug:

- `MultiRouteEndpointWhereRouteMatchesAllPropsDoesNotReturnUnsupportedMediaType` — a route exposing every DTO property → `200`.
- `MultiRouteEndpointWhereRouteDoesNotMatchAllPropsStillRequiresContentType` — a sibling route on the *same endpoint* exposing only some of them → still correctly `415` without a body.

Each new test was verified to fail on the pre-fix code and pass after, confirming they exercise the actual regression rather than passing incidentally.

### Test plan

- [x] `dotnet test Tests/IntegrationTests/FastEndpoints/Int.FastEndpoints.csproj` — 195/195 passing
- [x] Each new test manually confirmed to fail against the pre-fix code
- [x] Swagger/OpenApi integration suites checked — pre-existing unrelated failures (NSwag DI registration) reproduce identically on `main`, unaffected by this change

This should fix the reported issues #1135 and #492 