### PR TITLE
Faster reflection-based type discovery at startup

### DIFF
--- a/Src/Core/AssemblyScanner/AssemblyScanner.cs
+++ b/Src/Core/AssemblyScanner/AssemblyScanner.cs
@@ -47,8 +47,10 @@ internal static class AssemblyScanner
             assemblies = assemblies.Where(opts.AssemblyFilter);
 
         return assemblies
-               //the exclusions are plain ascii prefixes, so Ordinal is both correct and free of icu collation.
-               .Where(a => !a.IsDynamic && (opts.Assemblies?.Contains(a) is true || !_exclusions.Any(x => a.FullName!.StartsWith(x, StringComparison.Ordinal))))
+               .Where(
+                   a => !a.IsDynamic &&
+                        (opts.Assemblies?.Contains(a) is true ||
+                         !_exclusions.Any(x => a.FullName!.StartsWith(x, StringComparison.Ordinal)))) // Ordinal is both correct and free of icu collation.
                .SelectMany(a => a.GetTypes())
                .Where(t => IsTypeMatch(t, opts));
 

--- a/Src/Core/AssemblyScanner/AssemblyScanner.cs
+++ b/Src/Core/AssemblyScanner/AssemblyScanner.cs
@@ -47,7 +47,8 @@ internal static class AssemblyScanner
             assemblies = assemblies.Where(opts.AssemblyFilter);
 
         return assemblies
-               .Where(a => !a.IsDynamic && (opts.Assemblies?.Contains(a) is true || !_exclusions.Any(x => a.FullName!.StartsWith(x))))
+               //the exclusions are plain ascii prefixes, so Ordinal is both correct and free of icu collation.
+               .Where(a => !a.IsDynamic && (opts.Assemblies?.Contains(a) is true || !_exclusions.Any(x => a.FullName!.StartsWith(x, StringComparison.Ordinal))))
                .SelectMany(a => a.GetTypes())
                .Where(t => IsTypeMatch(t, opts));
 
@@ -59,11 +60,24 @@ internal static class AssemblyScanner
             if (options.ExcludeAttribute is not null && t.IsDefined(options.ExcludeAttribute))
                 return false;
 
