### PR TITLE
FrozenDictionary usages for build-once, read-many lookup caches

### DIFF
--- a/Src/Generator/AccessControlGenerator.cs
+++ b/Src/Generator/AccessControlGenerator.cs
@@ -256,7 +256,7 @@ public class AccessControlGenerator : IIncrementalGenerator
             sb.w(
                 """
 
-                    static partial void InitPermissions()
+                    static partial void InitPermissions(Dictionary<string, string> permNames, Dictionary<string, string> permCodes)
                     {
 
                 """);
@@ -265,8 +265,8 @@ public class AccessControlGenerator : IIncrementalGenerator
             {
                 sb.w(
                     $"""
-                             _permNames[{CsString(p.Name)}] = {p.CodeExpression};
-                             _permCodes[{p.CodeExpression}] = {CsString(p.Name)};
+                             permNames[{CsString(p.Name)}] = {p.CodeExpression};
+                             permCodes[{p.CodeExpression}] = {CsString(p.Name)};
 
                      """);
             }
@@ -369,6 +369,7 @@ public class AccessControlGenerator : IIncrementalGenerator
 
              using FastEndpoints;
              using System;
+             using System.Collections.Frozen;
              using System.Collections.Generic;
              using System.Linq;
 
@@ -376,17 +377,21 @@ public class AccessControlGenerator : IIncrementalGenerator
 
              public static partial class Allow
              {
-                 private static readonly Dictionary<string, string> _permNames = new();
-                 private static readonly Dictionary<string, string> _permCodes = new();
+                 private static readonly FrozenDictionary<string, string> _permNames;
+                 private static readonly FrozenDictionary<string, string> _permCodes;
 
                  static Allow()
                  {
-                     InitPermissions();
+                     var permNames = new Dictionary<string, string>();
+                     var permCodes = new Dictionary<string, string>();
+                     InitPermissions(permNames, permCodes);
+                     _permNames = permNames.ToFrozenDictionary();
+                     _permCodes = permCodes.ToFrozenDictionary();
                      Groups();
                      Describe();
                  }
 
-                 static partial void InitPermissions();
+                 static partial void InitPermissions(Dictionary<string, string> permNames, Dictionary<string, string> permCodes);
 
                  /// <summary>
                  /// implement this method to add custom permissions to the generated categories

--- a/Src/Library/Binder/RequestBinder.cs
+++ b/Src/Library/Binder/RequestBinder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json;
@@ -25,8 +26,8 @@ public class RequestBinder<TRequest> : IRequestBinder<TRequest> where TRequest :
     static PropCache? _fromFormProp;
     static PropCache? _fromBodyProp;
     static PropCache? _fromQueryProp;
-    static readonly Dictionary<string, PrimaryPropCacheEntry> _primaryProps = new(StringComparer.OrdinalIgnoreCase); //key: property name
-    static readonly Dictionary<string, PropCache> _formFileCollectionProps = new(StringComparer.OrdinalIgnoreCase);
+    static readonly FrozenDictionary<string, PrimaryPropCacheEntry> _primaryProps; //key: property name
+    static readonly FrozenDictionary<string, PropCache> _formFileCollectionProps;
     static readonly List<SecondaryPropCacheEntry> _fromClaimProps = [];
     static readonly List<SecondaryPropCacheEntry> _fromHeaderProps = [];
     static readonly List<SecondaryPropCacheEntry> _fromCookieProps = [];
@@ -34,14 +35,19 @@ public class RequestBinder<TRequest> : IRequestBinder<TRequest> where TRequest :
 
     static RequestBinder()
     {
-        if (_skipModelBinding)
-            return;
-
         // if the request dto type is an IEnumerable such as List<T>, or any class that implements IEnumerable,
         // it will be deserialized by STJ. so skip setup for this dto type.
         // otherwise, a request dto such as MyRequest<T> - which is not IEnumerable can have a value parser, so allow to proceed.
-        if (_tRequest.GetInterfaces().Contains(Types.IEnumerable))
+        if (_skipModelBinding || _tRequest.GetInterfaces().Contains(Types.IEnumerable))
+        {
+            _primaryProps = FrozenDictionary<string, PrimaryPropCacheEntry>.Empty;
+            _formFileCollectionProps = FrozenDictionary<string, PropCache>.Empty;
+
             return;
+        }
+
+        var primaryProps = new Dictionary<string, PrimaryPropCacheEntry>(StringComparer.OrdinalIgnoreCase);
+        var formFileCollectionProps = new Dictionary<string, PropCache>(StringComparer.OrdinalIgnoreCase);
 
         var dtoProps = _tRequest.BindableProps();
 
@@ -139,16 +145,19 @@ public class RequestBinder<TRequest> : IRequestBinder<TRequest> where TRequest :
 
             if (prop.PropertyType.IsAssignableTo(Types.IEnumerableOfIFormFile))
             {
-                AddFormFileCollectionPropCacheEntry(fieldName, prop, propSetter);
+                AddFormFileCollectionPropCacheEntry(fieldName, prop, propSetter, formFileCollectionProps);
 
                 continue;
             }
 
             {
                 if (addPrimary)
-                    AddPrimaryPropCacheEntry(fieldName, prop, propSetter, disabledSources);
+                    AddPrimaryPropCacheEntry(fieldName, prop, propSetter, disabledSources, primaryProps);
             }
         }
+
+        _primaryProps = primaryProps.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        _formFileCollectionProps = formFileCollectionProps.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
     }
 
     readonly bool _bindJsonBody;
