### PR TITLE
Add versioned OpenAPI options to AddVersioning

### DIFF
--- a/.okf/code-map.md
+++ b/.okf/code-map.md
@@ -20,6 +20,7 @@ tags: [layout]
 | `Src/CommandRules/` | Rule-based command dispatch package |
 | `Src/Security/` | JWT/cookie/refresh/revocation |
 | `Src/OpenApi/`, `Src/OpenApi.Kiota/` | OpenAPI + Kiota client gen |
+| `Src/AspVersioning/` | `Asp.Versioning.Http` integration (`AddVersioning`; net10-only optional `Action<VersionedOpenApiOptions>` configures versioned OpenAPI docs via `Asp.Versioning.OpenApi`) |
 | `Src/Swagger/`, `Src/ClientGen*` | Legacy NSwag-era packages (slnx “Legacy” folder) |
 | `Src/Generator/`, `Src/Generator.Cli/` | Roslyn generators + CLI |
 | `Src/Testing/` | `FastEndpoints.Testing` |

--- a/.okf/conventions.md
+++ b/.okf/conventions.md
@@ -40,6 +40,7 @@ tags: [conventions]
 - Manual resolve façade: `Endpoint`/`Group`/`Mapper` inherit `ServiceResolverClient`; `Validator`/`BinderContext`/`HttpContext` extensions forward via `ServiceResolverClient.Forward` (do not re-copy the eight Resolve methods).
 - Service registration generator can emit registration from attributes when generator is referenced.
 - Central package versions only in `Directory.Packages.props`; do not hardcode versions in csproj except intentional `VersionOverride` / constrained ranges already present.
+- `FastEndpoints.AspVersioning`: on .NET 10, `AddVersioning(...)` takes an optional trailing `Action<VersionedOpenApiOptions>` so consumers can configure the versioned OpenAPI documents from `Asp.Versioning.OpenApi` (that package is net10.0-only, hence the `#if NET10_0_OR_GREATER` guard and conditional package ref in `Src/AspVersioning/`).
 
 ## Testing conventions
 - Integration: `AppFixture<TProgram>` / collection fixtures from `FastEndpoints.Testing`.

--- a/.okf/testing.md
+++ b/.okf/testing.md
@@ -12,7 +12,7 @@ tags: [test]
 | --- | --- |
 | Framework | **xunit.v3**, Shouldly, FakeItEasy |
 | Test TFM | **net10.0** (`Tests/Directory.Build.props`) |
-| Unit | `Tests/UnitTests/FastEndpoints`, `…/FastEndpoints.Testing` (+ legacy Swagger unit commented in slnx) |
+| Unit | `Tests/UnitTests/FastEndpoints`, `…/FastEndpoints.Testing`, `…/FastEndpoints.AspVersioning` (+ legacy Swagger unit commented in slnx) |
 | Integration | `Tests/IntegrationTests/FastEndpoints` (main), OpenApi, OpenApi.Kiota, OData, Agents |
 | AOT | `Tests/NativeAotTests/NativeAotCheckerTests` + `NativeAot.slnx` |
 | Helpers package | `Src/Testing` → `FastEndpoints.Testing` (`AppFixture`, fixtures, Bogus) |

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,6 +53,7 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
         <PackageVersion Include="Asp.Versioning.Http" Version="8.1.1"/>
         <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1"/>
+        <PackageVersion Include="Asp.Versioning.OpenApi" Version="8.1.1"/>
         <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.18"/>
         <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.18"/>
         <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.18"/>
@@ -60,6 +61,7 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
         <PackageVersion Include="Asp.Versioning.Http" Version="10.0.1"/>
         <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.1"/>
+        <PackageVersion Include="Asp.Versioning.OpenApi" Version="10.0.1"/>
         <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10"/>
         <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10"/>
         <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.10"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -53,7 +53,6 @@
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
         <PackageVersion Include="Asp.Versioning.Http" Version="8.1.1"/>
         <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1"/>
