### PR TITLE
Cache bindable props per DTO type in binder hot path

### DIFF
--- a/.okf/architecture.md
+++ b/.okf/architecture.md
@@ -51,6 +51,7 @@ Attributes / Messaging.Core
 - **Security/OpenApi/OData/AspVersioning** reference Library (addons on top of core HTTP).
 - **Generator** references Attributes only (analyzer package); consumers reference Generator as analyzer.
 - **Agents** (`Mcp`, `A2A`) reference Library; share internal types via linked `Src/Agents/Shared/*.cs` (not a separate NuGet).
+- **Agents friend internals:** Library exposes selected internals to `FastEndpoints.Mcp` / `FastEndpoints.A2A` via `InternalsVisibleTo` (`Src/Library/Metadata.cs`). Those members are an effective binary contract across independently versioned packages; see stock in [gotchas.md](gotchas.md).
 - **Forbidden for agents:** invent reverse deps (e.g. Core → Library) or ship Agents.Shared as a public package unless code changes deliberately.
 
 ## Communication
@@ -83,10 +84,12 @@ Attributes / Messaging.Core
 5. Strong-name signing via `FastEndpoints.snk` (public key in Directory.Build.props / InternalsVisibleTo).
 6. Central package versions: root `Directory.Packages.props` (`ManagePackageVersionsCentrally`).
 7. Agents addons version **independently** of core (`Src/Agents/Directory.Build.props` imports parent then overrides).
+8. Do not rename, retype, or remove Library internals listed in the Agents friend-assembly stock ([gotchas.md](gotchas.md)) without checking published agent package compatibility and restocking OKF.
 
 ## Sources
 - `Src/Library/Main/MainExtensions.cs`
 - `Src/Library/Endpoint/Endpoint.cs`
 - `Src/Library/FastEndpoints.csproj`
+- `Src/Library/Metadata.cs`
 - `Src/Generator/DiscoveredTypesGenerator.cs`
 - `Src/Agents/Directory.Build.props`

--- a/.okf/gotchas.md
+++ b/.okf/gotchas.md
@@ -14,6 +14,24 @@ tags: [gotcha]
 - **Central versions pinned:** do not casually bump `Microsoft.CodeAnalysis.CSharp` (net8) or `Microsoft.OpenApi.Kiota.Builder` (OpenAPI 2 vs 3 clash); comments in `Directory.Packages.props`.
 - **Agents independent versioning:** `Src/Agents/Directory.Build.props` must `Import` parent props (MSBuild stops at first Directory.Build.props). Shared agent code is **linked compile**, not a NuGet.
 - **Agents not in main slnx:** A2A/Mcp projects may be commented out of `FastEndpoints.slnx`; still real packages; check solution before assuming build inclusion.
