### PR TITLE
Use FrozenSet lookups for permission/scope/claim-type checks

### DIFF
--- a/Src/Library/Main/MainExtensions.cs
+++ b/Src/Library/Main/MainExtensions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json.Serialization;
@@ -406,10 +407,11 @@ public static class MainExtensions
                 {
                     if (ep.AllowAnyPermission)
                     {
+                        var allowedPermissions = ep.AllowedPermissions.ToFrozenSet(StringComparer.Ordinal);
                         b.RequireAssertion(
                             x => x.User.Claims.Any(
                                 c => string.Equals(c.Type, Cfg.SecOpts.PermissionsClaimType, StringComparison.OrdinalIgnoreCase) &&
-                                     ep.AllowedPermissions.Contains(c.Value, StringComparer.Ordinal)));
+                                     allowedPermissions.Contains(c.Value)));
                     }
                     else
                     {
@@ -425,10 +427,11 @@ public static class MainExtensions
                 {
                     if (ep.AllowAnyScope)
                     {
+                        var allowedScopes = ep.AllowedScopes.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
                         b.RequireAssertion(
                             x => x.User.Claims.Any(
                                 c => string.Equals(c.Type, Cfg.SecOpts.ScopeClaimType, StringComparison.OrdinalIgnoreCase) &&
-                                     Cfg.SecOpts.ScopeParser(c.Value).Any(s => ep.AllowedScopes.Contains(s, StringComparer.OrdinalIgnoreCase))));
+                                     Cfg.SecOpts.ScopeParser(c.Value).Any(s => allowedScopes.Contains(s))));
                     }
                     else
                     {
@@ -446,10 +449,16 @@ public static class MainExtensions
 
                 if (ep.AllowedClaimTypes?.Count > 0)
                 {
+                    
                     if (ep.AllowAnyClaim)
-                        b.RequireAssertion(x => x.User.Claims.Any(c => ep.AllowedClaimTypes.Contains(c.Type, StringComparer.OrdinalIgnoreCase)));
+                    {
+                        var allowedClaimTypes = ep.AllowedClaimTypes.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+                        b.RequireAssertion(x => x.User.Claims.Any(c => allowedClaimTypes.Contains(c.Type)));
+                    }
                     else
+                    {
                         b.RequireAssertion(x => ep.AllowedClaimTypes.All(t => x.User.Claims.Any(c => string.Equals(c.Type, t, StringComparison.OrdinalIgnoreCase))));
+                    }
                 }
 
                 ep.PolicyBuilder?.Invoke(b);

--- a/Src/Library/Main/MainExtensions.cs
+++ b/Src/Library/Main/MainExtensions.cs
@@ -431,7 +431,7 @@ public static class MainExtensions
                         b.RequireAssertion(
                             x => x.User.Claims.Any(
                                 c => string.Equals(c.Type, Cfg.SecOpts.ScopeClaimType, StringComparison.OrdinalIgnoreCase) &&
-                                     Cfg.SecOpts.ScopeParser(c.Value).Any(s => allowedScopes.Contains(s))));
+                                     Cfg.SecOpts.ScopeParser(c.Value).Any(allowedScopes.Contains)));
                     }
                     else
                     {
@@ -449,16 +449,13 @@ public static class MainExtensions
 
                 if (ep.AllowedClaimTypes?.Count > 0)
                 {
-                    
                     if (ep.AllowAnyClaim)
                     {
                         var allowedClaimTypes = ep.AllowedClaimTypes.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
                         b.RequireAssertion(x => x.User.Claims.Any(c => allowedClaimTypes.Contains(c.Type)));
                     }
                     else
-                    {
                         b.RequireAssertion(x => ep.AllowedClaimTypes.All(t => x.User.Claims.Any(c => string.Equals(c.Type, t, StringComparison.OrdinalIgnoreCase))));
-                    }
                 }
 
                 ep.PolicyBuilder?.Invoke(b);

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -106,7 +106,9 @@ A new `CreateTokenWith<TService, TTokenResponse>()` overload lets endpoints that
 
 <details><summary>Frozen lookup caches for hot paths</summary>
 
-Several read-mostly internal lookup tables now use `FrozenDictionary` after startup construction, improving repeated lookup performance in request binding, access-control generation, and OpenAPI/Swagger metadata processing without changing public APIs.
+Several read-mostly internal lookup tables now use `FrozenDictionary`/`FrozenSet` after startup construction, improving repeated lookup performance in request binding, access-control generation, and OpenAPI/Swagger metadata processing without changing public APIs.
+
+Endpoint security policies now build a `FrozenSet` of allowed permissions/scopes/claim types once when the policy is constructed, instead of scanning the backing collection on every authorization check.
 
 </details>
 

--- a/TestHarness/Web/[Features]/Customers/Login/Endpoint.cs
+++ b/TestHarness/Web/[Features]/Customers/Login/Endpoint.cs
@@ -18,6 +18,7 @@ public class Endpoint : EndpointWithoutRequest
                     Allow.Customers_Retrieve,
                     Allow.Sales_Order_Create
                 ]);