-        <PackageVersion Include="Asp.Versioning.OpenApi" Version="8.1.1"/>
         <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.18"/>
         <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.18"/>
         <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.18"/>

--- a/FastEndpoints.slnx
+++ b/FastEndpoints.slnx
@@ -52,6 +52,7 @@
     <Folder Name="/Tests/UnitTests/">
         <Project Path="Tests/UnitTests/FastEndpoints/Unit.FastEndpoints.csproj"/>
         <Project Path="Tests/UnitTests/FastEndpoints.Testing/Unit.Testing.csproj"/>
+        <Project Path="Tests/UnitTests/FastEndpoints.AspVersioning/Unit.AspVersioning.csproj"/>
     </Folder>
     <Project Path="Src/AspVersioning/FastEndpoints.AspVersioning.csproj"/>
     <Project Path="Src/Attributes/FastEndpoints.Attributes.csproj"/>

--- a/Src/AspVersioning/Extensions.cs
+++ b/Src/AspVersioning/Extensions.cs
@@ -4,11 +4,28 @@ using Asp.Versioning.ApiExplorer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using NSwag.Generation.AspNetCore;
+#if NET10_0_OR_GREATER
+using Asp.Versioning.OpenApi;
+#endif
 
 namespace FastEndpoints.AspVersioning;
 
 public static class Extensions
 {
+#if NET10_0_OR_GREATER
+    /// <summary>
+    /// add Asp.Versioning.Http versioning support to the middleware pipeline and
+    /// configure the versioned open api documents
+    /// </summary>
+    /// <param name="versioningOptions">action for configuring the verioning options</param>
+    /// <param name="apiExplorerOptions">action for configuring the api explorer options</param>
+    /// <param name="openApiOptions">action for configuring the versioned open api options</param>
+    [UnconditionalSuppressMessage("aot", "IL2026")]
+    public static IServiceCollection AddVersioning(this IServiceCollection services,
+                                                   Action<ApiVersioningOptions>? versioningOptions = null,
+                                                   Action<ApiExplorerOptions>? apiExplorerOptions = null,
+                                                   Action<VersionedOpenApiOptions>? openApiOptions = null)
+#else
     /// <summary>
     /// add Asp.Versioning.Http versioning support to the middleware pipeline
     /// </summary>
@@ -18,6 +35,7 @@ public static class Extensions
     public static IServiceCollection AddVersioning(this IServiceCollection services,
                                                    Action<ApiVersioningOptions>? versioningOptions = null,
                                                    Action<ApiExplorerOptions>? apiExplorerOptions = null)
+#endif
     {
         var builder = versioningOptions is null
                           ? services.AddApiVersioning(VersioningDefaults)
@@ -38,6 +56,11 @@ public static class Extensions
         VersionSets.VersionFormat = tmp.GroupNameFormat;
 
         Config.VerOpts.IsUsingAspVersioning = true;
+
+#if NET10_0_OR_GREATER
+        if (openApiOptions is not null)
+            builder.AddOpenApi(openApiOptions);
+#endif
 
         return services;
 

--- a/Src/AspVersioning/FastEndpoints.AspVersioning.csproj
+++ b/Src/AspVersioning/FastEndpoints.AspVersioning.csproj
@@ -13,7 +13,6 @@
         <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer"/>
         <PackageReference Include="NSwag.Generation.AspNetCore"/> <!-- todo: remove when swagger support no longer needed -->
         <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
-
         <PackageReference Include="Asp.Versioning.OpenApi" Condition="'$(TargetFramework)' == 'net10.0'"/>
     </ItemGroup>
 

--- a/Src/AspVersioning/FastEndpoints.AspVersioning.csproj
+++ b/Src/AspVersioning/FastEndpoints.AspVersioning.csproj
@@ -13,6 +13,8 @@
         <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer"/>
         <PackageReference Include="NSwag.Generation.AspNetCore"/> <!-- todo: remove when swagger support no longer needed -->
         <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
+
+        <PackageReference Include="Asp.Versioning.OpenApi" Condition="'$(TargetFramework)' == 'net10.0'"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -237,6 +237,34 @@ Previously an indexer was treated as a bindable property, which failed endpoint 
 
 ## Improvements 🚀
 
+<details><summary>Configure versioned OpenAPI documents from <code>AddVersioning</code></summary>
+
+On .NET 10, `AddVersioning` accepts an optional third argument of type `Action<VersionedOpenApiOptions>`, letting consumers configure the versioned OpenAPI documents from the `Asp.Versioning.OpenApi` package, whose per-version document services are required by `MapOpenApi().WithDocumentPerVersion()`.
+
+```csharp
+services.AddVersioning(
+    o =>
+    {
+        o.ApiVersionReader = ApiVersionReader.Combine(new UrlSegmentApiVersionReader());
+    },
+    o =>
+    {
+        o.GroupNameFormat = "'v'VVV";
+        o.SubstituteApiVersionInUrl = true;
+    },
+    o => o.Document.AddDocumentTransformer(
+        (document, _, _) =>
+        {
+            document.Info.Title = "My API";
+            document.Info.Description = "My API description";
+            return Task.CompletedTask;
+        }));
+```
+
+The argument is optional, so existing callers of `AddVersioning` are unaffected. The new parameter is only available on .NET 10 targets because `Asp.Versioning.OpenApi` itself does not ship for earlier frameworks.
+
+</details>
+
 <details><summary>Kiota client generation uses Microsoft.OpenApi.Kiota.Builder 1.29.1</summary>
 
 `FastEndpoints.OpenApi.Kiota` and `FastEndpoints.ClientGen.Kiota` now ship with `Microsoft.OpenApi.Kiota.Builder` **1.29.1**, a security-only backport that stays on the `Microsoft.OpenApi` 2.x line compatible with `Microsoft.AspNetCore.OpenApi`.

--- a/Tests/UnitTests/FastEndpoints.AspVersioning/AddVersioningTests.cs
+++ b/Tests/UnitTests/FastEndpoints.AspVersioning/AddVersioningTests.cs
@@ -1,0 +1,53 @@
+using Asp.Versioning;
+using Asp.Versioning.ApiExplorer;
+using Asp.Versioning.OpenApi;
+using FastEndpoints.AspVersioning;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Unit.FastEndpoints.AspVersioning;
+
+public class AddVersioningTests
+{
+    [Fact(DisplayName = "AddVersioning wires the open api options action to the versioned open api options")]
+    public void AddVersioning_WithOpenApiOptions_ConfiguresVersionedOpenApi()
+    {
+        var services = new ServiceCollection();
+
+        services.AddVersioning(openApiOptions: o => o.Document.AddDocumentTransformer(
+            (document, _, _) =>
+            {
+                document.Info.Title = "My API";
+                return Task.CompletedTask;
+            }));
+
+        services.Any(d => d.ServiceType == typeof(IConfigureOptions<VersionedOpenApiOptions>)).ShouldBeTrue();
+    }
+
+    [Fact(DisplayName = "AddVersioning registers the versioned OpenAPI document services")]
+    public void AddVersioning_WithOpenApiOptions_RegistersVersionedOpenApi()
+    {
+        var services = new ServiceCollection();
+
+        services.AddLogging();
+
+        services.AddVersioning(
+            o => o.ApiVersionReader = ApiVersionReader.Combine(new UrlSegmentApiVersionReader()),
+            o => o.GroupNameFormat = "'v'VVV",
+            o => o.Document.AddDocumentTransformer(
+                (document, _, _) =>
+                {
+                    document.Info.Title = "My API";
+                    return Task.CompletedTask;
+                }));
+
+        using var sp = services.BuildServiceProvider();
+
+        var descriptions = sp.GetRequiredService<IApiVersionDescriptionProvider>().ApiVersionDescriptions;
+
+        descriptions.ShouldNotBeEmpty();
+
+        sp.GetRequiredService<IOptionsFactory<VersionedOpenApiOptions>>().ShouldNotBeNull();
+    }
+}

--- a/Tests/UnitTests/FastEndpoints.AspVersioning/AddVersioningTests.cs
+++ b/Tests/UnitTests/FastEndpoints.AspVersioning/AddVersioningTests.cs
@@ -1,7 +1,7 @@
 using Asp.Versioning;
-using Asp.Versioning.ApiExplorer;
 using Asp.Versioning.OpenApi;
 using FastEndpoints.AspVersioning;
+using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Xunit;
@@ -25,12 +25,22 @@ public class AddVersioningTests
         services.Any(d => d.ServiceType == typeof(IConfigureOptions<VersionedOpenApiOptions>)).ShouldBeTrue();
     }
 
+    [Fact(DisplayName = "AddVersioning does not register versioned OpenAPI services without open api options")]
+    public void AddVersioning_WithoutOpenApiOptions_DoesNotRegisterVersionedOpenApi()
+    {
+        var services = new ServiceCollection();
+
+        services.AddVersioning();
+
+        services.Any(d => d.ServiceType == typeof(IConfigureOptions<VersionedOpenApiOptions>)).ShouldBeFalse();
+        HasDocumentProvider(services).ShouldBeFalse();
+        HasOpenApiPostConfigure(services).ShouldBeFalse();
+    }
+
     [Fact(DisplayName = "AddVersioning registers the versioned OpenAPI document services")]
     public void AddVersioning_WithOpenApiOptions_RegistersVersionedOpenApi()
     {
         var services = new ServiceCollection();
-
-        services.AddLogging();
 
         services.AddVersioning(
             o => o.ApiVersionReader = ApiVersionReader.Combine(new UrlSegmentApiVersionReader()),
@@ -42,12 +52,13 @@ public class AddVersioningTests
                     return Task.CompletedTask;
                 }));
 