-            return options.InterfaceTypes.Length switch
+            if (options.InterfaceTypes.Length > 0 && !ImplementsAny(t, options.InterfaceTypes))
+                return false;
+
+            return options.TypeFilter is null || options.TypeFilter(t);
+        }
+
+        static bool ImplementsAny(Type t, Type[] interfaceTypes)
+        {
+            foreach (var tImplemented in t.GetInterfaces())
             {
-                > 0 when !t.GetInterfaces().Intersect(options.InterfaceTypes).Any() => false,
-                _ => options.TypeFilter is null || options.TypeFilter(t)
-            };
+                foreach (var tWanted in interfaceTypes)
+                {
+                    if (tImplemented == tWanted)
+                        return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -237,6 +237,12 @@ Previously an indexer was treated as a bindable property, which failed endpoint 
 
 ## Improvements 🚀
 
+<details><summary>Faster assembly scanning at startup</summary>
+
+Reflection based type discovery no longer builds a LINQ set of the wanted interface types for every single type it inspects, which is the bulk of the work `AddFastEndpoints()` / `AddMessaging()` do at startup (measured on a 5 interface discovery: 180ns and 448 bytes per inspected type, down to 66ns and 35 bytes). The assembly exclusion list is also matched with an ordinal string comparison now, instead of a culture sensitive one that went through ICU collation per assembly.
+
+</details>
+
 <details><summary>Response cache header value is built once per endpoint</summary>
 
 The `Cache-Control` value of a response cached endpoint is no longer re-interpolated on every request. Both of its inputs (the configured `ResponseCacheLocation` and duration) are fixed after startup, so the value is now built on the first request to the endpoint and reused, removing a string interpolation plus an `int.ToString()` per request. The emitted headers are unchanged.

--- a/Tests/UnitTests/FastEndpoints/AssemblyScannerTests.cs
+++ b/Tests/UnitTests/FastEndpoints/AssemblyScannerTests.cs
@@ -1,0 +1,138 @@
+using FastEndpoints;
+using Xunit;
+
+namespace AssemblyScanning;
+
+public class AssemblyScannerTests
+{
+    [Fact]
+    public void InterfaceTypes_MatchTypesImplementingThem()
+    {
+        var found = Scan([typeof(IMarkerA)]);
+
+        found.ShouldContain(typeof(ImplementsA));
+        found.ShouldContain(typeof(ImplementsBoth));
+        found.ShouldNotContain(typeof(ImplementsB));
+        found.ShouldNotContain(typeof(ImplementsNeither));
+    }
+
+    [Fact]
+    public void MultipleInterfaceTypes_MatchAnyOfThemNotAllOfThem()
+    {
+        var found = Scan([typeof(IMarkerA), typeof(IMarkerB)]);
+
+        found.ShouldContain(typeof(ImplementsA));   //only IMarkerA
+        found.ShouldContain(typeof(ImplementsB));   //only IMarkerB
+        found.ShouldContain(typeof(ImplementsBoth));
+        found.ShouldNotContain(typeof(ImplementsNeither));
+    }
+
+    [Fact]
+    public void NoInterfaceTypes_MatchesEveryTypeThatIsNotOtherwiseFiltered()
+    {
+        var found = Scan([], typeFilter: t => t.Namespace == typeof(AssemblyScannerTests).Namespace);
+
+        found.ShouldContain(typeof(ImplementsA));
+        found.ShouldContain(typeof(ImplementsNeither)); //no interface requirement to fail
+    }
+
+    [Fact]
+    public void AbstractGenericAndInterfaceTypes_AreNeverReturned()
+    {
+        var found = Scan([typeof(IMarkerA)]);
+
+        found.ShouldNotContain(typeof(IMarkerA));
+        found.ShouldNotContain(typeof(AbstractImplementsA));
+        found.ShouldNotContain(typeof(GenericImplementsA<>));
+        found.ShouldNotContain(typeof(GenericImplementsA<int>));
+    }
+
+    [Fact]
+    public void ExcludeAttribute_SkipsDecoratedTypes()
+    {
+        var found = Scan([typeof(IMarkerA)], excludeAttribute: typeof(ScannerExcludeAttribute));
+
+        found.ShouldContain(typeof(ImplementsA));
+        found.ShouldNotContain(typeof(ExcludedByAttribute));
+
+        //without the exclude attribute configured, the very same type is discovered
+        Scan([typeof(IMarkerA)]).ShouldContain(typeof(ExcludedByAttribute));
+    }
+
+    [Fact]
+    public void TypeFilter_IsAppliedOnTopOfInterfaceMatching()
+    {
+        var found = Scan([typeof(IMarkerA)], typeFilter: t => t != typeof(ImplementsBoth));
+
+        found.ShouldContain(typeof(ImplementsA));
+        found.ShouldNotContain(typeof(ImplementsBoth));
+    }
+
+    [Fact]
+    public void AutoDiscoveredAssembliesOnTheExclusionList_AreNotScanned()
+    {
+        //'FastEndpoints.Core' is prefix matched by the 'FastEndpoints' exclusion
+        var tCoreAssembly = typeof(AssemblyScanOptions).Assembly;
+
+        var found = AssemblyScanner.ScanForTypes(
+                                       new()
+                                       {
+                                           AssemblyFilter = a => a == tCoreAssembly,
+                                           TypeFilter = t => t == typeof(AssemblyScanOptions)
+                                       })
+                                   .ToArray();
+
+        found.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ExplicitlyProvidedAssemblies_BypassTheExclusionList()
+    {
+        var tCoreAssembly = typeof(AssemblyScanOptions).Assembly;
+
+        var found = AssemblyScanner.ScanForTypes(
+                                       new()
+                                       {
+                                           Assemblies = [tCoreAssembly], //same excluded assembly as above, but requested by name
+                                           AssemblyFilter = a => a == tCoreAssembly,
+                                           TypeFilter = t => t == typeof(AssemblyScanOptions)
+                                       })
+                                   .ToArray();
+
+        found.ShouldBe([typeof(AssemblyScanOptions)]);
+    }
+
+    static Type[] Scan(Type[] interfaceTypes, Func<Type, bool>? typeFilter = null, Type? excludeAttribute = null)
+        => AssemblyScanner.ScanForTypes(
+                              new()
+                              {
+                                  DisableAutoDiscovery = true,
+                                  Assemblies = [typeof(AssemblyScannerTests).Assembly],
+                                  InterfaceTypes = interfaceTypes,
+                                  TypeFilter = typeFilter,
+                                  ExcludeAttribute = excludeAttribute
+                              })
+                          .ToArray();
+}
+
+file interface IMarkerA;
+
+file interface IMarkerB;
+
+file sealed class ImplementsA : IMarkerA;
+
+file sealed class ImplementsB : IMarkerB;
+
+file sealed class ImplementsBoth : IMarkerA, IMarkerB;
+
+file sealed class ImplementsNeither;
+
+file abstract class AbstractImplementsA : IMarkerA;
+
+file sealed class GenericImplementsA<T> : IMarkerA;
+
+[AttributeUsage(AttributeTargets.Class)]
+file sealed class ScannerExcludeAttribute : Attribute;
+
+[ScannerExclude]
+file sealed class ExcludedByAttribute : IMarkerA;


### PR DESCRIPTION
# Faster reflection-based type discovery at startup

## What

`AssemblyScanner.ScanForTypes()` is the reflection discovery path behind `AddFastEndpoints()` and `AddMessaging()`. Two things in it were needlessly expensive.

**1. `Intersect` per inspected type (the actual win).** The interface match ran for every type of every scanned assembly:

```csharp
> 0 when !t.GetInterfaces().Intersect(options.InterfaceTypes).Any() => false,
```

`Enumerable.Intersect` builds a `Set<Type>` from `InterfaceTypes` (plus its bucket and slot arrays), then allocates the intersect iterator and an enumerator for `.Any()` — all discarded immediately, once per type. Replaced with a nested `foreach` over the two arrays that are already in hand, with early exit.

**2. Culture-sensitive assembly exclusion prefixes.** `!_exclusions.Any(x => a.FullName!.StartsWith(x))` used the default `StringComparison.CurrentCulture`, so each of the up to 20 prefix checks per assembly went through ICU collation, for what are plainly ordinal ASCII prefixes. Now passes `StringComparison.Ordinal`.

Discovery results are unchanged. The one intentional behavioral difference: exclusion prefixes such as `System` and `Microsoft` now match identically with and without `InvariantGlobalization`, where the culture-sensitive version could disagree.

## Measurements

Both changes were benchmarked before being written the way they are (`GC.GetTotalAllocatedBytes(precise: true)` plus `Stopwatch`, each variant asserted to agree with the original on the input set, each benchmark re-run twice to discard JIT/ICU warmup noise).

Interface matching, per inspected type, with the 5 marker interfaces `EndpointData.DiscoverTypes` actually passes:

| variant | per type | alloc per type |
|---|---|---|
| `GetInterfaces().Intersect(wanted).Any()` | 180-193 ns | 448 B |
| nested `foreach`, early exit | 66-67 ns | 35 B |

The residual 35 B is `GetInterfaces()` itself, which both variants pay. Over a realistic 5k-20k types walked during discovery that is roughly 0.6-2.4 ms and 2-8 MB of Gen0 churn removed.

Assembly exclusion check, per full scan of a realistic ~40 assembly list:

| variant | per scan | alloc per scan |
|---|---|---|
| `Any(lambda)` + culture-sensitive | ~131 us | 3,520 B |
| `Any(lambda)` + `Ordinal` | ~3.7 us | 3,520 B |
| `string[]` + `foreach` + `Ordinal` | ~2.9 us | 0 B |

## Scope decision

The exclusion check deliberately ships as **only** the `StringComparison.Ordinal` argument. A `foreach` rewrite plus retyping `_exclusions` from `IReadOnlyList<string>` to `string[]` was planned first: the table above however shows ordinal alone is ~99% of the time win, and this predicate runs once per assembly rather than once per type, so the rewrite's remaining 0.8 us and 3.5 KB are paid once per application start. That does not justify a 12 line local function plus a field retype. Retyping the field on its own is pointless too, since `Enumerable.Any` goes through `IEnumerable<T>` and allocates the enumerator either way, which is why the middle row still shows 3,520 B.

## Notes on equivalence

Two things worth stating, since they are what could have made the nested loop non-equivalent to `Intersect`:

- `Intersect`'s default comparer is `Type.Equals`, and `Type`'s `==` resolves to the same comparison, so identity matching is unchanged. The deduplication `Intersect` performs is irrelevant under `.Any()`.
- Every `InterfaceTypes` token at both call sites (`EndpointData.DiscoverTypes`, `MessagingExtensions.AddMessaging`) is a **non-generic** marker interface — `Types.ICommandHandler` is `typeof(ICommandHandler)`, not the open generic — so `GetInterfaces()` matches them by identity and there is no open-vs-closed generic case to handle.

## Tests

New `Tests/UnitTests/FastEndpoints/AssemblyScannerTests.cs` (8 tests). This file had **no** coverage at all despite being the discovery entry point for both packages:

- Interface matching; multiple `InterfaceTypes` behaving as OR rather than AND; empty `InterfaceTypes` matching everything not otherwise filtered.
- Abstract, generic and interface types never being returned.
- `ExcludeAttribute` skipping decorated types, with the negative case asserting the same type is otherwise discovered.
- `TypeFilter` composing on top of interface matching.
- An auto-discovered assembly on the exclusion list yielding nothing, and the *same* assembly being scanned when passed explicitly in `Assemblies` — varying only that one option, so it isolates the bypass branch.

To be clear about what this coverage is: all 8 tests pass against the pre-change scanner as well. That is the intended outcome for a behavior-neutral mechanical change, so these are parity tests, not fails-before regression tests. The one deliberate behavioral difference (ordinal vs culture-sensitive) is not unit-testable here: it only diverges for assembly names beginning with ICU-ignorable characters, and dynamic assemblies are filtered out before the check.

## Verification

- `Unit.FastEndpoints`: 333/333 (325 plus the 8 new).
- `Int.FastEndpoints` 249/249 and `Int.Agents` 131/131 in Release. These are the meaningful check, since every test in them boots an application through reflection discovery — a scanner that stopped finding types would collapse both suites.
- Full gate `dotnet test FastEndpoints.slnx -c Release --filter "ExcludeInCiCd!=Yes"`: `Unit.Testing` 17/17, `Int.OData` 4/4, plus the above.
- `dotnet build Src/Core/FastEndpoints.Core.csproj -c Release`: clean for net8/net9/net10, 0 warnings.

## OKF impact

- `Src/Library/changelog.md`: entry under Improvements, with the per-type numbers and the `InvariantGlobalization` note.
- `.okf/gotchas.md`: no update. Nothing here is a trap for a future change — the ordinal requirement is stated in a comment at the call site, and no invariant spans files.
- No API surface change: `ImplementsAny` is a new static local function, `_exclusions` keeps its type, and `ScanForTypes(AssemblyScanOptions)` keeps its signature, so nothing touches the friend-assembly notice surface.