+                o.User.Permissions.Add("CasePerm"); //for permission value casing tests
                 o.User.Roles.Add(Role.Customer);
                 o.User[Claim.CustomerID] = "CST001";
                 o.User["scope"] = "one two three";

--- a/TestHarness/Web/[Features]/TestCases/Security/ComparerSemanticsTest/ComparerSemanticsTests.cs
+++ b/TestHarness/Web/[Features]/TestCases/Security/ComparerSemanticsTest/ComparerSemanticsTests.cs
@@ -1,0 +1,63 @@
+namespace TestCases.ComparerSemanticsTest;
+
+//permission values must match with ordinal (case-sensitive) comparison
+
+public class PermissionCasingExactEndpoint : EndpointWithoutRequest<string>
+{
+    public override void Configure()
+    {
+        Get("/test-cases/comparer-tests/permission-casing-exact");
+        Permissions("CasePerm");
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        await Send.OkAsync("ok!");
+    }
+}
+
+public class PermissionCasingMismatchEndpoint : EndpointWithoutRequest<string>
+{
+    public override void Configure()
+    {
+        Get("/test-cases/comparer-tests/permission-casing-mismatch");
+        Permissions("caseperm");
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        await Send.OkAsync("ok!");
+    }
+}
+
+//scope values must match with case-insensitive comparison
+
+public class ScopeCasingMismatchEndpoint : EndpointWithoutRequest<string>
+{
+    public override void Configure()
+    {
+        Get("/test-cases/comparer-tests/scope-casing-mismatch");
+        Scopes("TWO");
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        await Send.OkAsync("ok!");
+    }
+}
+
+//claim types must match with case-insensitive comparison
+
+public class ClaimTypeCasingMismatchEndpoint : EndpointWithoutRequest<string>
+{
+    public override void Configure()
+    {
+        Get("/test-cases/comparer-tests/claim-type-casing-mismatch");
+        Claims("CUSTOMER-ID");
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        await Send.OkAsync("ok!");
+    }
+}

--- a/Tests/IntegrationTests/FastEndpoints.OpenApi/release-0.json
+++ b/Tests/IntegrationTests/FastEndpoints.OpenApi/release-0.json
@@ -3443,6 +3443,130 @@
         }
       }
     },
+    "/api/test-cases/comparer-tests/claim-type-casing-mismatch": {
+      "get": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesComparerSemanticsTestClaimTypeCasingMismatchEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "JWTBearerAuth": [ ]
+          }
+        ]
+      }
+    },
+    "/api/test-cases/comparer-tests/permission-casing-exact": {
+      "get": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesComparerSemanticsTestPermissionCasingExactEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "JWTBearerAuth": [ ]
+          }
+        ]
+      }
+    },
+    "/api/test-cases/comparer-tests/permission-casing-mismatch": {
+      "get": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesComparerSemanticsTestPermissionCasingMismatchEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "JWTBearerAuth": [ ]
+          }
+        ]
+      }
+    },
+    "/api/test-cases/comparer-tests/scope-casing-mismatch": {
+      "get": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesComparerSemanticsTestScopeCasingMismatchEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "JWTBearerAuth": [ ]
+          }
+        ]
+      }
+    },
     "/api/test-cases/custom-request-binder": {
       "post": {
         "tags": [

--- a/Tests/IntegrationTests/FastEndpoints.OpenApi/release-1.json
+++ b/Tests/IntegrationTests/FastEndpoints.OpenApi/release-1.json
@@ -3533,6 +3533,142 @@
         }
       }
     },