+- **Agents friend-assembly binary contract:** `Src/Library/Metadata.cs` grants `InternalsVisibleTo` to `FastEndpoints.Mcp` and `FastEndpoints.A2A`. Those packages are versioned independently of core, so recompiling add-ons against HEAD in this monorepo does **not** prove shipped NuGet binaries stay loadable. Changing an **internal** core member's name, arity, parameter types, or return type is a potential `MissingMethodException` / type-load break for already-published add-ons. Treat the stock below as a hard notice surface: if you touch any of these in `FastEndpoints` (Library), stop and check agent packages (rebuild + consider coordinated Agents release / version bump / dual overload when needed).
+  - **Reflection / binding helpers** (`Src/Library/Binder/BinderExtensions.cs`, `Src/Library/Extensions/ReflectionExtensions.cs`):
+    - `Type.BindableProps()` (return type is part of the CLR signature; e.g. `ICollection<PropertyInfo>` vs `PropertyInfo[]`)
+    - `PropertyInfo.FieldName()`
+    - `Type.IsComplexType()`
+    - `Type.IsCollection()`
+  - **Endpoint bootstrap / discovery** (`Src/Library/Main/EndpointBootstrap.cs`, `Src/Library/Main/EndpointData.cs`):
+    - `EndpointBootstrap.CreateEndpoint(HttpContext, EndpointDefinition)`
+    - `EndpointData.Found`
+  - **EndpointDefinition internal fields** (`Src/Library/Endpoint/Auxiliary/EndpointDefinition.cs`):
+    - `SerializerContext`
+    - `Disposable`
+    - `DisposableAsync`
+  - **Config / type tokens** (`Src/Library/Config/Config.cs`, `Src/Library/Types.cs`):
+    - `Config.SerOpts` (also via `using static FastEndpoints.Config` → `SerOpts.Options`)
+    - `Types` class + fields used by agents: `EmptyRequest`, `FromBodyAttribute`, `ToHeaderAttribute`, `String`
+  - **Primary agent call sites** (verify when restocking): `Src/Agents/Shared/AgentRequestBuilder.cs`, `AgentJsonPropertyNames.cs`, `AgentHttpContextFactory.cs`, `EndpointInvoker.cs`, `AgentEndpointCatalog.cs`; `Src/Agents/Mcp/McpToolSchemaFactory.cs`, `EndpointMcpToolSource.cs`; `Src/Agents/A2A/A2AJsonRpcEndpoint.cs`, `A2ASkillDispatcher.cs`, `Extensions.cs`.
+  - **Restock rule:** when agents gain or drop an internal core call, update this bullet (and [monorepo-packages.md](monorepo-packages.md) agents section) in the same change.
 - **Legacy vs modern OpenAPI:** harness prefers `FastEndpoints.OpenApi` + Scalar; NSwag Swagger/ClientGen live under Legacy and may have tests commented out.
 - **OpenAPI form files:** `FastEndpoints.OpenApi` normalizes `IFormFile` and form-file collections to inline binary string schemas and removes generated `IFormFile*` components; preserve rewrite-before-removal ordering to avoid dangling refs.
 - **OpenAPI schema `$ref` walking (Microsoft.OpenApi 2.x):** `OpenApiSchemaReference` often has null `Properties`/`Type` until resolved. Always `ResolveSchema()` before reading properties/composition; pass document `Components.Schemas` when `HostDocument` may be unset (e.g. `.http` export `SchemaPlaceholderBuilder`). Path-scoped cycle sets must key on the **resolved** schema so dual sibling refs to the same component both expand.
@@ -22,7 +40,7 @@ tags: [gotcha]
 - **CI filter:** tests with `Trait("ExcludeInCiCd","Yes")` never run in publish/Azure pipelines; don't rely on them as merge gates.
 - **WAF cache:** one cached factory per `AppFixture` type; misuse of static state across tests can leak. Use fixture `ConfigureServices` for doubles.
 - **Mappers are singletons:** no request state in mapper classes.
-- **Signing / InternalsVisibleTo:** must use full public key from props; unsigned local hacks break friend assemblies.
+- **Signing / InternalsVisibleTo:** must use full public key from props; unsigned local hacks break friend assemblies. Agent packages rely on signed friend access (see **Agents friend-assembly binary contract** above).
 - **User DotSettings:** `*.sln.DotSettings.user` is personal; don't treat as repo policy.
 - **Do not commit secrets:** NuGet keys, JWT signing material for real envs.
 - **Generated harness folders:** e.g. NativeAotChecker `Generated/`, `wwwroot/openapi/`, `aot/` are gitignored or build outputs; regenerate, don't hand-maintain.
@@ -37,8 +55,11 @@ tags: [gotcha]
 - **Handler short-circuit is opt-in:** pre-processors always skip the handler when `ResponseStarted` is true. `OnBeforeHandle*` does not, unless `DontExecuteHandlerIfResponseStarted()` is set (property `SkipHandlerIfResponseStarted`). Early return also skips `OnAfterHandle*`; post-processors still run.
 
 ## Sources