@@ -620,9 +629,9 @@ public class RequestBinder<TRequest> : IRequestBinder<TRequest> where TRequest :
         return false; // don't allow binding from any other sources
     }
 
-    static void AddPrimaryPropCacheEntry(string? fieldName, PropertyInfo propInfo, Action<object, object?> compiledSetter, Source? disabledSources)
+    static void AddPrimaryPropCacheEntry(string? fieldName, PropertyInfo propInfo, Action<object, object?> compiledSetter, Source? disabledSources, Dictionary<string, PrimaryPropCacheEntry> primaryProps)
     {
-        _primaryProps.Add(
+        primaryProps.Add(
             fieldName ?? propInfo.FieldName(),
             new()
             {
@@ -633,9 +642,9 @@ public class RequestBinder<TRequest> : IRequestBinder<TRequest> where TRequest :
             });
     }
 
-    static void AddFormFileCollectionPropCacheEntry(string? fieldName, PropertyInfo propInfo, Action<object, object?> compiledSetter)
+    static void AddFormFileCollectionPropCacheEntry(string? fieldName, PropertyInfo propInfo, Action<object, object?> compiledSetter, Dictionary<string, PropCache> formFileCollectionProps)
     {
-        _formFileCollectionProps.Add(
+        formFileCollectionProps.Add(
             fieldName ?? propInfo.FieldName(),
             new()
             {

--- a/Src/Library/Binder/RequestBinder.cs
+++ b/Src/Library/Binder/RequestBinder.cs
@@ -629,7 +629,11 @@ public class RequestBinder<TRequest> : IRequestBinder<TRequest> where TRequest :
         return false; // don't allow binding from any other sources
     }
 
-    static void AddPrimaryPropCacheEntry(string? fieldName, PropertyInfo propInfo, Action<object, object?> compiledSetter, Source? disabledSources, Dictionary<string, PrimaryPropCacheEntry> primaryProps)
+    static void AddPrimaryPropCacheEntry(string? fieldName,
+                                         PropertyInfo propInfo,
+                                         Action<object, object?> compiledSetter,
+                                         Source? disabledSources,
+                                         Dictionary<string, PrimaryPropCacheEntry> primaryProps)
     {
         primaryProps.Add(
             fieldName ?? propInfo.FieldName(),
@@ -642,7 +646,10 @@ public class RequestBinder<TRequest> : IRequestBinder<TRequest> where TRequest :
             });
     }
 
-    static void AddFormFileCollectionPropCacheEntry(string? fieldName, PropertyInfo propInfo, Action<object, object?> compiledSetter, Dictionary<string, PropCache> formFileCollectionProps)
+    static void AddFormFileCollectionPropCacheEntry(string? fieldName,
+                                                    PropertyInfo propInfo,
+                                                    Action<object, object?> compiledSetter,
+                                                    Dictionary<string, PropCache> formFileCollectionProps)
     {
         formFileCollectionProps.Add(
             fieldName ?? propInfo.FieldName(),

--- a/Src/Library/Config/ErrorOptions.cs
+++ b/Src/Library/Config/ErrorOptions.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Frozen;
-using FluentValidation.Results;
+﻿using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
 
@@ -79,7 +78,8 @@ public sealed class ErrorOptions
         /// <summary>
         /// the built-in map that ties together status codes to the relevant title and type values.
         /// </summary>
-        public FrozenDictionary<int, (string Title, string Url)> Map => _codeMap;
+        // Don't convert this to FrozenDictionary: it's a public API and consumers may assign/mutate the returned Dictionary.
+        public Dictionary<int, (string Title, string Url)> Map => _codeMap;
     #pragma warning restore CA1822
 
         /// <summary>
@@ -137,7 +137,7 @@ public sealed class ErrorOptions
                    ? p.Errors.First().Reason
                    : null;
 
-        static readonly FrozenDictionary<int, (string Title, string Url)> _codeMap = new Dictionary<int, (string Title, string Url)>
+        static readonly Dictionary<int, (string Title, string Url)> _codeMap = new()
         {
             { 400, ("Bad Request", "https://www.rfc-editor.org/rfc/rfc7231#section-6.5.1") },
             { 401, ("Unauthorized", "https://www.rfc-editor.org/rfc/rfc7235#section-3.1") },
@@ -169,6 +169,6 @@ public sealed class ErrorOptions
             { 431, ("Request Header Fields Too Large", "https://www.rfc-editor.org/rfc/rfc6585#section-5") },
             { 451, ("Unavailable For Legal Reasons", "https://www.rfc-editor.org/rfc/rfc7725#section-3") },
             { 500, ("Internal Server Error", "https://www.rfc-editor.org/rfc/rfc7231#section-6.6.1") }
-        }.ToFrozenDictionary();
+        };
     }
 }

--- a/Src/Library/Config/ErrorOptions.cs
+++ b/Src/Library/Config/ErrorOptions.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation.Results;
+﻿using System.Collections.Frozen;
+using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Metadata;
 
@@ -78,7 +79,7 @@ public sealed class ErrorOptions
         /// <summary>
         /// the built-in map that ties together status codes to the relevant title and type values.
         /// </summary>
-        public Dictionary<int, (string Title, string Url)> Map => _codeMap;
+        public FrozenDictionary<int, (string Title, string Url)> Map => _codeMap;
     #pragma warning restore CA1822
 
         /// <summary>
@@ -136,7 +137,7 @@ public sealed class ErrorOptions
                    ? p.Errors.First().Reason
                    : null;
 
-        static readonly Dictionary<int, (string Title, string Url)> _codeMap = new()
+        static readonly FrozenDictionary<int, (string Title, string Url)> _codeMap = new Dictionary<int, (string Title, string Url)>
         {
             { 400, ("Bad Request", "https://www.rfc-editor.org/rfc/rfc7231#section-6.5.1") },
             { 401, ("Unauthorized", "https://www.rfc-editor.org/rfc/rfc7235#section-3.1") },
@@ -168,6 +169,6 @@ public sealed class ErrorOptions
             { 431, ("Request Header Fields Too Large", "https://www.rfc-editor.org/rfc/rfc6585#section-5") },
             { 451, ("Unavailable For Legal Reasons", "https://www.rfc-editor.org/rfc/rfc7725#section-3") },
             { 500, ("Internal Server Error", "https://www.rfc-editor.org/rfc/rfc7231#section-6.6.1") }
-        };
+        }.ToFrozenDictionary();
     }
 }

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -98,17 +98,23 @@ Previously, only properties decorated with `[RouteParam]` (or another attribute 
 
 ## Improvements 🚀
 
+<details><summary>Refresh token service support for union-type returning endpoints</summary>
+
+A new `CreateTokenWith<TService, TTokenResponse>()` overload lets endpoints that return a union-type result (e.g. `Results<Ok<TokenResponse>, UnauthorizedHttpResult>`) create access/refresh token pairs, by decoupling the token response type from the endpoint's response type.
+
+</details>
+
+<details><summary>Frozen lookup caches for hot paths</summary>
+
+Several read-mostly internal lookup tables now use `FrozenDictionary` after startup construction, improving repeated lookup performance in request binding, access-control generation, and OpenAPI/Swagger metadata processing without changing public APIs.
+
+</details>
+
 <details><summary>Relaxed agent name validation</summary>
 
 A2A skill ids and MCP tool names now allow dots and forward slashes, so path/version-style identifiers such as `users/read.v1` can be published without renaming.
 
 Some external MCP adapters may still apply OpenAI-style function-name validation and reject dots or slashes.
-
-</details>
-
-<details><summary>Refresh token service support for union-type returning endpoints</summary>
-
-A new `CreateTokenWith<TService, TTokenResponse>()` overload lets endpoints that return a union-type result (e.g. `Results<Ok<TokenResponse>, UnauthorizedHttpResult>`) create access/refresh token pairs, by decoupling the token response type from the endpoint's response type.
 
 </details>
 

--- a/Src/OpenApi/Infrastructure/ConstructorDefaultExtensions.cs
+++ b/Src/OpenApi/Infrastructure/ConstructorDefaultExtensions.cs
@@ -36,9 +36,7 @@ static class ConstructorDefaultExtensions
         var defaults = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var parameter in parameters)