-        using var sp = services.BuildServiceProvider();
-
-        var descriptions = sp.GetRequiredService<IApiVersionDescriptionProvider>().ApiVersionDescriptions;
-
-        descriptions.ShouldNotBeEmpty();
-
-        sp.GetRequiredService<IOptionsFactory<VersionedOpenApiOptions>>().ShouldNotBeNull();
+        HasDocumentProvider(services).ShouldBeTrue();
+        HasOpenApiPostConfigure(services).ShouldBeTrue();
     }
+
+    static bool HasDocumentProvider(IServiceCollection services)
+        => services.Any(d => d.ServiceType.FullName == "Microsoft.Extensions.ApiDescriptions.IDocumentProvider");
+
+    static bool HasOpenApiPostConfigure(IServiceCollection services)
+        => services.Any(d => d.ServiceType == typeof(IPostConfigureOptions<OpenApiOptions>));
 }

--- a/Tests/UnitTests/FastEndpoints.AspVersioning/Unit.AspVersioning.csproj
+++ b/Tests/UnitTests/FastEndpoints.AspVersioning/Unit.AspVersioning.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <RootNamespace>Unit.FastEndpoints.AspVersioning</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\Src\AspVersioning\FastEndpoints.AspVersioning.csproj"/>
+
+        <PackageReference Include="Asp.Versioning.OpenApi"/>
+    </ItemGroup>
+
+</Project>

--- a/Tests/UnitTests/FastEndpoints.AspVersioning/Usings.cs
+++ b/Tests/UnitTests/FastEndpoints.AspVersioning/Usings.cs
@@ -1,0 +1,1 @@
+global using Shouldly;


### PR DESCRIPTION
Extends `AddVersioning` with an optional `openApiOptions` parameter (available on `net10.0`) to configure versioned `OpenAPI` documents via `builder.AddOpenApi(...)`. Includes:
- Conditional `net10.0`-only parameter and `Asp.Versioning.OpenApi` package reference
- Unit tests for versioned `OpenAPI` configuration
- Changelog entry and `OKF` sync

Addresses #1161 