### PR TITLE
Avoid double UTF-8/UTF-16 transcode in X402Serializer

### DIFF
--- a/Src/Library/X402/X402Serializer.cs
+++ b/Src/Library/X402/X402Serializer.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
@@ -16,10 +15,10 @@ static class X402Serializer
     internal static readonly X402JsonContext Context = new(Options);
 
     internal static string ToBase64<T>(T value, JsonTypeInfo<T> typeInfo)
-        => Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(value, typeInfo)));
+        => Convert.ToBase64String(JsonSerializer.SerializeToUtf8Bytes(value, typeInfo));
 
     internal static T FromBase64<T>(string value, JsonTypeInfo<T> typeInfo)
-        => JsonSerializer.Deserialize(Encoding.UTF8.GetString(Convert.FromBase64String(value)), typeInfo)! ??
+        => JsonSerializer.Deserialize(Convert.FromBase64String(value).AsSpan(), typeInfo)! ??
            throw new InvalidOperationException($"failed to deserialize x402 payload as [{typeof(T).Name}]!");
 }
 

--- a/Src/Library/changelog.md
+++ b/Src/Library/changelog.md
@@ -421,6 +421,12 @@ Roots are taken from the request DTO itself, so warmup still covers them when a 
 
 </details>
 
+<details><summary>Fewer allocations encoding/decoding x402 payment payloads</summary>
+
+`X402Serializer` no longer round-trips through an intermediate UTF-16 `string` when base64 encoding or decoding payment payloads. Encoding serializes directly to UTF-8 bytes, and decoding deserializes straight from the decoded byte span. Behavior is unchanged; each direction does one less allocation per x402-protected request.
+
+</details>
+
 ## Minor Breaking Changes ⚠️
 
 <details><summary>'FastEndpoints.Testing' requires xUnit.net v3 4.0</summary>


### PR DESCRIPTION
## Summary

`X402Serializer.ToBase64`/`FromBase64` round-tripped through an intermediate UTF-16 `string` on every encode and decode of an x402 payment payload (`Encoding.UTF8.GetBytes(JsonSerializer.Serialize(...))` / `JsonSerializer.Deserialize(Encoding.UTF8.GetString(...))`), doing one more allocation per direction than necessary. This switches both paths to serialize/deserialize UTF-8 bytes directly:

- `ToBase64`: `JsonSerializer.SerializeToUtf8Bytes(value, typeInfo)` → `Convert.ToBase64String(...)`
- `FromBase64`: `Convert.FromBase64String(value).AsSpan()` → `JsonSerializer.Deserialize(ReadOnlySpan<byte>, typeInfo)`

Behavior is unchanged; this only removes the redundant string transcode on each x402-protected request (`X402Middleware.cs:36, 79, 85, 114, 120, 277`).

## Changes

- `Src/Library/X402/X402Serializer.cs` — encode/decode go straight to/from UTF-8 bytes; dropped the now-unused `using System.Text;`
- `Src/Library/changelog.md` — added an Improvements entry

## Test plan

- [x] `dotnet build FastEndpoints.slnx -c Release` — net8/9/10 all clean
- [x] `dotnet test Tests/UnitTests/FastEndpoints/Unit.FastEndpoints.csproj` — 333/333 passing
- [x] `dotnet test Tests/IntegrationTests/FastEndpoints/Int.FastEndpoints.csproj` — 249/249 passing
- [x] `Tests/IntegrationTests/FastEndpoints/SecurityTests/X402Tests.cs` (11 tests, full payment/verification/settlement round-trip through the live endpoint flow) — all passing