-        {
             defaults[parameter.Name!] = parameter.DefaultValue;
-        }
 
         return defaults.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
     }

--- a/Src/OpenApi/Infrastructure/ConstructorDefaultExtensions.cs
+++ b/Src/OpenApi/Infrastructure/ConstructorDefaultExtensions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
@@ -6,8 +7,8 @@ namespace FastEndpoints.OpenApi;
 
 static class ConstructorDefaultExtensions
 {
-    static readonly ConcurrentDictionary<Type, IReadOnlyDictionary<string, object?>> _constructorDefaultCache = new();
-    static readonly IReadOnlyDictionary<string, object?> _emptyConstructorDefaults = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+    static readonly ConcurrentDictionary<Type, FrozenDictionary<string, object?>> _constructorDefaultCache = new();
+    static readonly FrozenDictionary<string, object?> _emptyConstructorDefaults = FrozenDictionary<string, object?>.Empty;
 
     internal static object? GetParentCtorDefaultValue(this PropertyInfo property)
     {
@@ -22,23 +23,23 @@ static class ConstructorDefaultExtensions
     }
 
     [UnconditionalSuppressMessage("aot", "IL2070")]
-    static IReadOnlyDictionary<string, object?> CreateConstructorDefaultMap(Type type)
+    static FrozenDictionary<string, object?> CreateConstructorDefaultMap(Type type)
     {
         var parameters = type.GetConstructors()
                              .MaxBy(static c => c.GetParameters().Length)?
-                             .GetParameters();
+                             .GetParameters()
+                             .Where(p => p is { HasDefaultValue: true, Name: not null });
 
-        if (parameters is null)
+        if (parameters is null || !parameters.Any())
             return _emptyConstructorDefaults;
 
         var defaults = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var parameter in parameters)
         {
-            if (parameter is { HasDefaultValue: true, Name: not null })
-                defaults[parameter.Name] = parameter.DefaultValue;
+            defaults[parameter.Name!] = parameter.DefaultValue;
         }
 
-        return defaults.Count == 0 ? _emptyConstructorDefaults : defaults;
+        return defaults.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/Src/OpenApi/Infrastructure/XmlDocLookup.cs
+++ b/Src/OpenApi/Infrastructure/XmlDocLookup.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Diagnostics.CodeAnalysis;
@@ -12,8 +13,8 @@ static class XmlDocLookup
     // dynamic/in-memory assemblies that share an empty Location string.
     // the value is a pre-indexed dictionary of extracted xml member text keyed by member id
     // (e.g. "P:Namespace.Type.Prop") so per-property lookup is O(1) without retaining the xml DOM.
-    static readonly ConditionalWeakTable<Assembly, Dictionary<string, XmlMemberInfo>> _xmlDocCache = new();
-    static readonly Dictionary<string, XmlMemberInfo> _emptyMembers = new(StringComparer.Ordinal);
+    static readonly ConditionalWeakTable<Assembly, FrozenDictionary<string, XmlMemberInfo>> _xmlDocCache = new();
+    static readonly FrozenDictionary<string, XmlMemberInfo> _emptyMembers = FrozenDictionary<string, XmlMemberInfo>.Empty;
 
     readonly record struct XmlMemberInfo(string? Summary, string? Remarks, string? Example);
 
@@ -122,11 +123,11 @@ static class XmlDocLookup
         return fullName.Replace('+', '.');
     }
 