-- `Src/Library/Main/MainExtensions.cs`
-- `Directory.Packages.props`
+- `Src/Library/Metadata.cs`
+- `Src/Library/Binder/BinderExtensions.cs`
+- `Src/Library/Extensions/ReflectionExtensions.cs`
+- `Src/Library/Main/EndpointBootstrap.cs`
+- `Src/Agents/Shared/` · `Src/Agents/Mcp/` · `Src/Agents/A2A/`
 - `Src/Agents/Directory.Build.props`
-- `Src/Generator/FastEndpoints.Generator.targets`
+- `Directory.Packages.props`
 - `FastEndpoints.slnx`

--- a/.okf/maintenance.md
+++ b/.okf/maintenance.md
@@ -19,6 +19,7 @@ tags: [maintain]
 Sync OKF when changes hit:
 - architecture / package boundaries / dependency directions
 - public APIs, endpoint pipeline contracts, messaging/job contracts
+- **Agents friend-assembly surface:** Library `internal` members consumed by `FastEndpoints.Mcp` / `FastEndpoints.A2A` via `InternalsVisibleTo` (stock in [gotchas.md](gotchas.md); summary in [monorepo-packages.md](monorepo-packages.md)). Restock when agents gain/drop internal core calls, or when those core members change signature/shape.
 - persistence SPIs (e.g. job storage interfaces)
 - deps / TFMs / central package management
 - build, test, pack, publish, codegen commands

--- a/.okf/monorepo-packages.md
+++ b/.okf/monorepo-packages.md
@@ -50,6 +50,11 @@ One root `.okf/` covers the whole repo. Packages are NuGet libraries, not separa
 - **Core line:** `Src/Directory.Build.props` `<Version>` (all standard Src packages unless overridden).
 - **Agents line:** per-csproj `<Version>` under `Src/Agents/` (props file documents independence).
 
+## Agents ↔ core friend surface
+`FastEndpoints.Mcp` / `FastEndpoints.A2A` reference Library with project refs in-repo, but are independently versioned NuGets. Core grants them friend access via `InternalsVisibleTo` in `Src/Library/Metadata.cs`. Shared agent plumbing is linked compile from `Src/Agents/Shared/*.cs` into each addon assembly (not a third NuGet).
+
+**When editing Library internals**, consult the **Agents friend-assembly binary contract** stock in [gotchas.md](gotchas.md). Signature changes to those internals can break already-published agent packages even when monorepo rebuilds succeed. Restock that list when agent packages add/remove internal core calls.
+
 ## Test / harness projects (non-pack or IsPackable false)
 - `Tests/**`, `TestHarness/**`, `Benchmark/**`: development only.
 
@@ -57,4 +62,5 @@ One root `.okf/` covers the whole repo. Packages are NuGet libraries, not separa
 - `FastEndpoints.slnx`
 - `Src/Directory.Build.props`
 - `Src/Agents/Directory.Build.props`
+- `Src/Library/Metadata.cs`
 - `Src/**/*.csproj`

--- a/Src/Attributes/Contracts/ReflectionCache.cs
+++ b/Src/Attributes/Contracts/ReflectionCache.cs
@@ -27,6 +27,14 @@ public sealed class TypeDefinition
     public ConcurrentDictionary<PropertyInfo, PropertyDefinition>? Properties { get; set; }
 
     /// <summary>
+    /// materialized snapshot of <see cref="Properties"/>' keys, cached so the bindable-props hot path (complex binders +
+    /// data-annotation validation recursion) doesn't allocate a fresh <c>List&lt;PropertyInfo&gt;</c> from
+    /// <see cref="ConcurrentDictionary{TKey,TValue}.Keys"/> on every call. assumes no post-startup key additions to
+    /// <see cref="Properties"/> (which the public api does not do).
+    /// </summary>
+    internal PropertyInfo[]? BindableProps { get; set; }
+
+    /// <summary>
     /// a func used for converting string values to the respective type by calling it's <c>TryParse()</c> method.
     /// </summary>
     public Func<StringValues, ParseResult>? ValueParser { get; set; }

