### PR TITLE
Bump Microsoft.OpenApi.Kiota.Builder to 1.29.1

### DIFF
--- a/.okf/dependencies.md
+++ b/.okf/dependencies.md
@@ -32,7 +32,7 @@ tags: [deps]
 | Microsoft.AspNetCore.OData | OData package |
 | ModelContextProtocol.AspNetCore | Agents MCP; v2.x targets the 2026-07-28 MCP spec (stateless-by-default transport, backward compatible with the addon's v1-style handler wiring) |
 | Microsoft.CodeAnalysis.CSharp **[4.11.0]** | Generators; pinned for net8 compatibility (comment in props) |
-| Microsoft.OpenApi.Kiota.Builder **[1.29.0]** | Pinned; Kiota OpenAPI 3.x vs AspNetCore.OpenApi 2.x mismatch |
+| Microsoft.OpenApi.Kiota.Builder **[1.29.1]** | Pinned; Kiota OpenAPI 3.x vs AspNetCore.OpenApi 2.x mismatch |
 | xunit.v3, Shouldly, FakeItEasy, Bogus | Test stack |
 | BenchmarkDotNet, NBomber | Benchmarks / load |
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
         <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10"/>
         <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.10"/>
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1"/>
-        <PackageVersion Include="Microsoft.OpenApi.Kiota.Builder" Version="[1.29.0]"/><!-- latest kiota uses Microsoft.OpenApi 3.x but Microsoft.AspNetCore.OpenApi still uses 2.x -->
+        <PackageVersion Include="Microsoft.OpenApi.Kiota.Builder" Version="[1.29.1]"/><!-- latest kiota uses Microsoft.OpenApi 3.x but Microsoft.AspNetCore.OpenApi still uses 2.x -->
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301"/>
         <PackageVersion Include="protobuf-net" Version="3.2.56"/>
         <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0"/>


### PR DESCRIPTION
## Summary
- Bumps `Microsoft.OpenApi.Kiota.Builder` from 1.29.0 to [1.29.1](https://www.nuget.org/packages/Microsoft.OpenApi.Kiota.Builder/1.29.1), addressing #1101.
- 1.29.1 is a security-only backport onto the 1.29.x line (microsoft/kiota#8038, released today — full changelog: [v1.29.1 release notes](https://github.com/microsoft/kiota/releases/tag/v1.29.1)) porting fixes for 11 disclosed CVEs, plus a bump of `Microsoft.OpenApi`/`Microsoft.OpenApi.YamlReader` to 2.12.0 — all while staying on the `Microsoft.OpenApi` 2.x line so it doesn't conflict with `Microsoft.AspNetCore.OpenApi` (still pinned to 2.x here).
- Per that changelog, the CVEs fixed include: literal/code injection across nearly every language writer (GHSA-2hx3-vp6r-mg3f / CVE-2026-41134), Python `x-ms-enum` description injection (GHSA-7f3j-j7jj-r3vr), Ruby `#`-interpolation injection (GHSA-xg2h-5xr2-29jw), C# doc-comment newline breakout (GHSA-3hrf-2gc2-mx32), PHP `$`-interpolation injection (GHSA-jqwh-526h-c92j), unsanitized client class/namespace names (GHSA-4vv7-jj25-4gh6), workspace output-path poisoning (GHSA-4rj6-vrwv-wr8m), plugin manifest `static_template.file` path escape (GHSA-4jwf-m4wg-8p66), SSRF via unrestricted external `$ref` resolution — now opt-in via `--allowed-external-origins` (GHSA-rg4h-fpcp-2qm8 / CVE-2026-59867), plus the `Microsoft.OpenApi` 2.12.0 bump (GHSA-v5pm-xwqc-g5wc) and an OpenTelemetry bump (GHSA-4625-4j76-fww9, GHSA-mr8r-92fq-pj8p, GHSA-q834-8qmm-v933).
- #1101 asks for `>= 1.32.5`, but every Kiota.Builder release from 1.30.0 onward moved to `Microsoft.OpenApi` 3.x, which breaks `Microsoft.AspNetCore.OpenApi`'s XML-comment source generator on this repo's net10 target (confirmed locally: `IOpenApiMediaType.Example cannot be assigned to -- it is read only`). Until `Microsoft.AspNetCore.OpenApi` itself moves to OpenApi 3.x, 1.29.1 is the newest compatible version and closes 11 of the CVEs flagged by #1101 without a breaking change.
- Note: `dotnet restore`/NuGet audit will still surface `NU1903`/`NU1904` warnings for 1.29.1 — the GHSA advisory version ranges haven't been narrowed to exclude this out-of-band 1.29.x backport yet, so the warnings are stale/expected, not unfixed vulnerabilities (see the kiota PR discussion).

## Test plan
- [x] `dotnet build FastEndpoints.slnx -c Release` — 0 errors
- [x] `dotnet test Tests/IntegrationTests/FastEndpoints.OpenApi.Kiota/Int.OpenApi.Kiota.csproj -c Release` — 4/4 passing (client-gen + command-mode export against the new builder; excluded from CI but run locally)
- [x] `dotnet test FastEndpoints.slnx -c Release --filter "ExcludeInCiCd!=Yes"` — same 4 pre-existing snapshot/CRLF failures as on `main` (verified unaffected by this change), no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gczAbMsgW4deQYkFpxdTZ