-    static Dictionary<string, XmlMemberInfo> GetXmlDoc(Assembly assembly)
+    static FrozenDictionary<string, XmlMemberInfo> GetXmlDoc(Assembly assembly)
         => _xmlDocCache.GetValue(assembly, LoadXmlDoc);
 
     [UnconditionalSuppressMessage("SingleFile", "IL3000", Justification = "XML doc lookup is optional when assembly paths are unavailable.")]
-    static Dictionary<string, XmlMemberInfo> LoadXmlDoc(Assembly assembly)
+    static FrozenDictionary<string, XmlMemberInfo> LoadXmlDoc(Assembly assembly)
     {
         var location = assembly.Location;
 
@@ -169,7 +170,7 @@ static class XmlDocLookup
             index[name] = new(summary, remarks, example);
         }
 
-        return index;
+        return index.ToFrozenDictionary(StringComparer.Ordinal);
 
         static string? GetSummary(XElement member)
         {

--- a/Src/OpenApi/Operations/OperationTransformer.Responses.cs
+++ b/Src/OpenApi/Operations/OperationTransformer.Responses.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.OpenApi;
@@ -9,7 +10,7 @@ sealed class ResponseOperationTransformer(DocumentOptions docOpts, SharedContext
 {
     readonly ResponseHeaderFactory _headerFactory = new(docOpts, sharedCtx);
 
-    static readonly Dictionary<string, string> _defaultDescriptions = new()
+    static readonly FrozenDictionary<string, string> _defaultDescriptions = new Dictionary<string, string>
     {
         { "200", "Success" },
         { "201", "Created" },
@@ -24,7 +25,7 @@ sealed class ResponseOperationTransformer(DocumentOptions docOpts, SharedContext
         { "406", "Not Acceptable" },
         { "429", "Too Many Requests" },
         { "500", "Server Error" }
-    };
+    }.ToFrozenDictionary();
 
     JsonNamingPolicy? NamingPolicy => sharedCtx.NamingPolicy;
     JsonSerializerOptions SerializerOptions => sharedCtx.SerializerOptions ?? Cfg.SerOpts.Options;

--- a/Src/Swagger/GlobalConfig.cs
+++ b/Src/Swagger/GlobalConfig.cs
@@ -1,4 +1,5 @@
-﻿global using Cfg = FastEndpoints.Config;
+global using Cfg = FastEndpoints.Config;
+using System.Collections.Frozen;
 
 namespace FastEndpoints.Swagger;
 
@@ -31,7 +32,7 @@ public static class GlobalConfig
     /// this route constraint type map will be used to determine the type for a route parameter if there's no matching property on the request dto.
     /// the dictionary key is the name of the constraint and the value is the  corresponding <see cref="System.Type" />
     /// </summary>
-    public static Dictionary<string, Type> RouteConstraintMap { get; } = new(StringComparer.OrdinalIgnoreCase)
+    public static FrozenDictionary<string, Type> RouteConstraintMap { get; } = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase)
     {
         { "int", typeof(int) },
         { "bool", typeof(bool) },
@@ -44,5 +45,5 @@ public static class GlobalConfig
         { "min", typeof(long) },
         { "max", typeof(long) },
         { "range", typeof(long) }
-    };
+    }.ToFrozenDictionary();
 }