+    "/api/test-cases/comparer-tests/claim-type-casing-mismatch": {
+      "get": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesComparerSemanticsTestClaimTypeCasingMismatchEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "JWTBearerAuth": [ ]
+          },
+          {
+            "ApiKey": [ ]
+          }
+        ]
+      }
+    },
+    "/api/test-cases/comparer-tests/permission-casing-exact": {
+      "get": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesComparerSemanticsTestPermissionCasingExactEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "JWTBearerAuth": [ ]
+          },
+          {
+            "ApiKey": [ ]
+          }
+        ]
+      }
+    },
+    "/api/test-cases/comparer-tests/permission-casing-mismatch": {
+      "get": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesComparerSemanticsTestPermissionCasingMismatchEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "JWTBearerAuth": [ ]
+          },
+          {
+            "ApiKey": [ ]
+          }
+        ]
+      }
+    },
+    "/api/test-cases/comparer-tests/scope-casing-mismatch": {
+      "get": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesComparerSemanticsTestScopeCasingMismatchEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "JWTBearerAuth": [ ]
+          },
+          {
+            "ApiKey": [ ]
+          }
+        ]
+      }
+    },
     "/api/test-cases/custom-request-binder": {
       "post": {
         "tags": [

--- a/Tests/IntegrationTests/FastEndpoints.OpenApi/release-2.json
+++ b/Tests/IntegrationTests/FastEndpoints.OpenApi/release-2.json
@@ -3724,6 +3724,130 @@
         }
       }
     },
+    "/api/test-cases/comparer-tests/claim-type-casing-mismatch": {
+      "get": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesComparerSemanticsTestClaimTypeCasingMismatchEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "JWTBearerAuth": [ ]
+          }
+        ]
+      }
+    },
+    "/api/test-cases/comparer-tests/permission-casing-exact": {
+      "get": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesComparerSemanticsTestPermissionCasingExactEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "JWTBearerAuth": [ ]
+          }
+        ]
+      }
+    },
+    "/api/test-cases/comparer-tests/permission-casing-mismatch": {
+      "get": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesComparerSemanticsTestPermissionCasingMismatchEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "JWTBearerAuth": [ ]
+          }
+        ]
+      }
+    },
+    "/api/test-cases/comparer-tests/scope-casing-mismatch": {
+      "get": {
+        "tags": [
+          "TestCases"
+        ],
+        "operationId": "TestCasesComparerSemanticsTestScopeCasingMismatchEndpoint",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "JWTBearerAuth": [ ]
+          }
+        ]
+      }
+    },
     "/api/test-cases/custom-request-binder": {
       "post": {
         "tags": [

--- a/Tests/IntegrationTests/FastEndpoints/SecurityTests/SecurityTests.cs
+++ b/Tests/IntegrationTests/FastEndpoints/SecurityTests/SecurityTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Http;
 using RefreshTest = TestCases.RefreshTokensTest;
+using TestCases.ComparerSemanticsTest;
 using TestCases.MissingClaimTest;
 using TestCases.ScopesTest;
 
@@ -41,6 +42,33 @@ public class SecurityTests(Sut App) : TestBase<Sut>
         var (rsp, _) = await App.CustomerClient.GETAsync<ScopeTestAllFailEndpoint, EmptyResponse>();
         rsp.IsSuccessStatusCode.ShouldBeFalse();
         rsp.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task PermissionMatchingIsCaseSensitive()
+    {
+        var (rsp, res) = await App.CustomerClient.GETAsync<PermissionCasingExactEndpoint, string>();
+        rsp.IsSuccessStatusCode.ShouldBeTrue();
+        res.ShouldBe("ok!");
+
+        var (rspMismatch, _) = await App.CustomerClient.GETAsync<PermissionCasingMismatchEndpoint, ErrorResponse>();
+        rspMismatch.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ScopeMatchingIsCaseInsensitive()
+    {
+        var (rsp, res) = await App.CustomerClient.GETAsync<ScopeCasingMismatchEndpoint, string>();
+        rsp.IsSuccessStatusCode.ShouldBeTrue();
+        res.ShouldBe("ok!");
+    }
+
+    [Fact]
+    public async Task ClaimTypeMatchingIsCaseInsensitive()
+    {
+        var (rsp, res) = await App.CustomerClient.GETAsync<ClaimTypeCasingMismatchEndpoint, string>();
+        rsp.IsSuccessStatusCode.ShouldBeTrue();
+        res.ShouldBe("ok!");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Cache `AllowedPermissions`/`AllowedScopes`/`AllowedClaimTypes` into `FrozenSet`s in `MainExtensions.cs` before use in the `RequireAssertion` claim-matching delegates, replacing per-check `Enumerable.Contains(..., comparer)` calls with O(1) frozen-set lookups. Continues the frozen-collection perf work from #1137.
- Preserves existing comparison semantics: permissions stay ordinal (case-sensitive), scopes and claim types stay ordinal-ignore-case.
- Adds `ComparerSemanticsTests` test endpoints and `SecurityTests` cases to lock in that casing behavior (permission mismatch → 403, scope/claim-type casing mismatch → still allowed).
- Updates OpenAPI snapshot fixtures (`release-0/1/2.json`) for the new test endpoints.