--- a/Src/Library/Binder/BinderExtensions.cs
+++ b/Src/Library/Binder/BinderExtensions.cs
@@ -186,10 +186,11 @@ static class BinderExtensions
             }
         }
 
-        internal ICollection<PropertyInfo> BindableProps()
+        internal PropertyInfo[] BindableProps()
         {
-            return (Cfg.BndOpts.ReflectionCache.GetOrAdd(type, static _ => new())
-                       .Properties ??= new(GetProperties(type))).Keys;
+            var typeDef = Cfg.BndOpts.ReflectionCache.GetOrAdd(type, static _ => new());
+
+            return typeDef.BindableProps ??= (typeDef.Properties ??= new(GetProperties(type))).Keys.ToArray();
 
             static IEnumerable<KeyValuePair<PropertyInfo, PropertyDefinition>> GetProperties(Type t)
             {

--- a/Src/Library/Binder/RequestBinder.cs
+++ b/Src/Library/Binder/RequestBinder.cs
@@ -57,7 +57,7 @@ public class RequestBinder<TRequest> : IRequestBinder<TRequest> where TRequest :
 
         var dtoProps = _tRequest.BindableProps();
 
-        if (dtoProps.Count == 0 && !Cfg.EpOpts.AllowEmptyRequestDtos)
+        if (dtoProps.Length == 0 && !Cfg.EpOpts.AllowEmptyRequestDtos)
         {
             throw new NotSupportedException(
                 $"Only request DTOs with publicly accessible properties are supported for request binding. " +

--- a/Src/Library/Testing/HttpClientExtensions.cs
+++ b/Src/Library/Testing/HttpClientExtensions.cs
@@ -769,7 +769,7 @@ public static class HttpClientExtensions
             var requestProps = requestType.BindableProps();
             var endpointProps = endpointRequestType.BindableProps();
 
-            if (requestProps.Count != endpointProps.Count ||
+            if (requestProps.Length != endpointProps.Length ||
                 !TryBuildDtoPropertyMap(requestProps, out var requestPropMap) ||
                 !TryBuildDtoPropertyMap(endpointProps, out var endpointPropMap))
                 return false;


### PR DESCRIPTION
## Summary

Caches the materialized set of bindable properties per request DTO type so the binder hot path stops allocating (and locking) on every call.

`BinderExtensions.BindableProps()` previously returned `ConcurrentDictionary.Keys`. Accessing that property does two costly things on every call: it acquires **all** of the dictionary's internal locks and then copies the keys into a freshly allocated `List<PropertyInfo>` snapshot. This method is called on the request-binding hot path (complex binders + data-annotation validation recursion), so both the locking and the allocations add up under load.

This PR materializes the keys into a `PropertyInfo[]` once and caches it on `TypeDefinition.BindableProps`, reusing it on subsequent calls — no repeated locking, no repeated allocation.

## Changes

- **`ReflectionCache.cs`** — added `internal PropertyInfo[]? BindableProps` to `TypeDefinition` to hold the cached snapshot.
- **`BinderExtensions.cs`** — `BindableProps()` now returns `PropertyInfo[]` and lazily populates/reuses the cached array (`typeDef.BindableProps ??= ...Keys.ToArray()`).
- **`RequestBinder.cs`** — updated call site from `.Count` to `.Length`.
- **`HttpClientExtensions.cs`** — updated call site from `.Count` to `.Length`.

## Behavior & assumptions

The cache assumes no properties are added to `TypeDefinition.Properties` after startup, which the public API does not do. The materialized array is treated as immutable for the lifetime of the type definition. Note the `.Keys` snapshot is still taken exactly once (on first access) to populate the cache — the locking cost is paid a single time rather than on every bind.

## Risk

Low. Purely a locking/allocation optimization on an existing code path; the returned property set is unchanged, and both call sites were updated to the array-typed API.