--- a/Src/Swagger/GlobalConfig.cs
+++ b/Src/Swagger/GlobalConfig.cs
@@ -1,5 +1,4 @@
 global using Cfg = FastEndpoints.Config;
-using System.Collections.Frozen;
 
 namespace FastEndpoints.Swagger;
 
@@ -32,7 +31,8 @@ public static class GlobalConfig
     /// this route constraint type map will be used to determine the type for a route parameter if there's no matching property on the request dto.
     /// the dictionary key is the name of the constraint and the value is the  corresponding <see cref="System.Type" />
     /// </summary>
-    public static FrozenDictionary<string, Type> RouteConstraintMap { get; } = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase)
+    // Don't convert this to FrozenDictionary: it's a public API and consumers may add custom route constraint mappings.
+    public static Dictionary<string, Type> RouteConstraintMap { get; } = new(StringComparer.OrdinalIgnoreCase)
     {
         { "int", typeof(int) },
         { "bool", typeof(bool) },
@@ -45,5 +45,5 @@ public static class GlobalConfig
         { "min", typeof(long) },
         { "max", typeof(long) },
         { "range", typeof(long) }
-    }.ToFrozenDictionary();
+    };
 }

--- a/Src/Swagger/OperationProcessor.cs
+++ b/Src/Swagger/OperationProcessor.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Frozen;
 using System.ComponentModel;
 using System.Globalization;
 using System.Reflection;
@@ -38,7 +39,7 @@ sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationPro
     [GeneratedRegex("(?<={)([^?:}]+)[^}]*(?=})")]
     private static partial Regex RouteConstraintsRegex();
 
-    static readonly Dictionary<string, string> _defaultDescriptions = new()
+    static readonly FrozenDictionary<string, string> _defaultDescriptions = new Dictionary<string, string>
     {
         { "200", "Success" },
         { "201", "Created" },
@@ -53,7 +54,7 @@ sealed partial class OperationProcessor(DocumentOptions docOpts) : IOperationPro
         { "406", "Not Acceptable" },
         { "429", "Too Many Requests" },
         { "500", "Server Error" }
-    };
+    }.ToFrozenDictionary();
 
     public bool Process(OperationProcessorContext ctx)
     {


### PR DESCRIPTION
## Use FrozenDictionary for build-once, read-many lookup caches

Converts several internal `Dictionary` fields to `System.Collections.Frozen.FrozenDictionary` across the request-binding, error-handling, and OpenAPI/Swagger doc-generation paths. Each converted table is built exactly once (per type, per assembly, or as a static field) and then read repeatedly — the shape `FrozenDictionary` is designed to speed up, at the cost of a slower one-time build.

### Changed

- **`RequestBinder<TRequest>`** — `_primaryProps`/`_formFileCollectionProps`, built once per DTO type, read on every request bound to that DTO.
- **`ErrorOptions.ProblemDetailsConfig`** — `_codeMap`, read on every ProblemDetails error response.
- **`ConstructorDefaultExtensions`** — per-`Type` constructor-default cache, read on every OpenAPI doc generation pass.
- **`XmlDocLookup`** — per-`Assembly` XML doc cache, read on every OpenAPI doc generation pass.
- **`OperationTransformer.Responses`** / **`Swagger.OperationProcessor`** — `_defaultDescriptions` status-code maps.
- **`AccessControlGenerator`** — the generated `Allow` class's `_permNames`/`_permCodes` permission lookup tables, read on every permission check in every consuming app. Required reshaping the generated `InitPermissions` partial method to populate local mutable dictionaries that get frozen and assigned in the static constructor (readonly fields can only be assigned from the declaring type's own constructor, and `InitPermissions` may have zero implementations in projects with no registered permissions).
- **`Swagger.GlobalConfig.RouteConstraintMap`** — read on every OpenAPI/Swagger doc generation pass to resolve route-constrained parameter types.

### Why

All of these dictionaries are populated once (at type load, in a static constructor, or cached once per key) and never mutated afterward, while reads happen on a hot or semi-hot path — request binding, error responses, or doc-generation passes that can run on every request depending on which OpenAPI pipeline is in use. That's exactly the build-once/read-many pattern `FrozenDictionary` trades slower construction for faster lookups on.

### Testing

- Reviewed each conversion site's build/read frequency to confirm none rebuild the dictionary more often than before, including verifying that Microsoft.AspNetCore.OpenApi rebuilds its document per request while NSwag caches it — both amortize the one-time build cost across many reads either way.
- `AccessControlGeneratorTests` (which compile the generator's actual emitted output) pass, including the zero-permission case where `InitPermissions` has no implementation.
- No behavior change intended anywhere — only the backing collection type for already-immutable-after-construction data.